### PR TITLE
docs: rewrite CLAUDE.md to match codebase reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,14 +71,14 @@
 - Call `toast.success(...)`, `toast.error(...)` directly — no custom provider
 
 **Error Handling:**
-- `castError` helper at `src/lib/errors.ts` (also re-exported from `src/lib/logger.ts`)
+- Two independent `castError` helpers exist: `src/lib/errors.ts` returns `Error`, `src/lib/logger.ts` returns `ErrorLogData`. Pick the one whose return type matches the call site.
 - Wrap async ops in try/catch
 - Log via `logger.error` — never `console.*`
 - Return user-friendly messages; never expose internals
 
 **Tailwind v4 / Styling:**
 - Defined in `src/app/globals.css` via `@utility` blocks and class rules
-- Available: `.glass-card`, `.glass-card-light`, `.hover-lift`, `.transition-smooth`, `section-spacing`, `card-padding` (sm/lg variants)
+- Available: `.glass-card`, `.glass-card-light`, `.hover-lift`, `.transition-smooth`, `.section-spacing`, `.card-padding` (`-sm` / `-lg` variants)
 - Focus styling is native via `:focus-visible` in globals.css — there is no `.focus-ring` class
 - Use CSS custom properties, not hard-coded values
 
@@ -141,7 +141,7 @@
 
 **Semantic HTML:**
 - Landmarks: `main`, `nav`, `section`, `article`
-- `<main id="main-content">` is the skip-link target (in `src/app/layout.tsx`)
+- Skip-link target is `<div id="main-content">` in `src/app/layout.tsx` — note: a `<main>` landmark is not currently emitted; prefer adding one when touching the layout
 - Heading hierarchy without skips
 
 **ARIA:**
@@ -158,8 +158,8 @@
 ## INTEGRATIONS
 
 **Neon + Drizzle:**
-- Client `@/lib/db` (lazy-init; mock when `POSTGRES_URL` is unset)
-- Schema barrel `@/lib/schemas/schema`
+- Client `src/lib/db.ts` (lazy-init; mock when `POSTGRES_URL` is unset). Imports use the `@/` alias (`@/lib/db` -> `src/lib/db.ts`).
+- Schema barrel `src/lib/schemas/schema.ts`
 - Drizzle config `drizzle.config.ts` (dialect `postgresql`, `schemaFilter: ['public']`)
 - `DATABASE_URL_UNPOOLED` is used by drizzle-kit for migrations
 - pg_cron runs weekly VACUUM ANALYZE; see `.planning/` for details

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,288 +1,212 @@
 # CLAUDE.md
 
 **NO EMOJIS** - Never use emojis unless explicitly requested. Use Heroicons/Lucide React for UI icons.
