### PR TITLE
fix: admin error panel styling with standard Tailwind classes

### DIFF
--- a/src/app/admin/errors/page.tsx
+++ b/src/app/admin/errors/page.tsx
@@ -122,15 +122,15 @@ export default function ErrorsPage() {
   ).sort();
 
   return (
-    <div className="min-h-screen bg-muted dark:bg-background">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="border-b border-border bg-card dark:border-border dark:bg-muted">
+      <div className="border-b border-border bg-card">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <div>
-            <h1 className="text-3xl font-bold text-foreground dark:text-foreground">
+            <h1 className="text-3xl font-bold text-foreground">
               Error Monitoring
             </h1>
-            <p className="mt-1 text-sm text-secondary-foreground dark:text-secondary-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               Track and resolve application errors
             </p>
           </div>
@@ -150,7 +150,7 @@ export default function ErrorsPage() {
         </div>
 
         {/* Filters */}
-        <Card size="sm" className="mb-content-block">
+        <Card className="mb-6">
           <ErrorFilters
             timeRange={timeRange}
             onTimeRangeChange={setTimeRange}
@@ -163,14 +163,14 @@ export default function ErrorsPage() {
         </Card>
 
         {/* Results Count */}
-        <div className="mb-4 text-sm text-secondary-foreground dark:text-secondary-foreground">
+        <div className="mb-4 text-sm text-muted-foreground">
           Showing {filteredErrors.length} of {errors.length} errors
         </div>
 
         {/* Error List */}
-        <Card size="none">
-          <div className="border-b border-border p-4 dark:border-border">
-            <h3 className="text-lg font-semibold text-foreground dark:text-foreground">
+        <Card>
+          <div className="border-b border-border p-4">
+            <h3 className="text-lg font-semibold text-foreground">
               Error Groups
             </h3>
           </div>
@@ -179,7 +179,7 @@ export default function ErrorsPage() {
             <div className="flex items-center justify-center py-12">
               <div className="text-center">
                 <div className="mx-auto h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
-                <p className="mt-4 text-secondary-foreground dark:text-secondary-foreground">
+                <p className="mt-4 text-muted-foreground">
                   Loading errors...
                 </p>
               </div>

--- a/src/components/admin/MetricCard.tsx
+++ b/src/components/admin/MetricCard.tsx
@@ -26,23 +26,23 @@ export function MetricCard({
   subtitle,
 }: MetricCardProps) {
   const changeColors = {
-    increase: 'text-success-dark dark:text-success-text',
-    decrease: 'text-destructive-dark dark:text-destructive-text',
-    neutral: 'text-muted-foreground dark:text-muted-foreground',
+    increase: 'text-green-600 dark:text-green-400',
+    decrease: 'text-red-600 dark:text-red-400',
+    neutral: 'text-muted-foreground',
   };
 
   return (
-    <Card>
+    <Card className="p-6">
       <div className="flex items-center justify-between">
         <div className="flex-1">
-          <p className="text-sm font-medium text-muted-foreground dark:text-muted-foreground">
+          <p className="text-sm font-medium text-muted-foreground">
             {title}
           </p>
-          <p className="mt-2 text-3xl font-bold text-foreground dark:text-foreground">
+          <p className="mt-2 text-3xl font-bold text-foreground">
             {value}
           </p>
           {subtitle && (
-            <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground">
+            <p className="mt-1 text-sm text-muted-foreground">
               {subtitle}
             </p>
           )}
@@ -53,7 +53,7 @@ export function MetricCard({
           )}
         </div>
         {icon && (
-          <div className="ml-4 flex h-12 w-12 items-center justify-center rounded-lg bg-accent/20 dark:bg-primary-hover">
+          <div className="ml-4 flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
             {icon}
           </div>
         )}

--- a/src/components/admin/errors/ErrorDetailModal.tsx
+++ b/src/components/admin/errors/ErrorDetailModal.tsx
@@ -90,12 +90,12 @@ export function ErrorDetailModal({
           <DialogTitle className="text-2xl">{error.error_type}</DialogTitle>
           <div className="flex items-center gap-3 text-sm text-muted-foreground">
             <span>{error.count} occurrences</span>
-            <span>•</span>
+            <span>-</span>
             <span
               className={
                 error.level === 'fatal'
-                  ? 'text-destructive-dark'
-                  : 'text-warning-dark'
+                  ? 'text-red-500 font-medium'
+                  : 'text-yellow-500 font-medium'
               }
             >
               {error.level}
@@ -105,10 +105,10 @@ export function ErrorDetailModal({
 
         {/* Message */}
         <div className="space-y-2">
-          <h3 className="text-sm font-semibold text-foreground dark:text-foreground">
+          <h3 className="text-sm font-semibold text-foreground">
             Message
           </h3>
-          <p className="text-sm text-secondary-foreground dark:text-secondary-foreground">
+          <p className="text-sm text-muted-foreground">
             {error.message}
           </p>
         </div>
@@ -116,18 +116,18 @@ export function ErrorDetailModal({
         {/* Timestamps */}
         <div className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground dark:text-foreground">
+            <h3 className="text-sm font-semibold text-foreground">
               First Seen
             </h3>
-            <p className="text-sm text-secondary-foreground dark:text-secondary-foreground">
+            <p className="text-sm text-muted-foreground">
               {format(new Date(error.first_seen), 'PPpp')}
             </p>
           </div>
           <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground dark:text-foreground">
+            <h3 className="text-sm font-semibold text-foreground">
               Last Seen
             </h3>
-            <p className="text-sm text-secondary-foreground dark:text-secondary-foreground">
+            <p className="text-sm text-muted-foreground">
               {format(new Date(error.last_seen), 'PPpp')}
             </p>
           </div>
@@ -136,10 +136,10 @@ export function ErrorDetailModal({
         {/* Stack Trace */}
         {occurrences.length > 0 && occurrences[0]?.stack_trace && (
           <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground dark:text-foreground">
+            <h3 className="text-sm font-semibold text-foreground">
               Stack Trace
             </h3>
-            <pre className="overflow-x-auto rounded-md bg-muted dark:bg-background p-4 text-xs">
+            <pre className="overflow-x-auto rounded-md bg-zinc-900 text-zinc-100 p-4 text-xs">
               <code>{occurrences[0]?.stack_trace}</code>
             </pre>
           </div>
@@ -147,7 +147,7 @@ export function ErrorDetailModal({
 
         {/* Recent Occurrences */}
         <div className="space-y-2">
-          <h3 className="text-sm font-semibold text-foreground dark:text-foreground">
+          <h3 className="text-sm font-semibold text-foreground">
             Recent Occurrences
           </h3>
           {isLoadingOccurrences ? (
@@ -159,7 +159,7 @@ export function ErrorDetailModal({
               {occurrences.slice(0, 10).map((occurrence) => (
                 <div
                   key={occurrence.id}
-                  className="rounded-md border border-border p-3 dark:border-border"
+                  className="rounded-md border border-border p-3"
                 >
                   <div className="flex items-center justify-between">
                     <span className="text-xs text-muted-foreground">
@@ -172,7 +172,7 @@ export function ErrorDetailModal({
                     )}
                   </div>
                   {occurrence.user_email && (
-                    <div className="mt-1 text-xs text-secondary-foreground dark:text-secondary-foreground">
+                    <div className="mt-1 text-xs text-muted-foreground">
                       User: {occurrence.user_email}
                     </div>
                   )}
@@ -183,7 +183,7 @@ export function ErrorDetailModal({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-3 border-t border-border pt-4 dark:border-border">
+        <div className="flex items-center justify-end gap-3 border-t border-border pt-4">
           <Button variant="outline" onClick={onClose}>
             Close
           </Button>

--- a/src/components/admin/errors/ErrorFilters.tsx
+++ b/src/components/admin/errors/ErrorFilters.tsx
@@ -5,6 +5,14 @@
 
 'use client';
 
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Calendar, Filter, Search, X } from 'lucide-react';
 
 interface ErrorFiltersProps {
@@ -27,21 +35,21 @@ export function ErrorFilters({
   errorTypes,
 }: ErrorFiltersProps) {
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between p-4">
       {/* Search Input */}
       <div className="relative flex-1 max-w-md">
-        <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
-        <input
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
           type="text"
           placeholder="Search errors..."
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
-          className="w-full rounded-md border-border-primary py-2 pl-10 pr-10 text-sm focus:border-primary focus:ring-primary dark:border-border-primary-dark dark:bg-bg-secondary-dark dark:text-foreground dark:placeholder-text-muted"
+          className="pl-10 pr-10"
         />
         {searchQuery && (
           <button
             onClick={() => onSearchQueryChange('')}
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-secondary-foreground dark:hover:text-secondary-foreground"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />
           </button>
@@ -50,35 +58,37 @@ export function ErrorFilters({
 
       <div className="flex items-center gap-4">
         {/* Time Range Dropdown */}
-        <div className="flex items-center gap-tight">
-          <Calendar className="h-5 w-5 text-muted-foreground" />
-          <select
-            value={timeRange}
-            onChange={(e) => onTimeRangeChange(e.target.value)}
-            className="rounded-md border-border-primary py-2 pl-3 pr-10 text-sm focus:border-primary focus:ring-primary dark:border-border-primary-dark dark:bg-bg-secondary-dark dark:text-foreground"
-          >
-            <option value="1">Last 1 hour</option>
-            <option value="24">Last 24 hours</option>
-            <option value="168">Last 7 days</option>
-            <option value="720">Last 30 days</option>
-          </select>
+        <div className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
+          <Select value={timeRange} onValueChange={onTimeRangeChange}>
+            <SelectTrigger className="w-[140px]">
+              <SelectValue placeholder="Time range" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="1">Last 1 hour</SelectItem>
+              <SelectItem value="24">Last 24 hours</SelectItem>
+              <SelectItem value="168">Last 7 days</SelectItem>
+              <SelectItem value="720">Last 30 days</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
 
         {/* Error Type Dropdown */}
-        <div className="flex items-center gap-tight">
-          <Filter className="h-5 w-5 text-muted-foreground" />
-          <select
-            value={errorType}
-            onChange={(e) => onErrorTypeChange(e.target.value)}
-            className="rounded-md border-border py-2 pl-3 pr-10 text-sm focus:border-primary focus:ring-primary dark:border-border dark:bg-muted dark:text-foreground"
-          >
-            <option value="all">All Types</option>
-            {errorTypes.map((type) => (
-              <option key={type} value={type}>
-                {type}
-              </option>
-            ))}
-          </select>
+        <div className="flex items-center gap-2">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          <Select value={errorType} onValueChange={onErrorTypeChange}>
+            <SelectTrigger className="w-[140px]">
+              <SelectValue placeholder="Error type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Types</SelectItem>
+              {errorTypes.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
     </div>

--- a/src/components/admin/errors/ErrorList.tsx
+++ b/src/components/admin/errors/ErrorList.tsx
@@ -17,7 +17,7 @@ export function ErrorList({ errors, onErrorClick }: ErrorListProps) {
   if (errors.length === 0) {
     return (
       <div className="py-12 text-center">
-        <p className="text-sm text-secondary-foreground dark:text-secondary-foreground">
+        <p className="text-sm text-muted-foreground">
           No errors found
         </p>
       </div>
@@ -26,12 +26,12 @@ export function ErrorList({ errors, onErrorClick }: ErrorListProps) {
 
   const getStatusColor = (error: GroupedError): string => {
     if (error.resolved_at) {
-      return 'bg-muted-foreground';
+      return 'bg-gray-400';
     }
     if (error.level === 'fatal') {
-      return 'bg-destructive-dark';
+      return 'bg-red-500';
     }
-    return 'bg-warning-dark';
+    return 'bg-yellow-500';
   };
 
   const getStatusLabel = (error: GroupedError): string => {
@@ -45,41 +45,41 @@ export function ErrorList({ errors, onErrorClick }: ErrorListProps) {
   };
 
   return (
-    <div className="divide-y divide-border dark:divide-border">
+    <div className="divide-y divide-border">
       {errors.map((error) => (
         <div
           key={error.fingerprint}
           onClick={() => onErrorClick(error)}
-          className="cursor-pointer p-4 hover:bg-muted dark:hover:bg-muted transition-colors"
+          className="cursor-pointer p-4 hover:bg-muted/50 transition-colors"
         >
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-3">
                 {/* Status Indicator */}
                 <div
-                  className={`h-2 w-2 rounded-full shrink-0 ${getStatusColor(error)}`}
+                  className={`h-2.5 w-2.5 rounded-full shrink-0 ${getStatusColor(error)}`}
                   title={getStatusLabel(error)}
                 />
 
                 {/* Error Type */}
-                <h3 className="font-semibold text-foreground dark:text-foreground truncate">
+                <h3 className="font-semibold text-foreground truncate">
                   {error.error_type}
                 </h3>
 
                 {/* Occurrence Count */}
-                <span className="text-sm font-medium text-muted-foreground shrink-0">
-                  {error.count}×
+                <span className="text-sm font-medium text-muted-foreground shrink-0 bg-muted px-2 py-0.5 rounded">
+                  {error.count}x
                 </span>
               </div>
 
               {/* Error Message */}
-              <p className="mt-1 text-sm text-secondary-foreground dark:text-secondary-foreground line-clamp-2">
+              <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
                 {error.message}
               </p>
 
               {/* Route if available */}
               {error.route && (
-                <p className="mt-1 text-xs text-muted-foreground font-mono">
+                <p className="mt-1 text-xs text-muted-foreground/70 font-mono">
                   {error.route}
                 </p>
               )}

--- a/src/components/admin/errors/ErrorStats.tsx
+++ b/src/components/admin/errors/ErrorStats.tsx
@@ -21,7 +21,7 @@ export function ErrorStats({ stats, isLoading = false }: ErrorStatsProps) {
         {[...Array(4)].map((_, i) => (
           <div
             key={i}
-            className="h-32 animate-pulse rounded-xl bg-muted dark:bg-muted"
+            className="h-32 animate-pulse rounded-xl bg-muted"
           />
         ))}
       </div>
@@ -41,21 +41,21 @@ export function ErrorStats({ stats, isLoading = false }: ErrorStatsProps) {
         title="Unique Types"
         value={stats.unique_types}
         subtitle="Error patterns"
-        icon={<AlertTriangle className="h-6 w-6 text-warning-dark" />}
+        icon={<AlertTriangle className="h-6 w-6 text-yellow-500" />}
       />
 
       <MetricCard
         title="Fatal Errors"
         value={stats.fatal_count}
         subtitle="Requires attention"
-        icon={<XCircle className="h-6 w-6 text-destructive-dark" />}
+        icon={<XCircle className="h-6 w-6 text-red-500" />}
       />
 
       <MetricCard
         title="Unresolved"
         value={stats.unresolved_count}
         subtitle={`${stats.resolved_count} resolved`}
-        icon={<CheckCircle className="h-6 w-6 text-success-dark" />}
+        icon={<CheckCircle className="h-6 w-6 text-green-500" />}
       />
     </div>
   );


### PR DESCRIPTION
- Replace broken custom CSS classes with standard Tailwind colors
- Use shadcn Select/Input components in ErrorFilters instead of raw inputs
- Fix status indicator colors: bg-gray-400, bg-red-500, bg-yellow-500
- Fix icon colors: text-yellow-500, text-red-500, text-green-500
- Fix code block styling with bg-zinc-900 text-zinc-100
- Simplify page backgrounds to bg-background, bg-card
- All components now use working color classes compatible with Tailwind v4