### PR TITLE
hotfix: remove page-level revalidate from portfolio + showcase

### DIFF
--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -13,11 +13,10 @@ import {
 } from '@/lib/showcase'
 import { formatDate } from '@/lib/utils'
 
-// Enable ISR with 1-hour revalidation for database data
-// React cache() handles request deduplication at data layer
-export const revalidate = 3600
-
-// Generate static params for all projects
+// Generate static params for all projects. Caching is handled at the
+// data-layer level (`'use cache'` + `cacheLife()` in src/lib/showcase.ts);
+// page-level `export const revalidate` is incompatible with
+// nextConfig.cacheComponents = true.
 export async function generateStaticParams() {
 	const slugs = await getAllShowcaseSlugs()
 	const results = slugs.map(slug => ({ slug }))

--- a/src/app/showcase/page.tsx
+++ b/src/app/showcase/page.tsx
@@ -8,9 +8,8 @@ import { TypewriterText } from '@/components/ui/TypewriterText'
 import { Analytics } from '@/components/utilities/Analytics'
 import { getShowcaseItems } from '@/lib/showcase'
 
-// Enable ISR with 1-hour revalidation
-export const revalidate = 3600
-
+// Caching handled at data-layer level (src/lib/showcase.ts uses 'use cache'
+// + cacheLife). Page-level revalidate is incompatible with cacheComponents.
 export const metadata: Metadata = {
 	title: 'Showcase - Our Work | Hudson Digital Solutions',
 	description:


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mProduction deploy of v4.1 merge commit `a850e1b` failed:[0m
[38;5;8m   4[0m [37m> Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.[0m
[38;5;8m   5[0m 
[38;5;8m   6[0m [37m`export const revalidate = 3600` was still present in:[0m
[38;5;8m   7[0m [37m- `src/app/portfolio/[slug]/page.tsx:18`[0m
[38;5;8m   8[0m [37m- `src/app/showcase/page.tsx:12`[0m
[38;5;8m   9[0m 
[38;5;8m  10[0m [37mCaching is now handled at the data-layer level (`'use cache'` + `cacheLife()` in `src/lib/showcase.ts`). Page-level `revalidate` is incompatible with `cacheComponents: true`.[0m
[38;5;8m  11[0m 
[38;5;8m  12[0m [37mThe original phase 64 commit message claimed these were removed, but the diff didn't include them — they were edited during the initial deferral cycle and never re-applied when phase 64 was recovered. Caught by Vercel build, not local build (local build still succeeded somehow — likely because cacheComponents validation runs in webpack production-mode only).[0m
[38;5;8m  13[0m 
[38;5;8m  14[0m [37m## Test plan[0m
[38;5;8m  15[0m [37m- [x] `bun run typecheck` ✓[0m
[38;5;8m  16[0m [37m- [x] `bun run lint` ✓[0m
[38;5;8m  17[0m [37m- [x] `bun run test:unit` ✓ 403 / 0[0m
[38;5;8m  18[0m [37m- [x] `bun run build` ✓[0m
[38;5;8m  19[0m [37m- [ ] Vercel deploy succeeds[0m
[38;5;8m  20[0m [37m- [ ] Post-deploy: portfolio + showcase pages render with cached data layer[0m
[38;5;8m  21[0m 
[38;5;8m  22[0m [37m[hudsor01][0m