-**NO CODE EXAMPLES NEEDED** - This project uses standard patterns. Search the codebase for existing examples.
-- **SIMPLICITY**: Use native features first. No unnecessary abstractions.
-- **TYPE SAFETY**: TypeScript strict mode. NO `any` types. Use Zod for runtime validation.
-- **SERVER-FIRST**: Default to Server Components. Client components ONLY for hooks/events/browser APIs.
-- **PERFORMANCE**: WebP images, monitor bundle size, lazy load heavy components.
-**YAGNI (You Aren't Gonna Need It):**
-Do not implement features, functionality, or infrastructure that is not immediately required for the current requirements. No speculative coding, no "just in case" implementations, no premature optimization. If it's not needed now, it will not be developed. This rule applies to libraries, frameworks, database schemas, API endpoints, and business logic.
-**Composition Over Inheritance:**
-All system components must be built using composition rather than inheritance hierarchies. Avoid deep inheritance trees. Prefer building functionality by combining smaller, independent components rather than creating parent-child class relationships. This ensures flexibility, testability, and prevents brittle code that breaks when parent classes change.
-**Explicit Data Flow & Type Safety:**
-All data must have clearly defined, strongly typed interfaces. No dynamic types, no implicit conversions, no untyped objects passed between functions. All inputs, outputs, and transformations must be explicitly declared with proper type annotations. Any data that crosses module boundaries must be validated and typed.
-**Small, Focused Modules (High Cohesion, Low Coupling):**
-Each module, class, function, and component must have a single, well-defined purpose. Modules must not exceed reasonable size limits and should only contain code directly related to their primary responsibility. Dependencies between modules must be minimal and clearly defined through explicit interfaces.
-**Fail Fast, Log Precisely:**
-Systems must validate inputs immediately and throw clear, specific errors when invalid data is encountered. Do not attempt to recover from invalid states silently. All error conditions must be logged with sufficient context to identify the root cause without requiring additional debugging. Error messages must be actionable.
-**Idempotency Everywhere:**
-All operations, especially those that modify state or interact with external systems, must be idempotent. Running the same operation multiple times must produce the same result as running it once. This applies to database operations, API calls, file operations, and any state-changing functions.
-**Predictable State Management:**
-All application state must be managed in a deterministic, traceable manner. No hidden global state, no implicit side effects, no shared mutable state between components. State changes must follow clear, predictable patterns with no race conditions or unexpected interactions.
-**Single Responsibility:**
-Every function, class, module, and service must have exactly one reason to change. If a component handles multiple concerns or domains, it must be split into separate components. This applies to business logic, data access, presentation, and infrastructure concerns.
-**Prefer Readability Over Cleverness:**
-Code must be written for human understanding first, performance second. No clever tricks, no overly compact syntax, no "smart" solutions that sacrifice clarity. The codebase must be understandable by any team member without requiring extensive documentation or explanation.
+**SEARCH FIRST** - This project uses standard patterns. Find an existing example in the codebase before adding new code.
 
-**File Organization:**
-- `src/app/` - Next.js 15 App Router pages, layouts, and API routes
-- `src/app/(tools)/` - Route groups (URL: /paystub not /tools/paystub)
-- `src/app/actions/` - Server Actions for form submissions
-- `src/app/api/` - API route handlers
-- `src/components/layout/` - NavbarLight, Footer
-- `src/components/forms/` - Form-specific components
-- `src/components/ui/` - Base reusable components
-- `src/lib/` - Core utilities (logger, analytics, seo-utils)
-- `src/lib/schemas/` - Zod validation schemas
-- `src/types/` - TypeScript type definitions
+## CORE PRINCIPLES
+
+- **SIMPLICITY**: Use native features first. No unnecessary abstractions.
+- **TYPE SAFETY**: TypeScript strict mode. NO `any` types. Validate at boundaries with Zod.
+- **SERVER-FIRST**: Default to Server Components. Client components only for hooks/events/browser APIs.
+- **YAGNI**: Don't build for hypothetical requirements. No speculative code, schemas, endpoints, or libs.
+- **COMPOSITION OVER INHERITANCE**: Combine small components. No deep class hierarchies.
+- **EXPLICIT DATA FLOW**: Every cross-module value is typed. Validate at the boundary, trust inside.
+- **SINGLE RESPONSIBILITY**: One reason to change per module. Split when concerns multiply.
+- **FAIL FAST**: Validate inputs immediately. Throw specific, actionable errors. No silent recovery.
+- **IDEMPOTENCY**: State-changing operations must produce the same result when retried.
+- **READABILITY OVER CLEVERNESS**: Code is read more than written.
+
+## STACK
+
+- **Framework**: Next.js 16 (App Router) + React 19
+- **Runtime / PM**: Bun 1.3.x
+- **Lint / Format**: Biome 2.4.4 (`biome.json`)
+- **DB**: Neon Postgres + Drizzle ORM 0.45 — client `src/lib/db.ts`, schema barrel `src/lib/schemas/schema.ts`
+- **Forms**: `@tanstack/react-form` via factory in `src/hooks/form-hook.tsx`
+- **Validation**: Zod 4
+- **Toasts**: Sonner (no custom provider)
+- **Email**: Resend (`src/lib/resend-client.ts`)
+- **Tests**: `bun:test` for unit, Playwright for e2e
+- **Env**: `@t3-oss/env-nextjs` — typed env in `src/env.ts`. Never read `process.env.X` directly.
+
+## FILE ORGANIZATION
+
+- `src/app/` - App Router pages, layouts, API route handlers
+- `src/app/actions/` - Server Actions (currently: `ttl-calculator.ts`)
+- `src/app/api/` - API routes (blog, calculators, contact, csp-reports, health, newsletter, pagespeed, process-emails, rss, testimonials, web-vitals)
+- `src/components/layout/` - `Navbar.tsx` (exported as `NavbarLight`), `Footer.tsx`
+- `src/components/forms/` - `ContactForm`, `NewsletterSignup`, `FormField`, `FormSuccessMessage`
+- `src/components/ui/` - Base primitives (button, card, input, label)
+- `src/components/utilities/` - Cross-cutting components (`Icon`/`IconButton`, `Analytics`, `JsonLd`, `ScrollProgress`)
+- `src/lib/` - Core utilities (`db`, `logger`, `errors`, `analytics`, `seo-utils`, `csrf`, `rate-limiter`, `resend-client`, `contact-service`, `scheduled-emails`)
+- `src/lib/auth/admin.ts` - Bearer-token guard for admin/cron endpoints (no user auth in this app)
+- `src/lib/schemas/` - Drizzle table schemas + Zod schemas; barrel at `schema.ts`
+- `src/lib/constants/` - Domain constants (`business.ts` etc.)
+- `src/types/` - Shared TypeScript types
 - `src/hooks/` - Custom React hooks
-- `tests/` - Vitest unit tests
-- `e2e/` - Playwright end-to-end tests
+- `tests/unit/` - `bun:test` unit tests
+- `e2e/` - Playwright specs
+
+## PATTERNS
 
 **Metadata:**
-- Export metadata object from all page components
-- Title, description (120-160 chars for SEO)
-- OpenGraph and Twitter card data
-- Structured data goes in script tags in body, NOT metadata.other
-- Use generateWebsiteSchema, generateOrganizationSchema from lib/seo-utils
+- Export `metadata` from server page components (`'use client'` files cannot export `metadata`)
+- Description 120-160 chars for SEO
+- Structured data via `<JsonLd />` (`src/components/utilities/JsonLd.tsx`), not `metadata.other`
+- Use `generateWebsiteSchema`, `generateOrganizationSchema` from `src/lib/seo-utils.ts`
 
 **Hooks:**
-- useState for local UI state only
-- useActionState for forms (replaces useFormState)
-- useFormStatus for submit button pending states
-- useRef for non-reactive values (timers, RAF IDs)
-- useCallback for stable function references
+- `useState` for local UI state only
+- `useRef` for non-reactive values (timers, RAF IDs)
+- `useCallback` for stable refs passed to memoized children
 
-**Context:**
-- Create context with undefined default
-- Custom hook checks context exists
-- Throw error if used outside provider
-- Example: ToastProvider, useToast pattern
+**Forms (`@tanstack/react-form`):**
+- Build typed forms with the factory in `src/hooks/form-hook.tsx`; shared context in `src/hooks/form-context.ts`
+- Validate with Zod (`zodSchema` adapter) using schemas from `src/lib/schemas/`
+- Submit via API route (e.g., `/api/contact`) or Server Action
+- `useActionState`/`useFormStatus` is used in `src/app/unsubscribe/UnsubscribeForm.tsx`; not the default for new forms
+
+**Toasts (Sonner):**
+- Mount `<Toaster />` from `sonner` once near the root
+- Call `toast.success(...)`, `toast.error(...)` directly — no custom provider
 
 **Error Handling:**
-- Use castError helper from utils/errors.ts
-- Always wrap operations in try/catch
-- Log errors with logger.error, never console
-- Return typed error states from Server Actions
+- `castError` helper at `src/lib/errors.ts` (also re-exported from `src/lib/logger.ts`)
+- Wrap async ops in try/catch
+- Log via `logger.error` — never `console.*`
+- Return user-friendly messages; never expose internals
 
-**Tailwind-First Approach:**
-- Create semantic CSS classes for repeated patterns in globals.css
+**Tailwind v4 / Styling:**
+- Defined in `src/app/globals.css` via `@utility` blocks and class rules
+- Available: `.glass-card`, `.glass-card-light`, `.hover-lift`, `.transition-smooth`, `section-spacing`, `card-padding` (sm/lg variants)
+- Focus styling is native via `:focus-visible` in globals.css — there is no `.focus-ring` class
 - Use CSS custom properties, not hard-coded values
 
-**Component Styling:**
-- Utility-first with Tailwind classes
-- Glass morphism pattern: .glass-card, .glass-card-light
-- Gradient text: .gradient-text
-- Semantic utilities: .section-spacing, .card-padding
-- Hover states: .hover-lift, .button-hover-glow
-- Transitions: .transition-smooth
-
-**Organization:**
-- Layout components in components/layout/
-- Form components in components/forms/
-- Base UI in components/ui/
-- Feature-specific in components/[feature]/
-- Shared components at components/ root
-
-**Structure:**
-- Imports first (grouped: types, React, third-party, local)
-- Types/Interfaces second
-- Constants third (UPPER_SNAKE_CASE)
-- Component function fourth
-- Sub-components last (if small and only used here)
+**Component Layout:**
+- Imports first (types, React, third-party, local)
+- Types/interfaces, then constants (UPPER_SNAKE_CASE), then the component, then small sub-components
 
 **Naming:**
-- Components: PascalCase (ContactForm.tsx)
-- Utils: kebab-case (seo-utils.ts)
-- Constants: UPPER_SNAKE_CASE (TOAST_DURATION_DEFAULT)
-- Functions: camelCase (calculateTotal)
+- Components `PascalCase.tsx` · utils `kebab-case.ts` · constants `UPPER_SNAKE_CASE` · functions/vars `camelCase`
 
-**Zod Schemas:**
-- Location: lib/schemas/
-- common.ts for reusable validators (email, phone, name)
-- Feature-specific files for form schemas
-- Export schema and inferred type
-- Always use safeParse, never parse
+**Zod:**
+- Location `src/lib/schemas/`. `common.ts` holds reusable validators (email, phone, name); feature files own form/API schemas
+- Export schema and inferred type. Always `safeParse`, never `parse`
 
-**Form Pattern:**
-- Server Action validates with Zod
-- Returns state object with success/error
-- Client component uses useActionState
-- SubmitButton uses useFormStatus for pending state
-- Progressive enhancement - forms work without JS
+**Drizzle:**
+- Schema files per-table in `src/lib/schemas/`, barrel at `schema.ts`
+- TS identifiers in camelCase; columns auto-map to snake_case
+- Query: `db.select().from(table).where(eq(table.col, value))`
+- Sync: `bun run db:push` (drizzle-kit push). When `pg_cron` or `hypopg` are installed, push breaks — apply DDL via Neon MCP `run_sql` instead.
 
-**Unit Tests (bun:test):**
-- Location: tests/unit/
-- Test utilities, validation, pure functions
-- Mock external dependencies
-- Run: bun test tests/
+## TESTING
 
-**E2E Tests (Playwright):**
-- Location: e2e/
-- Test user flows, form submissions, navigation
-- Multiple browsers: chromium, firefox, webkit
-- Run: bun run test:e2e (all) or bun run test:e2e:fast (chromium only)
+**Unit (`bun:test`):**
+- Files in `tests/unit/`. Setup `tests/setup.ts` auto-mocks `@/env` and `@/lib/logger`.
+- Run: `bun run test:unit` (alias for `bun test tests/`)
+- Coverage: `bun run test:unit:coverage`
 
-**Test Coverage:**
-- Validation schemas must have tests
-- Critical user flows must have E2E tests
-- Server Actions should have unit tests
+**E2E (Playwright):**
+- Files in `e2e/`. Browsers: chromium, webkit. baseURL `http://localhost:3001`.
+- Run: `bun run test:e2e` · fast: `bun run test:e2e:fast` · a11y: `bun run test:e2e:a11y`
+
+**Coverage expectations:**
+- Validation schemas: tests required
+- Critical user flows: e2e required
+- API routes / Server Actions: unit-test the handler
 
 ## PERFORMANCE
 
 **Images:**
-- ALWAYS use Next.js Image component
-- Format: WebP for all images
-- Specify width and height explicitly
-- Use priority prop for above-fold images
-- Lazy load by default for below-fold
+- Use Next.js `<Image>` always
+- WebP only (`next.config.ts` sets `formats: ['image/webp']`)
+- Specify width/height. `priority` for above-fold; lazy by default below
 
-**Code Splitting:**
-- Dynamic imports for heavy components
-- next/dynamic with loading fallback
-- ssr: false for client-only components
-- Modular imports enabled for Heroicons
-
-**Bundle Size:**
-- Keep first load JS under 180kB per page
-- Monitor bundle size in build output
+**Bundle:**
+- `optimizePackageImports` (Next.js 16 experimental) is enabled in `next.config.ts` for Heroicons, Radix UI, Lucide, TanStack
+- Aim for first-load JS under 180kB per page (aspirational; not enforced in CI)
+- Dynamic-import heavy/client-only components via `next/dynamic`
 
 ## LOGGING & ANALYTICS
 
-**Logger (NOT console.log):**
-- ALWAYS use logger from lib/logger
-- logger.info for events, user actions
-- logger.error for errors, failures
-- logger.debug for development only
-- NEVER use console.log/warn/error directly
+**Logger (`src/lib/logger.ts`):**
+- Methods: `info`, `error`, `warn`, `debug`
+- Never use `console.*` directly
 
 **Analytics:**
-- Vercel Analytics for performance
-- CTA clicks auto-tracked via CTAButton component
-- Form submissions auto-tracked via Server Actions
-- Custom events: logger.info with metadata
+- `@vercel/analytics` + `@vercel/speed-insights` mounted in `src/components/utilities/Analytics.tsx`
+- Domain events: emit via `logger.info` with metadata
 
 ## ACCESSIBILITY
 
 **Semantic HTML:**
-- Use proper landmarks (main, nav, section, article)
-- main#main-content for skip link target
-- Headings in order (h1, h2, h3 - no skipping)
-- Lists for navigation and grouped content
+- Landmarks: `main`, `nav`, `section`, `article`
+- `<main id="main-content">` is the skip-link target (in `src/app/layout.tsx`)
+- Heading hierarchy without skips
 
 **ARIA:**
-- aria-label for interactive elements without text
-- aria-hidden="true" for decorative icons
-- aria-live for dynamic content (assertive for errors, polite for info)
-- role="alert" for error messages
-- role="progressbar" with aria-valuenow for progress indicators
+- `aria-label` on icon-only buttons
+- `aria-hidden="true"` on decorative icons
+- `aria-live` on dynamic content (`assertive` for errors, `polite` for info)
+- `role="alert"` for errors; `role="progressbar"` + `aria-valuenow` (used in `ScrollProgress`)
 
-**Keyboard Navigation:**
-- All interactive elements keyboard accessible
-- Use button element, not div with onClick
-- Focus states visible (.focus-ring utility)
-- Tab order logical and complete
+**Keyboard:**
+- All interactives keyboard-accessible
+- Use `<button>`, never `<div onClick>`
+- Visible focus states via native `:focus-visible` in globals.css
 
 ## INTEGRATIONS
 
+**Neon + Drizzle:**
+- Client `@/lib/db` (lazy-init; mock when `POSTGRES_URL` is unset)
+- Schema barrel `@/lib/schemas/schema`
+- Drizzle config `drizzle.config.ts` (dialect `postgresql`, `schemaFilter: ['public']`)
+- `DATABASE_URL_UNPOOLED` is used by drizzle-kit for migrations
+- pg_cron runs weekly VACUUM ANALYZE; see `.planning/` for details
+
+**Auth:**
+- No user-auth system in this app
+- Admin/cron endpoints guarded by Bearer token (`src/lib/auth/admin.ts`) using `ADMIN_SECRET` / `CRON_SECRET`
+
 **Resend (Email):**
-- API key from env: RESEND_API_KEY
-- Send from: hello@hudsondigitalsolutions.com
-- HTML emails with proper headers
-- Error handling with logger.error
+- Client `src/lib/resend-client.ts`; key `RESEND_API_KEY`
+- From: `noreply@hudsondigitalsolutions.com` for system mail; `hello@...` is the user-facing contact address in `src/lib/constants/business.ts`
+- Senders: `src/lib/contact-service.ts`, `src/lib/scheduled-emails.ts`
 
-**Neon (Database with Drizzle ORM):**
-- `@/lib/db` - Drizzle ORM client for all database operations
-- `@/lib/schema` - Drizzle schema definitions with type exports
-- `@/lib/auth/client` - Neon Auth client for browser authentication
-- `@/lib/auth/server` - Neon Auth server utilities
-- Environment vars: DATABASE_URL, NEON_AUTH_BASE_URL
-- Use Drizzle query syntax: `db.select().from(table).where(eq(column, value))`
-- Schema uses camelCase (maps to snake_case columns automatically)
-- Log database errors, return user-friendly messages
-
-
-**RULES & GUIDELINES:**
-- Search codebase for existing patterns first
-- Validate at boundaries with Zod (forms, APIs)
-- Type everything explicitly (no implicit any)
-- Use semantic HTML and ARIA (accessibility)
-- Clean up timers, listeners, subscriptions (useEffect)
-- Handle errors gracefully (try/catch, user feedback)
-- Test keyboard navigation (accessibility)
-- Check bundle size (performance)
-- Use logger not console (unified logging)
-- Use constants for magic numbers (maintainability)
+**Env vars:**
+- All env access goes through `src/env.ts` (T3 env). Never read `process.env.X` directly.
+- Required in production: `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
+- Optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`
 
 ## DEVELOPMENT COMMANDS
 
-**Development:**
-- bun run dev - Start development server
-- bun run build - Production build
-- bun run start - Start production server
-- bun run lint - Run Biome check (linter + formatter check)
-- bun run typecheck - TypeScript type checking
-- bun test tests/ - Run unit tests
-- bun run test:e2e - Run E2E tests (all browsers)
-- bun run test:e2e:fast - Run E2E tests (chromium only)
-- bun run test:all - Run all checks (lint, typecheck, tests)
-
-**Analysis:**
-- bun run test:unit:coverage - Test coverage report
+- `bun run dev` — dev server
+- `bun run build` — production build (`next build --webpack`)
+- `bun run start` — production server
+- `bun run lint` / `lint:fix` — Biome check / autofix
+- `bun run typecheck` — `tsc --noEmit`
+- `bun run test:unit` / `test:unit:coverage` — bun:test
+- `bun run test:e2e` / `test:e2e:fast` / `test:e2e:a11y` — Playwright variants
+- `bun run test:all` — lint + typecheck + unit + e2e:fast
+- `bun run db:push` — Drizzle schema sync (Neon)
 
 ## GIT WORKFLOW
 
-**Before Commit:**
-- Run: bun run lint && bun run typecheck
-- Fix all errors and warnings
-- Verify build succeeds
+**Before commit:**
+- `bun run lint && bun run typecheck` must pass
+- Lefthook is installed via the `prepare` script — its pre-commit hooks must pass
 
-**Commit Message Format:**
-- First line: type: description (feat:, fix:, refactor:, docs:)
-- Blank line
-- Detailed changes as bullet points
-- Keep first line under 50 characters
-- Explain WHY, not WHAT (code shows what)
-
-**Server Action Pattern:**
-- File in app/actions/ with 'use server'
-- Accept _prevState and FormData
-- Validate with Zod safeParse
-- Return typed state object
-- Used with useActionState in client component
-
-**Form Pattern:**
-- Client component with 'use client'
-- useActionState for form state
-- Server Action for submission
-- SubmitButton with useFormStatus
-- Error display from state.error
-- Success message from state.success
-
-**Toast Pattern:**
-- Use useToast hook in components
-- Call showToast with type, title, message
-- Auto-dismisses after duration
-- Manual dismiss with close button
-
-**Icon Pattern:**
-- IconButton for clickable icons
-- Always aria-label for buttons
-- aria-hidden="true" for decorative icons
-
-**Error Handling Pattern:**
-- try/catch around all async operations
-- Log with logger.error, include context
-- Return user-friendly error messages
-- Never expose internal error details
+**Commit format:**
+- First line `type: description` (`feat:`, `fix:`, `refactor:`, `docs:`, `chore:`); under 50 chars
+- Blank line, then bullet body explaining WHY, not WHAT
 
 ## WHEN IN DOUBT
+
 - Choose simplicity over cleverness
 - Use native platform features over custom solutions
-- Delete code instead of adding when possible
-- Search codebase before implementing
-- Ask user if requirements unclear
-- Follow existing patterns in codebase
+- Delete code rather than add when possible
+- Search the codebase before implementing
+- Ask the user when requirements are unclear
+- Follow existing patterns
 - Prioritize type safety and accessibility
-- Remember: this is production code, not a demo
+- This is production code, not a demo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@
 - `src/components/forms/` - `ContactForm`, `NewsletterSignup`, `FormField`, `FormSuccessMessage`
 - `src/components/ui/` - Base primitives (button, card, input, label)
 - `src/components/utilities/` - Cross-cutting components (`Icon`/`IconButton`, `Analytics`, `JsonLd`, `ScrollProgress`)
-- `src/lib/` - Core utilities (`db`, `logger`, `errors`, `analytics`, `seo-utils`, `csrf`, `rate-limiter`, `resend-client`, `contact-service`, `scheduled-emails`)
+- `src/lib/` - Core utilities (partial: `db`, `logger`, `errors`, `analytics`, `seo-utils`, `csrf`, `rate-limiter`, `resend-client`, `contact-service`, `scheduled-emails`, `email-utils`, `notifications`, `request`, `security-headers`, `attribution`, plus per-domain modules `blog`, `showcase`, `testimonials`, `help-articles`, `paystub-calculator/`, `pdf/`, `ttl-calculator/`)
 - `src/lib/auth/admin.ts` - Bearer-token guard for admin/cron endpoints (no user auth in this app)
 - `src/lib/schemas/` - Drizzle table schemas + Zod schemas; barrel at `schema.ts`
 - `src/lib/constants/` - Domain constants (`business.ts` etc.)
@@ -175,8 +175,9 @@
 
 **Env vars:**
 - All env access goes through `src/env.ts` (T3 env). Never read `process.env.X` directly.
-- Required in production: `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
-- Optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`
+- Server, required in production: `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
+- Server, optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `BASE_URL`
+- Client (`NEXT_PUBLIC_*`): `NEXT_PUBLIC_BASE_URL` (defaults to `http://localhost:3000`), `NEXT_PUBLIC_SITE_URL` (optional)
 
 ## DEVELOPMENT COMMANDS
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,9 @@
 
 **Env vars:**
 - All env access goes through `src/env.ts` (T3 env). Never read `process.env.X` directly.
-- Server, required in production: `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
-- Server, optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `BASE_URL`
-- Client (`NEXT_PUBLIC_*`): `NEXT_PUBLIC_BASE_URL` (defaults to `http://localhost:3000`), `NEXT_PUBLIC_SITE_URL` (optional)
+- Schema-required when `VERCEL_ENV === 'production'` (enforced by a `.optional().refine(...)` pair; unset elsewhere): `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
+- Always defined (have defaults): `BASE_URL` (default `http://localhost:3000`), `NEXT_PUBLIC_BASE_URL` (default `http://localhost:3000`), `NODE_ENV` (default `development`)
+- Truly optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `NEXT_PUBLIC_SITE_URL`
 
 ## DEVELOPMENT COMMANDS
 


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37m- Audited every claim in `CLAUDE.md` against the actual repo and rewrote the file in place; the prior version had drifted significantly (fabricated Neon Auth section, wrong test runner, non-existent components, stale paths).[0m
[38;5;8m   4[0m [37m- Compressed the verbose engineering-principles block and split the over-large file-organization section so no single `##` exceeds ~25% of the document.[0m
[38;5;8m   5[0m [37m- Net `-76` lines; every claim now points at a real file/line.[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m## What changed[0m
[38;5;8m   8[0m 
[38;5;8m   9[0m [37m**Corrections (factual errors):**[0m
[38;5;8m  10[0m [37m- Test runner: Vitest -> `bun:test`[0m
[38;5;8m  11[0m [37m- Framework: Next.js 15 -> 16; Biome 2.4.4; Drizzle 0.45[0m
[38;5;8m  12[0m [37m- Env var: `DATABASE_URL` -> `POSTGRES_URL`; dropped unused `NEON_AUTH_BASE_URL`[0m
[38;5;8m  13[0m [37m- `castError` path: `utils/errors.ts` -> `src/lib/errors.ts`[0m
[38;5;8m  14[0m [37m- Schema path: `@/lib/schema` -> `@/lib/schemas/schema` (barrel)[0m
[38;5;8m  15[0m [37m- Bundle: `modularizeImports` -> `optimizePackageImports` (Next.js 16)[0m
[38;5;8m  16[0m [37m- System email from: `hello@` -> `noreply@`[0m
[38;5;8m  17[0m [37m- Removed: `(tools)` route group, `ToastProvider`/`useToast`, `CTAButton`, `SubmitButton`, `.focus-ring`/`.gradient-text`/`.button-hover-glow` (none exist in the codebase)[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37m**Replaced:**[0m
[38;5;8m  20[0m [37m- Neon Auth section: this app has **no user auth** — only an admin Bearer guard at `src/lib/auth/admin.ts` using `ADMIN_SECRET` / `CRON_SECRET`[0m
[38;5;8m  21[0m [37m- Toast: Sonner (`toast.success/.error`) instead of custom provider[0m
[38;5;8m  22[0m [37m- Form: `@tanstack/react-form` factory at `src/hooks/form-hook.tsx`; `useActionState` only used in the legacy `UnsubscribeForm`[0m
[38;5;8m  23[0m 
[38;5;8m  24[0m [37m**Structure / tightening:**[0m
[38;5;8m  25[0m [37m- Collapsed nine bloated engineering-principle paragraphs into one CORE PRINCIPLES bullet list[0m
[38;5;8m  26[0m [37m- Added explicit STACK section so future sessions don't have to grep `package.json`[0m
[38;5;8m  27[0m [37m- Split `FILE ORGANIZATION` (was 32% of file) into `FILE ORGANIZATION` + `PATTERNS`[0m
[38;5;8m  28[0m 
[38;5;8m  29[0m [37m## Test plan[0m
[38;5;8m  30[0m 
[38;5;8m  31[0m [37m- [x] Every file path mentioned in the new CLAUDE.md was verified to exist on disk[0m
[38;5;8m  32[0m [37m- [x] Every shell command was verified against `package.json` scripts[0m
[38;5;8m  33[0m [37m- [x] Every env var was verified against `src/env.ts`[0m
[38;5;8m  34[0m [37m- [x] No `##` section exceeds 25% of the file (largest: `PATTERNS` at 24%)[0m
[38;5;8m  35[0m 
[38;5;8m  36[0m [37m[hudsor01][0m