### PR TITLE
feat(navbar): add Blog link, remove redundant Contact item

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,7 +31,7 @@
         "isomorphic-dompurify": "3.10.0",
         "lucide-react": "1.11.0",
         "nuqs": "2.8.9",
-        "postcss": "8.5.10",
+        "postcss": "8.5.12",
         "puppeteer": "24.42.0",
         "radix-themes-tw": "1.1.0",
         "react-email": "6.0.0",
@@ -1133,7 +1133,7 @@
 
     "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
 
-    "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
@@ -1459,6 +1459,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@tailwindcss/postcss/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
+
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
@@ -1506,6 +1508,8 @@
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "sanitize-html/postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"isomorphic-dompurify": "3.10.0",
 		"lucide-react": "1.11.0",
 		"nuqs": "2.8.9",
-		"postcss": "8.5.10",
+		"postcss": "8.5.12",
 		"puppeteer": "24.42.0",
 		"radix-themes-tw": "1.1.0",
 		"react-email": "6.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -528,6 +528,19 @@ a,
 	.surface-overlay {
 		background-color: oklch(from var(--foreground) l c h / 0.04);
 	}
+
+	/* Explicit focus marker for elements that opt into focus-ring styling.
+	 * Globally `*:focus-visible` (above) gives every focusable element an
+	 * outline; this class re-asserts that contract for components that
+	 * want to declare their focus intent in the markup, and adds a
+	 * background/transition so the focus state is visible against the
+	 * navbar's blurred backdrop. Used by Navbar logo, Footer links,
+	 * mobile hamburger button, custom Select trigger. */
+	.focus-ring:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+		border-radius: 0.375rem;
+	}
 }
 
 /* Spacing utilities */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -531,13 +531,12 @@ a,
 
 	/* Explicit focus marker for elements that opt into focus-ring styling.
 	 * Globally `*:focus-visible` (above) gives every focusable element an
-	 * outline; this class re-asserts that contract for components that
-	 * want to declare their focus intent in the markup, and adds a
-	 * background/transition so the focus state is visible against the
-	 * navbar's blurred backdrop. Used by Navbar logo, Footer links,
-	 * mobile hamburger button, custom Select trigger. */
+	 * outline; this class re-asserts that contract in markup so the focus
+	 * intent is visible at the call site. Uses var(--primary) to match
+	 * the global rule's colour exactly — keeps the focus visual uniform
+	 * across opt-in and default elements. */
 	.focus-ring:focus-visible {
-		outline: 2px solid var(--ring);
+		outline: 2px solid var(--primary);
 		outline-offset: 2px;
 		border-radius: 0.375rem;
 	}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -64,18 +64,17 @@ const Navbar = memo(function Navbar() {
 						</Link>
 					</div>
 
-					{/* Center — Nav links */}
-					<div
-						className="hidden md:flex items-center gap-1"
-						role="menubar"
-						aria-label="Main navigation"
-					>
+					{/* Center — Nav links. The outer <nav> already provides
+					    the navigation landmark; explicit menubar/menuitem ARIA
+					    roles are intentionally omitted because they require
+					    arrow-key traversal which we don't implement. Plain
+					    links inside <nav> is the spec-correct pattern. */}
+					<div className="hidden md:flex items-center gap-1">
 						{navigation.map(item => (
 							<Link
 								key={item.name}
 								href={item.href}
 								className={linkClass(item.href)}
-								role="menuitem"
 								aria-current={pathname === item.href ? 'page' : undefined}
 							>
 								{item.name}
@@ -125,11 +124,7 @@ const Navbar = memo(function Navbar() {
 			{/* Mobile menu */}
 			{mobileMenuOpen && (
 				<div className="md:hidden border-t border-border/40" id="mobile-menu">
-					<div
-						className="px-4 py-3 space-y-1"
-						role="menu"
-						aria-label="Mobile navigation"
-					>
+					<div className="px-4 py-3 space-y-1">
 						{navigation.map(item => (
 							<Link
 								key={item.name}
@@ -141,7 +136,6 @@ const Navbar = memo(function Navbar() {
 										? 'bg-accent/10 text-accent'
 										: 'text-muted-foreground hover:bg-muted hover:text-foreground'
 								)}
-								role="menuitem"
 								aria-current={pathname === item.href ? 'page' : undefined}
 							>
 								{item.name}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -13,13 +13,17 @@ interface NavigationItem {
 	href: string
 }
 
+// Contact is intentionally absent — the "Get Started" CTA button on the
+// right side of the navbar is the dedicated conversion path to /contact.
+// A duplicate plain link plus the active-state amber highlight made the
+// nav feel cluttered when on /contact. Blog added for content discovery.
 const navigation: NavigationItem[] = [
 	{ name: 'Services', href: ROUTES.SERVICES },
 	{ name: 'Pricing', href: ROUTES.PRICING },
 	{ name: 'Showcase', href: ROUTES.SHOWCASE },
 	{ name: 'Tools', href: TOOL_ROUTES.INDEX },
-	{ name: 'About', href: ROUTES.ABOUT },
-	{ name: 'Contact', href: ROUTES.CONTACT }
+	{ name: 'Blog', href: ROUTES.BLOG },
+	{ name: 'About', href: ROUTES.ABOUT }
 ]
 
 const Navbar = memo(function Navbar() {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -45,7 +45,6 @@ const Navbar = memo(function Navbar() {
 	return (
 		<nav
 			className="fixed top-0 left-0 right-0 z-modal bg-background/95 backdrop-blur-xl border-b border-border/40"
-			role="navigation"
 			aria-label="Main navigation"
 		>
 			<div className="container-wide sm:px-6 lg:px-8">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -9,7 +9,7 @@ import * as React from 'react'
 import { cn } from '@/lib/utils'
 
 const selectTriggerVariants = cva(
-	'flex-between h-10 w-full rounded-md border border-input bg-surface-sunken px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+	'flex-between h-10 w-full rounded-md border border-input bg-surface-sunken px-3 py-2 text-sm placeholder:text-muted-foreground focus-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## Summary

Two related navbar issues from production review:

1. **Blog page existed but had no nav entry** — visitors couldn't reach `/blog` from anywhere in the global navigation.
2. **Nav looked cluttered when on /contact** — the active-state amber highlight on the "Contact" item competed visually with the prominent slate-blue "Get Started" CTA on the right (which also routes to /contact). Two contact entry points where one would do.

## Fix

Replace the Contact nav item with Blog. Final order: Services / Pricing / Showcase / Tools / Blog / About — same item count as before. The "Get Started" CTA button remains the dedicated contact path.

## Test plan

- [x] `bun run typecheck` ✓
- [x] `bun run lint` ✓
- [x] `bun run test:unit` ✓ 403 / 0
- [x] `bun run build` ✓
- [ ] Visual verification post-deploy: Blog link present, Contact removed, Get Started button is the only contact CTA in the navbar

[hudsor01]