### PR TITLE
chore: migrate legacy React/Next.js patterns to modern equivalents

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -9,153 +9,187 @@
  * - Rate limiting
  * - CSRF protection
  */
+
+import { type NextRequest, NextResponse } from 'next/server'
 import { env } from '@/env'
 import { validateCsrfForMutation } from '@/lib/csrf'
-import { getClientIp, RATE_LIMIT_CONFIGS, unifiedRateLimiter, type RateLimitType } from '@/lib/rate-limiter'
+import {
+	getUnifiedRateLimiter,
+	RATE_LIMIT_CONFIGS,
+	type RateLimitType
+} from '@/lib/rate-limiter'
+import { getClientIp } from '@/lib/request'
 import { applySecurityHeaders } from '@/lib/security-headers'
-import { NextResponse, type NextRequest } from 'next/server'
 
 // Run on Edge Runtime for minimal overhead
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - public folder
-     */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
-};
+	matcher: [
+		/*
+		 * Match all request paths except for the ones starting with:
+		 * - _next/static (static files)
+		 * - _next/image (image optimization files)
+		 * - favicon.ico (favicon file)
+		 * - public folder
+		 */
+		'/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'
+	]
+}
 
 export async function proxy(request: NextRequest) {
-  const response = NextResponse.next({ request });
-  const url = request.nextUrl;
-  const clientIp = getClientIp(request);
+	const response = NextResponse.next({ request })
+	const url = request.nextUrl
+	const clientIp = getClientIp(request)
 
-  // Note: Neon Auth session management is handled by the SDK automatically
-  // via cookies. The SDK refreshes tokens transparently when needed.
-  // No manual session refresh is required in middleware.
+	// Note: Neon Auth session management is handled by the SDK automatically
+	// via cookies. The SDK refreshes tokens transparently when needed.
+	// No manual session refresh is required in middleware.
 
-  // Generate nonce for CSP
-  const nonce = Math.random().toString(36).substring(2, 18);
+	// Generate nonce for CSP
+	const nonce = Math.random().toString(36).substring(2, 18)
 
-  // Add security headers using centralized configuration with nonce
-  applySecurityHeaders(response, nonce);
+	// Add security headers using centralized configuration with nonce
+	applySecurityHeaders(response, nonce)
 
-  // Store nonce in header for use in components
-  response.headers.set('X-CSP-Nonce', nonce);
+	// Store nonce in header for use in components
+	response.headers.set('X-CSP-Nonce', nonce)
 
-  // Add performance headers
-  response.headers.set('X-Request-Time', Date.now().toString());
+	// Add performance headers
+	response.headers.set('X-Request-Time', Date.now().toString())
 
-  // Force HTTPS in production
-  if (env.NODE_ENV === 'production' &&
-      request.headers.get('x-forwarded-proto') === 'http') {
-    return NextResponse.redirect(
-      `https://${request.headers.get('host')}${request.nextUrl.pathname}${request.nextUrl.search}`,
-      { status: 301 }
-    );
-  }
+	// Force HTTPS in production
+	if (
+		env.NODE_ENV === 'production' &&
+		request.headers.get('x-forwarded-proto') === 'http'
+	) {
+		return NextResponse.redirect(
+			`https://${request.headers.get('host')}${request.nextUrl.pathname}${request.nextUrl.search}`,
+			{ status: 301 }
+		)
+	}
 
-  // Security: Block common attack patterns
-  const userAgent = request.headers.get('user-agent') || '';
-  const suspiciousPatterns = [
-    /sqlmap/i,
-    /nikto/i,
-    /nessus/i,
-    /masscan/i,
-    /zmap/i,
-    /nmap/i,
-    /gobuster/i,
-    /dirb/i
-  ];
+	// Security: Block common attack patterns
+	const userAgent = request.headers.get('user-agent') || ''
+	const suspiciousPatterns = [
+		/sqlmap/i,
+		/nikto/i,
+		/nessus/i,
+		/masscan/i,
+		/zmap/i,
+		/nmap/i,
+		/gobuster/i,
+		/dirb/i
+	]
 
-  if (suspiciousPatterns.some(pattern => pattern.test(userAgent))) {
-    return new NextResponse('Blocked', { status: 403 });
-  }
+	if (suspiciousPatterns.some(pattern => pattern.test(userAgent))) {
+		return new NextResponse('Blocked', { status: 403 })
+	}
 
-  // CSRF Protection
-  if (!await validateCsrfForMutation(request)) {
-    return new NextResponse('Invalid CSRF token', { status: 403 });
-  }
+	// CSRF Protection
+	if (!(await validateCsrfForMutation(request))) {
+		return new NextResponse('Invalid CSRF token', { status: 403 })
+	}
 
-  // Rate limiting for API endpoints
-  const pathname = url.pathname;
-  if (pathname.startsWith('/api/')) {
-    // Determine rate limit type based on endpoint
-    let limitType: RateLimitType = 'api';
+	// Rate limiting for API endpoints
+	const pathname = url.pathname
+	if (pathname.startsWith('/api/')) {
+		// Determine rate limit type based on endpoint
+		let limitType: RateLimitType = 'api'
 
-    if (pathname.startsWith('/api/contact')) {
-      limitType = 'contactFormApi';
-    } else if (pathname.startsWith('/api/newsletter')) {
-      limitType = 'newsletter';
-    } else if (pathname.startsWith('/api/testimonials') || pathname.startsWith('/api/portfolio')) {
-      limitType = 'readOnlyApi';
-    }
+		if (pathname.startsWith('/api/contact')) {
+			limitType = 'contactFormApi'
+		} else if (pathname.startsWith('/api/newsletter')) {
+			limitType = 'newsletter'
+		} else if (
+			pathname.startsWith('/api/testimonials') ||
+			pathname.startsWith('/api/portfolio')
+		) {
+			limitType = 'readOnlyApi'
+		}
 
-    // Create rate limit identifier
-    const identifier = `${limitType}:${clientIp}:${pathname.split('/').slice(0, 3).join('/')}`;
+		// Create rate limit identifier
+		const identifier = `${limitType}:${clientIp}:${pathname.split('/').slice(0, 3).join('/')}`
 
-    // Check rate limit
-    const isAllowed = await unifiedRateLimiter.checkLimit(identifier, limitType);
+		// Check rate limit
+		const isAllowed = await getUnifiedRateLimiter().checkLimit(
+			identifier,
+			limitType
+		)
 
-    if (!isAllowed) {
-      const limitInfo = await unifiedRateLimiter.getLimitInfo(identifier, limitType);
-      return new NextResponse('Too Many Requests', {
-        status: 429,
-        headers: {
-          'Retry-After': '60',
-          'X-RateLimit-Limit': RATE_LIMIT_CONFIGS[limitType].maxRequests.toString(),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': new Date(limitInfo.resetTime).toISOString()
-        }
-      });
-    }
+		if (!isAllowed) {
+			const limitInfo = await getUnifiedRateLimiter().getLimitInfo(
+				identifier,
+				limitType
+			)
+			return new NextResponse('Too Many Requests', {
+				status: 429,
+				headers: {
+					'Retry-After': '60',
+					'X-RateLimit-Limit':
+						RATE_LIMIT_CONFIGS[limitType].maxRequests.toString(),
+					'X-RateLimit-Remaining': '0',
+					'X-RateLimit-Reset': new Date(limitInfo.resetTime).toISOString()
+				}
+			})
+		}
 
-    // Add rate limiting headers for monitoring
-    const limitInfo = await unifiedRateLimiter.getLimitInfo(identifier, limitType);
-    response.headers.set('X-RateLimit-Limit', RATE_LIMIT_CONFIGS[limitType].maxRequests.toString());
-    response.headers.set('X-RateLimit-Remaining', limitInfo.remaining.toString());
-    response.headers.set('X-Client-IP', clientIp);
-  }
+		// Add rate limiting headers for monitoring
+		const limitInfo = await getUnifiedRateLimiter().getLimitInfo(
+			identifier,
+			limitType
+		)
+		response.headers.set(
+			'X-RateLimit-Limit',
+			RATE_LIMIT_CONFIGS[limitType].maxRequests.toString()
+		)
+		response.headers.set(
+			'X-RateLimit-Remaining',
+			limitInfo.remaining.toString()
+		)
+		response.headers.set('X-Client-IP', clientIp)
+	}
 
+	// Remove preload headers since fonts are from Google and CSS paths are dynamic
 
-  // Remove preload headers since fonts are from Google and CSS paths are dynamic
+	// Implement stale-while-revalidate for static pages
+	if (url.pathname.match(/^\/(about|services|pricing|privacy)$/)) {
+		response.headers.set(
+			'Cache-Control',
+			'public, s-maxage=3600, stale-while-revalidate=86400'
+		)
+	}
 
-  // Implement stale-while-revalidate for static pages
-  if (url.pathname.match(/^\/(about|services|pricing|privacy)$/)) {
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=3600, stale-while-revalidate=86400'
-    );
-  }
+	// Blog pages - longer cache with stale-while-revalidate
+	if (url.pathname.startsWith('/blog')) {
+		response.headers.set(
+			'Cache-Control',
+			'public, s-maxage=7200, stale-while-revalidate=604800'
+		)
+	}
 
-  // Blog pages - longer cache with stale-while-revalidate
-  if (url.pathname.startsWith('/blog')) {
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=7200, stale-while-revalidate=604800'
-    );
-  }
+	// API routes - no cache by default
+	if (url.pathname.startsWith('/api')) {
+		response.headers.set('Cache-Control', 'no-store, max-age=0')
 
-  // API routes - no cache by default
-  if (url.pathname.startsWith('/api')) {
-    response.headers.set('Cache-Control', 'no-store, max-age=0');
+		// Add CORS headers for API routes
+		response.headers.set(
+			'Access-Control-Allow-Origin',
+			env.NODE_ENV === 'production' ? 'https://hudsondigitalsolutions.com' : '*'
+		)
+		response.headers.set(
+			'Access-Control-Allow-Methods',
+			'GET, POST, PUT, DELETE, OPTIONS'
+		)
+		response.headers.set(
+			'Access-Control-Allow-Headers',
+			'Content-Type, Authorization, X-CSRF-Token'
+		)
+	}
 
-    // Add CORS headers for API routes
-    response.headers.set('Access-Control-Allow-Origin', env.NODE_ENV === 'production'
-      ? 'https://hudsondigitalsolutions.com'
-      : '*'
-    );
-    response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-CSRF-Token');
-  }
+	// Add timing header for performance monitoring
+	response.headers.set(
+		'Server-Timing',
+		`proxy;dur=${Date.now() - parseInt(response.headers.get('X-Request-Time') || '0', 10)}`
+	)
 
-
-  // Add timing header for performance monitoring
-  response.headers.set('Server-Timing', `proxy;dur=${Date.now() - parseInt(response.headers.get('X-Request-Time') || '0')}`);
-
-  return response;
+	return response
 }

--- a/src/components/calculators/CalculatorResults.tsx
+++ b/src/components/calculators/CalculatorResults.tsx
@@ -6,6 +6,7 @@
 'use client'
 
 import { CheckCircle2 } from 'lucide-react'
+import Link from 'next/link'
 import { useState } from 'react'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -180,7 +181,7 @@ export function CalculatorResults({
 					Let&apos;s discuss how we can help you achieve better results.
 				</p>
 				<Button asChild>
-					<a href="/contact">Schedule Free Consultation</a>
+					<Link href="/contact">Schedule Free Consultation</Link>
 				</Button>
 			</Card>
 		</div>

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -1,12 +1,19 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { FormSuccessMessage } from '@/components/forms/FormSuccessMessage'
 import { FieldGroup } from '@/components/ui/field'
 import formOptions from '@/data/form-options.json'
 import { useAppForm } from '@/hooks/form-hook'
 import { useContactFormSubmit } from '@/hooks/use-contact-form-submit'
 import type { ContactFormData } from '@/lib/schemas/contact'
+
+// Module-level constants — these arrays are deserialized once at import
+// time from the static JSON. No need to wrap in useMemo per render.
+const serviceOptions = formOptions.services
+const budgetOptions = formOptions.budget
+const timelineOptions = formOptions.timeline
+const contactTimeOptions = formOptions.contactTime
 
 export default function ContactForm({
 	className = ''
@@ -15,11 +22,6 @@ export default function ContactForm({
 }) {
 	const mutation = useContactFormSubmit()
 	const [showSuccess, setShowSuccess] = useState(false)
-
-	const serviceOptions = useMemo(() => formOptions.services, [])
-	const budgetOptions = useMemo(() => formOptions.budget, [])
-	const timelineOptions = useMemo(() => formOptions.timeline, [])
-	const contactTimeOptions = useMemo(() => formOptions.contactTime, [])
 
 	const form = useAppForm({
 		defaultValues: {

--- a/src/components/forms/floating-field.tsx
+++ b/src/components/forms/floating-field.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { forwardRef, useState } from 'react'
+import type { ChangeEvent, Ref } from 'react'
+import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -39,7 +40,7 @@ const useFloatingLabelStyles = (
 interface FloatingInputProps {
 	name: string
 	value: string
-	onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+	onChange: (e: ChangeEvent<HTMLInputElement>) => void
 	onBlur?: () => void
 	placeholder: string
 	type?: 'text' | 'email' | 'tel'
@@ -48,74 +49,69 @@ interface FloatingInputProps {
 	disabled?: boolean
 	className?: string
 	id?: string
+	ref?: Ref<HTMLInputElement>
 }
 
-export const FloatingInput = forwardRef<HTMLInputElement, FloatingInputProps>(
-	(
-		{
-			name,
-			value,
-			onChange,
-			onBlur,
-			placeholder,
-			type = 'text',
-			autoComplete,
-			required = false,
-			disabled = false,
-			className = '',
-			id,
-			...props
-		},
-		ref
-	) => {
-		const [isFocused, setIsFocused] = useState(false)
-		const { getLabelClasses, isActive } = useFloatingLabelStyles(
-			value,
-			isFocused,
-			disabled
-		)
+export function FloatingInput({
+	name,
+	value,
+	onChange,
+	onBlur,
+	placeholder,
+	type = 'text',
+	autoComplete,
+	required = false,
+	disabled = false,
+	className = '',
+	id,
+	ref,
+	...props
+}: FloatingInputProps) {
+	const [isFocused, setIsFocused] = useState(false)
+	const { getLabelClasses, isActive } = useFloatingLabelStyles(
+		value,
+		isFocused,
+		disabled
+	)
 
-		const handleFocus = () => setIsFocused(true)
-		const handleBlur = () => {
-			setIsFocused(false)
-			onBlur?.()
-		}
-
-		return (
-			<div className="relative">
-				<Input
-					ref={ref}
-					name={name}
-					value={value}
-					onChange={onChange}
-					onFocus={handleFocus}
-					onBlur={handleBlur}
-					type={type}
-					autoComplete={autoComplete}
-					required={required}
-					disabled={disabled}
-					id={id || name}
-					placeholder=" "
-					className={cn('pt-4 pb-2', isActive && 'border-accent', className)}
-					{...props}
-				/>
-
-				<Label htmlFor={id || name} className={getLabelClasses()}>
-					{placeholder}
-					{required && <span className="text-destructive ml-1">*</span>}
-				</Label>
-			</div>
-		)
+	const handleFocus = () => setIsFocused(true)
+	const handleBlur = () => {
+		setIsFocused(false)
+		onBlur?.()
 	}
-)
 
-FloatingInput.displayName = 'FloatingInput'
+	return (
+		<div className="relative">
+			<Input
+				ref={ref}
+				name={name}
+				value={value}
+				onChange={onChange}
+				onFocus={handleFocus}
+				onBlur={handleBlur}
+				type={type}
+				autoComplete={autoComplete}
+				required={required}
+				disabled={disabled}
+				id={id || name}
+				placeholder=" "
+				className={cn('pt-4 pb-2', isActive && 'border-accent', className)}
+				{...props}
+			/>
+
+			<Label htmlFor={id || name} className={getLabelClasses()}>
+				{placeholder}
+				{required && <span className="text-destructive ml-1">*</span>}
+			</Label>
+		</div>
+	)
+}
 
 // Floating Textarea Component
 interface FloatingTextareaProps {
 	name: string
 	value: string
-	onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
+	onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
 	onBlur?: () => void
 	placeholder: string
 	rows?: number
@@ -123,73 +119,65 @@ interface FloatingTextareaProps {
 	disabled?: boolean
 	className?: string
 	id?: string
+	ref?: Ref<HTMLTextAreaElement>
 }
 
-export const FloatingTextarea = forwardRef<
-	HTMLTextAreaElement,
-	FloatingTextareaProps
->(
-	(
-		{
-			name,
-			value,
-			onChange,
-			onBlur,
-			placeholder,
-			rows = 4,
-			required = false,
-			disabled = false,
-			className = '',
-			id,
-			...props
-		},
-		ref
-	) => {
-		const [isFocused, setIsFocused] = useState(false)
-		const { getLabelClasses, isActive } = useFloatingLabelStyles(
-			value,
-			isFocused,
-			disabled
-		)
+export function FloatingTextarea({
+	name,
+	value,
+	onChange,
+	onBlur,
+	placeholder,
+	rows = 4,
+	required = false,
+	disabled = false,
+	className = '',
+	id,
+	ref,
+	...props
+}: FloatingTextareaProps) {
+	const [isFocused, setIsFocused] = useState(false)
+	const { getLabelClasses, isActive } = useFloatingLabelStyles(
+		value,
+		isFocused,
+		disabled
+	)
 
-		const handleFocus = () => setIsFocused(true)
-		const handleBlur = () => {
-			setIsFocused(false)
-			onBlur?.()
-		}
-
-		return (
-			<div className="relative">
-				<Textarea
-					ref={ref}
-					name={name}
-					value={value}
-					onChange={onChange}
-					onFocus={handleFocus}
-					onBlur={handleBlur}
-					rows={rows}
-					required={required}
-					disabled={disabled}
-					id={id || name}
-					placeholder=" "
-					className={cn(
-						'pt-6 pb-2 resize-none',
-						isActive && 'border-accent',
-						className
-					)}
-					{...props}
-				/>
-
-				<Label htmlFor={id || name} className={getLabelClasses()}>
-					{placeholder}
-					{required && <span className="text-destructive ml-1">*</span>}
-				</Label>
-			</div>
-		)
+	const handleFocus = () => setIsFocused(true)
+	const handleBlur = () => {
+		setIsFocused(false)
+		onBlur?.()
 	}
-)
 
-FloatingTextarea.displayName = 'FloatingTextarea'
+	return (
+		<div className="relative">
+			<Textarea
+				ref={ref}
+				name={name}
+				value={value}
+				onChange={onChange}
+				onFocus={handleFocus}
+				onBlur={handleBlur}
+				rows={rows}
+				required={required}
+				disabled={disabled}
+				id={id || name}
+				placeholder=" "
+				className={cn(
+					'pt-6 pb-2 resize-none',
+					isActive && 'border-accent',
+					className
+				)}
+				{...props}
+			/>
+
+			<Label htmlFor={id || name} className={getLabelClasses()}>
+				{placeholder}
+				{required && <span className="text-destructive ml-1">*</span>}
+			</Label>
+		</div>
+	)
+}
 
 // Default export for backward compatibility
 export default FloatingInput

--- a/src/components/forms/floating-field.tsx
+++ b/src/components/forms/floating-field.tsx
@@ -178,6 +178,3 @@ export function FloatingTextarea({
 		</div>
 	)
 }
-
-// Default export for backward compatibility
-export default FloatingInput

--- a/src/components/glass-card.tsx
+++ b/src/components/glass-card.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority'
-import * as React from 'react'
+import type { HTMLAttributes, Ref } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -27,19 +27,26 @@ const glassCardVariants = cva('transition-smooth', {
 })
 
 export interface GlassCardProps
-	extends React.HTMLAttributes<HTMLDivElement>,
-		VariantProps<typeof glassCardVariants> {}
+	extends HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof glassCardVariants> {
+	ref?: Ref<HTMLDivElement>
+}
 
-const GlassCard = React.forwardRef<HTMLDivElement, GlassCardProps>(
-	({ className, variant, padding, hover, ...props }, ref) => (
+function GlassCard({
+	className,
+	variant,
+	padding,
+	hover,
+	ref,
+	...props
+}: GlassCardProps) {
+	return (
 		<div
 			ref={ref}
 			className={cn(glassCardVariants({ variant, padding, hover }), className)}
 			{...props}
 		/>
 	)
-)
-
-GlassCard.displayName = 'GlassCard'
+}
 
 export { GlassCard, glassCardVariants }

--- a/src/components/paystub/AnnualWageSummary.tsx
+++ b/src/components/paystub/AnnualWageSummary.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { FileText } from 'lucide-react'
-import type React from 'react'
 import { getCurrentTaxData } from '@/lib/paystub-calculator/paystub-utils'
 import { formatCurrency, formatDate } from '@/lib/utils'
 import type { PaystubData } from '@/types/paystub'
@@ -10,9 +9,7 @@ interface AnnualWageSummaryProps {
 	employeeData: PaystubData
 }
 
-export const AnnualWageSummary: React.FC<AnnualWageSummaryProps> = ({
-	employeeData
-}) => {
+export function AnnualWageSummary({ employeeData }: AnnualWageSummaryProps) {
 	const handleSaveAsPDF = () => {
 		if (typeof window !== 'undefined') {
 			window.print()

--- a/src/components/paystub/PayStub.tsx
+++ b/src/components/paystub/PayStub.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type React from 'react'
 import { Card } from '@/components/ui/card'
 import { logger } from '@/lib/logger'
 import { downloadPDF } from '@/lib/pdf/client-pdf'
@@ -26,11 +25,7 @@ interface PayStubProps {
 	}
 }
 
-export const PayStub: React.FC<PayStubProps> = ({
-	payPeriod,
-	employeeData,
-	ytdTotals
-}) => {
+export function PayStub({ payPeriod, employeeData, ytdTotals }: PayStubProps) {
 	const handleSaveAsPDF = async () => {
 		try {
 			const filename = `paystub-${employeeData.employeeName || 'employee'}-${payPeriod.payDate}.pdf`

--- a/src/components/paystub/PayStubDeductions.tsx
+++ b/src/components/paystub/PayStubDeductions.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type React from 'react'
 import { formatCurrency } from '@/lib/utils'
 
 interface PayStubDeductionsProps {
@@ -12,14 +11,14 @@ interface PayStubDeductionsProps {
 	ytdMedicare: number
 }
 
-export const PayStubDeductions: React.FC<PayStubDeductionsProps> = ({
+export function PayStubDeductions({
 	federalTax,
 	socialSecurity,
 	medicare,
 	ytdFederalTax,
 	ytdSocialSecurity,
 	ytdMedicare
-}) => {
+}: PayStubDeductionsProps) {
 	const totalDeductions = federalTax + socialSecurity + medicare
 
 	return (

--- a/src/components/paystub/PayStubEarnings.tsx
+++ b/src/components/paystub/PayStubEarnings.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type React from 'react'
 import { formatCurrency } from '@/lib/utils'
 
 interface PayStubEarningsProps {
@@ -9,11 +8,11 @@ interface PayStubEarningsProps {
 	grossPay: number
 }
 
-export const PayStubEarnings: React.FC<PayStubEarningsProps> = ({
+export function PayStubEarnings({
 	hourlyRate,
 	hours,
 	grossPay
-}) => {
+}: PayStubEarningsProps) {
 	return (
 		<div className="mb-5">
 			<h3 className="m-0 mb-subheading.5 text-sm border-b border-black pb-1.5">

--- a/src/components/paystub/PayStubEmployeeInfo.tsx
+++ b/src/components/paystub/PayStubEmployeeInfo.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import type React from 'react'
-
 interface PayStubEmployeeInfoProps {
 	employeeName: string
 	employeeId?: string
@@ -10,13 +8,13 @@ interface PayStubEmployeeInfoProps {
 	taxYear: number
 }
 
-export const PayStubEmployeeInfo: React.FC<PayStubEmployeeInfoProps> = ({
+export function PayStubEmployeeInfo({
 	employeeName,
 	employeeId,
 	period,
 	totalPeriods,
 	taxYear
-}) => {
+}: PayStubEmployeeInfoProps) {
 	return (
 		<div className="flex-between mb-5">
 			<div>

--- a/src/components/paystub/PayStubHeader.tsx
+++ b/src/components/paystub/PayStubHeader.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type React from 'react'
 import { formatCurrency, formatDate } from '@/lib/utils'
 
 interface PayStubHeaderProps {
@@ -10,12 +9,12 @@ interface PayStubHeaderProps {
 	netPay: number
 }
 
-export const PayStubHeader: React.FC<PayStubHeaderProps> = ({
+export function PayStubHeader({
 	employerName,
 	payDate,
 	checkNumber,
 	netPay
-}) => {
+}: PayStubHeaderProps) {
 	const payDateObj = new Date(payDate)
 	return (
 		<div className="border-b-2 border-black pb-5 mb-5">

--- a/src/components/paystub/PayStubSaveButton.tsx
+++ b/src/components/paystub/PayStubSaveButton.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { FileText } from 'lucide-react'
-import type React from 'react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
@@ -9,9 +8,7 @@ interface PayStubSaveButtonProps {
 	onSave: () => void
 }
 
-export const PayStubSaveButton: React.FC<PayStubSaveButtonProps> = ({
-	onSave
-}) => {
+export function PayStubSaveButton({ onSave }: PayStubSaveButtonProps) {
 	return (
 		<div className="no-print absolute -top-16 right-0 z-modal">
 			<Button

--- a/src/components/paystub/PayStubYearToDate.tsx
+++ b/src/components/paystub/PayStubYearToDate.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type React from 'react'
 import { formatCurrency } from '@/lib/utils'
 
 interface PayStubYearToDateProps {
@@ -11,13 +10,13 @@ interface PayStubYearToDateProps {
 	netPay: number
 }
 
-export const PayStubYearToDate: React.FC<PayStubYearToDateProps> = ({
+export function PayStubYearToDate({
 	grossPay,
 	federalTax,
 	socialSecurity,
 	medicare,
 	netPay
-}) => {
+}: PayStubYearToDateProps) {
 	return (
 		<div className="border-t border-black pt-4">
 			<h3 className="m-0 mb-subheading.5 text-sm">YEAR-TO-DATE TOTALS</h3>

--- a/src/components/paystub/PaystubForm.tsx
+++ b/src/components/paystub/PaystubForm.tsx
@@ -19,12 +19,8 @@ import {
 	getIncomeTaxStates,
 	getNoIncomeTaxStates
 } from '@/lib/paystub-calculator/states-utils'
-import type {
-	FilingStatus,
-	FormErrors,
-	PayFrequency,
-	PaystubData
-} from '@/types/paystub'
+import type { FormErrors } from '@/types/common'
+import type { FilingStatus, PayFrequency, PaystubData } from '@/types/paystub'
 
 interface PaystubFormProps {
 	paystubData: PaystubData

--- a/src/components/pricing-card.tsx
+++ b/src/components/pricing-card.tsx
@@ -1,12 +1,12 @@
 import { X } from 'lucide-react'
 import Link from 'next/link'
-import * as React from 'react'
+import type { HTMLAttributes, Ref } from 'react'
 
 import { GlassCard } from '@/components/glass-card'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
-export interface PricingCardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface PricingCardProps extends HTMLAttributes<HTMLDivElement> {
 	name: string
 	price: string
 	description: string
@@ -16,25 +16,24 @@ export interface PricingCardProps extends React.HTMLAttributes<HTMLDivElement> {
 	cta: string
 	href: string
 	roi?: string
+	ref?: Ref<HTMLDivElement>
 }
 
-const PricingCard = React.forwardRef<HTMLDivElement, PricingCardProps>(
-	(
-		{
-			className,
-			name,
-			price,
-			description,
-			features,
-			notIncluded = [],
-			popular = false,
-			cta,
-			href,
-			roi,
-			...props
-		},
-		ref
-	) => (
+function PricingCard({
+	className,
+	name,
+	price,
+	description,
+	features,
+	notIncluded = [],
+	popular = false,
+	cta,
+	href,
+	roi,
+	ref,
+	...props
+}: PricingCardProps) {
+	return (
 		<div ref={ref} className={cn('relative', className)} {...props}>
 			{popular && (
 				<div className="absolute -top-3 left-1/2 transform -translate-x-1/2 z-10">
@@ -122,8 +121,6 @@ const PricingCard = React.forwardRef<HTMLDivElement, PricingCardProps>(
 			</GlassCard>
 		</div>
 	)
-)
-
-PricingCard.displayName = 'PricingCard'
+}
 
 export { PricingCard }

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -1,12 +1,12 @@
 import { Code2, ExternalLink, Sparkles } from 'lucide-react'
 import Link from 'next/link'
-import * as React from 'react'
+import type { HTMLAttributes, Ref } from 'react'
 
 import { GlassCard } from '@/components/glass-card'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 
-export interface ProjectCardProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ProjectCardProps extends HTMLAttributes<HTMLDivElement> {
 	id?: string
 	slug: string
 	title: string
@@ -15,23 +15,22 @@ export interface ProjectCardProps extends React.HTMLAttributes<HTMLDivElement> {
 	featured?: boolean
 	stats?: Record<string, string>
 	tech_stack: string[]
+	ref?: Ref<HTMLDivElement>
 }
 
-const ProjectCard = React.forwardRef<HTMLDivElement, ProjectCardProps>(
-	(
-		{
-			className,
-			slug,
-			title,
-			description,
-			category,
-			featured = false,
-			stats = {},
-			tech_stack,
-			...props
-		},
-		ref
-	) => (
+function ProjectCard({
+	className,
+	slug,
+	title,
+	description,
+	category,
+	featured = false,
+	stats = {},
+	tech_stack,
+	ref,
+	...props
+}: ProjectCardProps) {
+	return (
 		<div
 			ref={ref}
 			className={cn(
@@ -121,8 +120,6 @@ const ProjectCard = React.forwardRef<HTMLDivElement, ProjectCardProps>(
 			</Link>
 		</div>
 	)
-)
-
-ProjectCard.displayName = 'ProjectCard'
+}
 
 export { ProjectCard }

--- a/src/components/testimonial-card.tsx
+++ b/src/components/testimonial-card.tsx
@@ -1,11 +1,10 @@
 import { MessageCircle, Star } from 'lucide-react'
-import * as React from 'react'
+import type { HTMLAttributes, Ref } from 'react'
 
 import { GlassCard } from '@/components/glass-card'
 import { cn } from '@/lib/utils'
 
-export interface TestimonialCardProps
-	extends React.HTMLAttributes<HTMLDivElement> {
+export interface TestimonialCardProps extends HTMLAttributes<HTMLDivElement> {
 	testimonialId?: number | string
 	name: string
 	company: string
@@ -14,23 +13,22 @@ export interface TestimonialCardProps
 	rating: number
 	service?: string
 	highlight?: string
+	ref?: Ref<HTMLDivElement>
 }
 
-const TestimonialCard = React.forwardRef<HTMLDivElement, TestimonialCardProps>(
-	(
-		{
-			className,
-			name,
-			company,
-			role,
-			content,
-			rating,
-			service,
-			highlight,
-			...props
-		},
-		ref
-	) => (
+function TestimonialCard({
+	className,
+	name,
+	company,
+	role,
+	content,
+	rating,
+	service,
+	highlight,
+	ref,
+	...props
+}: TestimonialCardProps) {
+	return (
 		<GlassCard
 			ref={ref}
 			variant="light"
@@ -80,8 +78,6 @@ const TestimonialCard = React.forwardRef<HTMLDivElement, TestimonialCardProps>(
 			</div>
 		</GlassCard>
 	)
-)
-
-TestimonialCard.displayName = 'TestimonialCard'
+}
 
 export { TestimonialCard }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { cva, type VariantProps } from 'class-variance-authority'
-import * as React from 'react'
+import type { HTMLAttributes } from 'react'
 import { cn } from '@/lib/utils'
 
 const alertVariants = cva(
@@ -20,41 +20,42 @@ const alertVariants = cva(
 	}
 )
 
-const Alert = React.forwardRef<
-	HTMLDivElement,
-	React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-	<div
-		ref={ref}
-		role="alert"
-		className={cn(alertVariants({ variant }), className)}
-		{...props}
-	/>
-))
-Alert.displayName = 'Alert'
+function Alert({
+	className,
+	variant,
+	...props
+}: HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>) {
+	return (
+		<div
+			role="alert"
+			className={cn(alertVariants({ variant }), className)}
+			{...props}
+		/>
+	)
+}
 
-const AlertTitle = React.forwardRef<
-	HTMLParagraphElement,
-	React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-	<h5
-		ref={ref}
-		className={cn('mb-1 font-medium leading-none tracking-tight', className)}
-		{...props}
-	/>
-))
-AlertTitle.displayName = 'AlertTitle'
+function AlertTitle({
+	className,
+	...props
+}: HTMLAttributes<HTMLHeadingElement>) {
+	return (
+		<h5
+			className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+			{...props}
+		/>
+	)
+}
 
-const AlertDescription = React.forwardRef<
-	HTMLParagraphElement,
-	React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-	<div
-		ref={ref}
-		className={cn('text-sm [&_p]:leading-relaxed', className)}
-		{...props}
-	/>
-))
-AlertDescription.displayName = 'AlertDescription'
+function AlertDescription({
+	className,
+	...props
+}: HTMLAttributes<HTMLParagraphElement>) {
+	return (
+		<div
+			className={cn('text-sm [&_p]:leading-relaxed', className)}
+			{...props}
+		/>
+	)
+}
 
 export { Alert, AlertDescription, AlertTitle }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,8 +3,7 @@
 import { cva } from 'class-variance-authority'
 import { ExternalLink, MessageCircle, Star, X } from 'lucide-react'
 import Link from 'next/link'
-import type { ComponentType, SVGProps } from 'react'
-import * as React from 'react'
+import type { ComponentType, HTMLAttributes, Ref, SVGProps } from 'react'
 import { Icon } from '@/components/utilities/Icon'
 import { cn } from '@/lib/utils'
 import { Button } from './button'
@@ -41,10 +40,11 @@ const cardVariants = cva(
 )
 
 // Base Card props
-interface BaseCardProps extends React.HTMLAttributes<HTMLDivElement> {
+interface BaseCardProps extends HTMLAttributes<HTMLDivElement> {
 	variant?: 'default' | 'glass' | 'glassLight' | 'glassSection' | 'outline'
 	size?: 'sm' | 'md' | 'lg' | 'xl' | 'none'
 	hover?: boolean
+	ref?: Ref<HTMLDivElement>
 }
 
 // Service Card props
@@ -108,8 +108,9 @@ export type CardProps =
 	| ProjectCardProps
 	| TestimonialCardProps
 
-const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
-	const { className, variant, size, hover, ...rest } = props as BaseCardProps
+function Card(props: CardProps) {
+	const { className, variant, size, hover, ref, ...rest } =
+		props as BaseCardProps
 
 	// Service Card
 	if ('variant' in props && props.variant === 'service') {
@@ -512,66 +513,44 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 			{...rest}
 		/>
 	)
-})
-Card.displayName = 'Card'
+}
 
-const CardHeader = React.forwardRef<
-	HTMLDivElement,
-	React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-	<div
-		ref={ref}
-		className={cn('flex flex-col space-y-1.5', className)}
-		{...props}
-	/>
-))
-CardHeader.displayName = 'CardHeader'
+function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+	return (
+		<div className={cn('flex flex-col space-y-1.5', className)} {...props} />
+	)
+}
 
-const CardTitle = React.forwardRef<
-	HTMLParagraphElement,
-	React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-	<h3
-		ref={ref}
-		className={cn(
-			'text-2xl font-semibold leading-none tracking-tight',
-			className
-		)}
-		{...props}
-	/>
-))
-CardTitle.displayName = 'CardTitle'
+function CardTitle({
+	className,
+	...props
+}: HTMLAttributes<HTMLHeadingElement>) {
+	return (
+		<h3
+			className={cn(
+				'text-2xl font-semibold leading-none tracking-tight',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
 
-const CardDescription = React.forwardRef<
-	HTMLParagraphElement,
-	React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-	<p
-		ref={ref}
-		className={cn('text-sm text-muted-foreground', className)}
-		{...props}
-	/>
-))
-CardDescription.displayName = 'CardDescription'
+function CardDescription({
+	className,
+	...props
+}: HTMLAttributes<HTMLParagraphElement>) {
+	return (
+		<p className={cn('text-sm text-muted-foreground', className)} {...props} />
+	)
+}
 
-const CardContent = React.forwardRef<
-	HTMLDivElement,
-	React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-	<div ref={ref} className={cn('pt-0', className)} {...props} />
-))
-CardContent.displayName = 'CardContent'
+function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+	return <div className={cn('pt-0', className)} {...props} />
+}
 
-const CardFooter = React.forwardRef<
-	HTMLDivElement,
-	React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-	<div
-		ref={ref}
-		className={cn('flex items-center pt-0', className)}
-		{...props}
-	/>
-))
-CardFooter.displayName = 'CardFooter'
+function CardFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+	return <div className={cn('flex items-center pt-0', className)} {...props} />
+}
 
 export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -2,28 +2,28 @@
 
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
 import { Check } from 'lucide-react'
-import * as React from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { cn } from '@/lib/utils'
 
-const Checkbox = React.forwardRef<
-	React.ElementRef<typeof CheckboxPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-	<CheckboxPrimitive.Root
-		ref={ref}
-		className={cn(
-			'peer h-4 w-4 shrink-0 rounded-none border border-primary shadow focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-foreground',
-			className
-		)}
-		{...props}
-	>
-		<CheckboxPrimitive.Indicator
-			className={cn('flex items-center justify-center text-current')}
+function Checkbox({
+	className,
+	...props
+}: ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>) {
+	return (
+		<CheckboxPrimitive.Root
+			className={cn(
+				'peer h-4 w-4 shrink-0 rounded-none border border-primary shadow focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-foreground',
+				className
+			)}
+			{...props}
 		>
-			<Check className="h-4 w-4" />
-		</CheckboxPrimitive.Indicator>
-	</CheckboxPrimitive.Root>
-))
-Checkbox.displayName = CheckboxPrimitive.Root.displayName
+			<CheckboxPrimitive.Indicator
+				className={cn('flex items-center justify-center text-current')}
+			>
+				<Check className="h-4 w-4" />
+			</CheckboxPrimitive.Indicator>
+		</CheckboxPrimitive.Root>
+	)
+}
 
 export { Checkbox }

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { cva, type VariantProps } from 'class-variance-authority'
-import * as React from 'react'
+import type { InputHTMLAttributes, Ref } from 'react'
 import { cn } from '@/lib/utils'
 
 const inputVariants = cva(
@@ -19,28 +19,27 @@ const inputVariants = cva(
 	}
 )
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
-	VariantProps<typeof inputVariants>
-
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-	({ className, variant, type, ...props }, ref) => {
-		return (
-			<div className="relative">
-				{variant === 'currency' && (
-					<span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-						$
-					</span>
-				)}
-				<input
-					type={type}
-					className={cn(inputVariants({ variant }), className)}
-					ref={ref}
-					{...props}
-				/>
-			</div>
-		)
+export type InputProps = InputHTMLAttributes<HTMLInputElement> &
+	VariantProps<typeof inputVariants> & {
+		ref?: Ref<HTMLInputElement>
 	}
-)
-Input.displayName = 'Input'
+
+function Input({ className, variant, type, ref, ...props }: InputProps) {
+	return (
+		<div className="relative">
+			{variant === 'currency' && (
+				<span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+					$
+				</span>
+			)}
+			<input
+				type={type}
+				className={cn(inputVariants({ variant }), className)}
+				ref={ref}
+				{...props}
+			/>
+		</div>
+	)
+}
 
 export { Input, inputVariants }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,11 +1,9 @@
 'use client'
 
-'use client'
-
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
-import * as React from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { cn } from '@/lib/utils'
 
 const selectTriggerVariants = cva(
@@ -30,131 +28,135 @@ const SelectGroup = SelectPrimitive.Group
 
 const SelectValue = SelectPrimitive.Value
 
-const SelectTrigger = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Trigger>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
-		VariantProps<typeof selectTriggerVariants>
->(({ className, variant, children, ...props }, ref) => (
-	<SelectPrimitive.Trigger
-		ref={ref}
-		className={cn(selectTriggerVariants({ variant }), className)}
-		{...props}
-	>
-		{children}
-		<SelectPrimitive.Icon asChild>
-			<ChevronDown className="h-4 w-4 opacity-50" />
-		</SelectPrimitive.Icon>
-	</SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
-
-const SelectScrollUpButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollUpButton
-		ref={ref}
-		className={cn('flex-center cursor-default py-1', className)}
-		{...props}
-	>
-		<ChevronUp className="h-4 w-4" />
-	</SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
-
-const SelectScrollDownButton = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.ScrollDownButton
-		ref={ref}
-		className={cn('flex-center cursor-default py-1', className)}
-		{...props}
-	>
-		<ChevronDown className="h-4 w-4" />
-	</SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName =
-	SelectPrimitive.ScrollDownButton.displayName
-
-const SelectContent = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Content>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-	<SelectPrimitive.Portal>
-		<SelectPrimitive.Content
-			ref={ref}
-			className={cn(
-				'relative z-modal max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-				position === 'popper' &&
-					'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
-				className
-			)}
-			position={position}
+function SelectTrigger({
+	className,
+	variant,
+	children,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
+	VariantProps<typeof selectTriggerVariants>) {
+	return (
+		<SelectPrimitive.Trigger
+			className={cn(selectTriggerVariants({ variant }), className)}
 			{...props}
 		>
-			<SelectScrollUpButton />
-			<SelectPrimitive.Viewport
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<ChevronDown className="h-4 w-4 opacity-50" />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	)
+}
+
+function SelectScrollUpButton({
+	className,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>) {
+	return (
+		<SelectPrimitive.ScrollUpButton
+			className={cn('flex-center cursor-default py-1', className)}
+			{...props}
+		>
+			<ChevronUp className="h-4 w-4" />
+		</SelectPrimitive.ScrollUpButton>
+	)
+}
+
+function SelectScrollDownButton({
+	className,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>) {
+	return (
+		<SelectPrimitive.ScrollDownButton
+			className={cn('flex-center cursor-default py-1', className)}
+			{...props}
+		>
+			<ChevronDown className="h-4 w-4" />
+		</SelectPrimitive.ScrollDownButton>
+	)
+}
+
+function SelectContent({
+	className,
+	children,
+	position = 'popper',
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.Content>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Content
 				className={cn(
-					'p-1',
+					'relative z-modal max-h-96 min-w-32 overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
 					position === 'popper' &&
-						'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
+						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+					className
 				)}
+				position={position}
+				{...props}
 			>
-				{children}
-			</SelectPrimitive.Viewport>
-			<SelectScrollDownButton />
-		</SelectPrimitive.Content>
-	</SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cn(
+						'p-1',
+						position === 'popper' &&
+							'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	)
+}
 
-const SelectLabel = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Label>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Label
-		ref={ref}
-		className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
-		{...props}
-	/>
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+function SelectLabel({
+	className,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.Label>) {
+	return (
+		<SelectPrimitive.Label
+			className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+			{...props}
+		/>
+	)
+}
 
-const SelectItem = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Item>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-	<SelectPrimitive.Item
-		ref={ref}
-		className={cn(
-			'relative flex w-full cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
-			className
-		)}
-		{...props}
-	>
-		<span className="absolute left-2 flex-center h-3.5 w-3.5">
-			<SelectPrimitive.ItemIndicator>
-				<Check className="h-4 w-4" />
-			</SelectPrimitive.ItemIndicator>
-		</span>
+function SelectItem({
+	className,
+	children,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.Item>) {
+	return (
+		<SelectPrimitive.Item
+			className={cn(
+				'relative flex w-full cursor-default select-none items-center rounded-xs py-1.5 pl-8 pr-2 text-sm outline-hidden focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50',
+				className
+			)}
+			{...props}
+		>
+			<span className="absolute left-2 flex-center h-3.5 w-3.5">
+				<SelectPrimitive.ItemIndicator>
+					<Check className="h-4 w-4" />
+				</SelectPrimitive.ItemIndicator>
+			</span>
 
-		<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-	</SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	)
+}
 
-const SelectSeparator = React.forwardRef<
-	React.ElementRef<typeof SelectPrimitive.Separator>,
-	React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-	<SelectPrimitive.Separator
-		ref={ref}
-		className={cn('-mx-1 my-1 h-px bg-muted', className)}
-		{...props}
-	/>
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+function SelectSeparator({
+	className,
+	...props
+}: ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>) {
+	return (
+		<SelectPrimitive.Separator
+			className={cn('-mx-1 my-1 h-px bg-muted', className)}
+			{...props}
+		/>
+	)
+}
 
 export {
 	Select,

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,21 +1,17 @@
 'use client'
 
-'use client'
-
 import * as SeparatorPrimitive from '@radix-ui/react-separator'
-import * as React from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { cn } from '@/lib/utils'
 
-const Separator = React.forwardRef<
-	React.ElementRef<typeof SeparatorPrimitive.Root>,
-	React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(
-	(
-		{ className, orientation = 'horizontal', decorative = true, ...props },
-		ref
-	) => (
+function Separator({
+	className,
+	orientation = 'horizontal',
+	decorative = true,
+	...props
+}: ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>) {
+	return (
 		<SeparatorPrimitive.Root
-			ref={ref}
 			decorative={decorative}
 			orientation={orientation}
 			className={cn(
@@ -26,7 +22,6 @@ const Separator = React.forwardRef<
 			{...props}
 		/>
 	)
-)
-Separator.displayName = SeparatorPrimitive.Root.displayName
+}
 
 export { Separator }

--- a/src/components/utilities/ErrorBoundary.tsx
+++ b/src/components/utilities/ErrorBoundary.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { TIMEOUTS } from '@/lib/constants/timeouts'
+import { logger } from '@/lib/logger'
 
 // Error handling is now managed by React Query for API calls
 
@@ -47,7 +48,7 @@ function DefaultErrorFallback({
 			setCopied(true)
 			setTimeout(() => setCopied(false), TIMEOUTS.COPY_FEEDBACK)
 		} catch (err) {
-			console.error('[ErrorBoundary] Failed to copy error details', err)
+			logger.error('[ErrorBoundary] Failed to copy error details', err)
 			// Fallback to a textarea method if clipboard API fails
 			const textArea = document.createElement('textarea')
 			textArea.value = errorDetails
@@ -83,12 +84,12 @@ function DefaultErrorFallback({
 			//   body: JSON.stringify(errorReport)
 			// });
 
-			console.warn('[ErrorBoundary] Error report prepared', errorReport)
+			logger.warn('[ErrorBoundary] Error report prepared', errorReport)
 			alert(
 				'Error report has been prepared. Please contact support with the error details.'
 			)
 		} catch (err) {
-			console.error('[ErrorBoundary] Failed to report error', err)
+			logger.error('[ErrorBoundary] Failed to report error', err)
 		}
 	}
 
@@ -194,7 +195,7 @@ export function ErrorBoundary({
 		// Call custom error handler if provided
 		onError?.(error, errorInfo)
 
-		console.error('[ErrorBoundary] Error Boundary Caught', {
+		logger.error('[ErrorBoundary] Error Boundary Caught', {
 			name: errorObj.name,
 			message: errorObj.message,
 			componentStack: errorInfo.componentStack

--- a/src/components/utilities/ErrorBoundary.tsx
+++ b/src/components/utilities/ErrorBoundary.tsx
@@ -218,9 +218,6 @@ export function ErrorBoundary({
 	)
 }
 
-// Export default for backwards compatibility
-export default ErrorBoundary
-
 // Component-specific error boundary with minimal UI
 export function ComponentErrorBoundary({
 	children,

--- a/src/components/utilities/WebVitalsReporting.tsx
+++ b/src/components/utilities/WebVitalsReporting.tsx
@@ -6,6 +6,7 @@
 'use client'
 
 import { useReportWebVitals } from 'next/web-vitals'
+import { logger } from '@/lib/logger'
 
 export function WebVitalsReporting() {
 	useReportWebVitals(metric => {
@@ -14,14 +15,13 @@ export function WebVitalsReporting() {
 
 		// Log performance issues in development
 		if (process.env.NODE_ENV === 'development') {
-			const rating =
-				metric.rating === 'poor'
-					? '[POOR]'
-					: metric.rating === 'needs-improvement'
-						? '[WARN]'
-						: '[GOOD]'
-			console.warn(
-				`${rating} ${metric.name}: ${metric.value} (${metric.rating})`
+			logger.warn(
+				`[WebVitals] ${metric.name}: ${metric.value} (${metric.rating})`,
+				{
+					name: metric.name,
+					value: metric.value,
+					rating: metric.rating
+				}
 			)
 		}
 	})
@@ -59,6 +59,6 @@ async function storeWebVital(metric: WebVitalMetric) {
 		})
 	} catch (error) {
 		// Silently fail - don't disrupt user experience
-		console.error('[WebVitals] Failed to store web vital:', error)
+		logger.error('[WebVitals] Failed to store web vital', error)
 	}
 }

--- a/src/emails/contact-welcome.tsx
+++ b/src/emails/contact-welcome.tsx
@@ -10,7 +10,7 @@ interface ContactWelcomeProps {
 	 * lines (`\n\n`); each paragraph becomes one `<Text>` block. Single
 	 * `\n` within a paragraph stays as a soft line break. Content is plain
 	 * text with sequence variables already substituted by
-	 * processEmailTemplate; React Email auto-escapes children, so no
+	 * replaceTemplateVariables; React Email auto-escapes children, so no
 	 * manual HTML escaping is needed.
 	 */
 	content: string

--- a/src/hooks/form-hook.tsx
+++ b/src/hooks/form-hook.tsx
@@ -130,7 +130,8 @@ function GenericField({
 }
 
 // =============================================================================
-// Field Components (for backward compatibility)
+// Field Components — bound to TanStack Form via createFormHook below.
+// Consumed as form.AppField → field.TextField, field.SelectField, etc.
 // =============================================================================
 
 interface TextFieldProps {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -91,16 +91,3 @@ export function trackError(error: Error | string, fatal = false): void {
 		logger.warn('Failed to track error:', err)
 	}
 }
-
-/**
- * Analytics object for backwards compatibility
- * Provides both direct exports and default object with methods
- */
-const analytics = {
-	trackEvent,
-	identify,
-	trackConversion,
-	trackError
-}
-
-export default analytics

--- a/src/lib/api/rate-limit-wrapper.ts
+++ b/src/lib/api/rate-limit-wrapper.ts
@@ -6,7 +6,8 @@
 import type { NextRequest } from 'next/server'
 import { errorResponse } from '@/lib/api/responses'
 import { createServerLogger } from '@/lib/logger'
-import { getClientIp, unifiedRateLimiter } from '@/lib/rate-limiter'
+import { getUnifiedRateLimiter } from '@/lib/rate-limiter'
+import { getClientIp } from '@/lib/request'
 
 /**
  * Rate limit keys corresponding to different rate limiting tiers
@@ -56,7 +57,10 @@ export function withRateLimit(
 
 	return async (request: NextRequest): Promise<Response> => {
 		const clientIp = getClientIp(request)
-		const isAllowed = await unifiedRateLimiter.checkLimit(clientIp, limitKey)
+		const isAllowed = await getUnifiedRateLimiter().checkLimit(
+			clientIp,
+			limitKey
+		)
 
 		if (!isAllowed) {
 			logger.warn(`Rate limit exceeded for ${limitKey}`, {
@@ -86,7 +90,10 @@ export function withRateLimitParams<T>(
 
 	return async (request: NextRequest, context: T): Promise<Response> => {
 		const clientIp = getClientIp(request)
-		const isAllowed = await unifiedRateLimiter.checkLimit(clientIp, limitKey)
+		const isAllowed = await getUnifiedRateLimiter().checkLimit(
+			clientIp,
+			limitKey
+		)
 
 		if (!isAllowed) {
 			logger.warn(`Rate limit exceeded for ${limitKey}`, {

--- a/src/lib/contact-service.tsx
+++ b/src/lib/contact-service.tsx
@@ -13,7 +13,7 @@ import { ContactAdminNotification } from '@/emails/contact-admin-notification'
 import { ContactWelcome } from '@/emails/contact-welcome'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { LEAD_QUALITY_THRESHOLDS } from '@/lib/constants/lead-scoring'
-import { getEmailSequences, processEmailTemplate } from '@/lib/email-utils'
+import { getEmailSequences, replaceTemplateVariables } from '@/lib/email-utils'
 import type { Logger } from '@/lib/logger'
 import { notifyHighValueLead } from '@/lib/notifications'
 import { getResendClient, isResendConfigured } from '@/lib/resend-client'
@@ -139,11 +139,11 @@ export async function sendWelcomeEmail(
 	}
 
 	try {
-		const processedContent = processEmailTemplate(
+		const processedContent = replaceTemplateVariables(
 			sequence.content,
 			emailVariables
 		)
-		const processedSubject = processEmailTemplate(
+		const processedSubject = replaceTemplateVariables(
 			sequence.subject,
 			emailVariables
 		)

--- a/src/lib/email-utils.ts
+++ b/src/lib/email-utils.ts
@@ -42,7 +42,11 @@ export function generateEmail(
 }
 
 /**
- * Get all email sequences (legacy compatibility)
+ * Get all email sequences keyed by both legacy sequence names
+ * (`standard-welcome`, `high-value-consultation`, etc.) and the
+ * canonical template names. Both contact-service and scheduled-emails
+ * look up sequences by these aliases when picking which template to
+ * send for a given lead.
  */
 export function getEmailSequences() {
 	return {
@@ -52,14 +56,4 @@ export function getEmailSequences() {
 		'enterprise-nurture': emailTemplates['follow-up'],
 		...emailTemplates
 	}
-}
-
-/**
- * Process email template (legacy compatibility)
- */
-export function processEmailTemplate(
-	template: string,
-	data: EmailData
-): string {
-	return replaceTemplateVariables(template, data)
 }

--- a/src/lib/email-utils.ts
+++ b/src/lib/email-utils.ts
@@ -1,5 +1,3 @@
-// Native email utilities - logic only, no template bloat
-
 import emailTemplates from '@/data/email-templates.json'
 
 interface EmailData {

--- a/src/lib/pdf/paystub-template.tsx
+++ b/src/lib/pdf/paystub-template.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer'
-import type React from 'react'
 import type { PayPeriod, PaystubData } from '@/types/paystub'
 
 const styles = StyleSheet.create({
@@ -86,166 +85,168 @@ interface PaystubPDFProps {
 	}
 }
 
-export const PaystubPDF: React.FC<PaystubPDFProps> = ({
+export function PaystubPDF({
 	payPeriod,
 	employeeData,
 	ytdTotals
-}) => (
-	<Document>
-		<Page size="LETTER" style={styles.page}>
-			{/* Header */}
-			<View style={styles.header}>
-				<Text style={styles.employerName}>{employeeData.employerName}</Text>
-				<View style={styles.payInfo}>
-					<Text>Pay Date: {payPeriod.payDate}</Text>
-					<Text>Check #: {payPeriod.period.toString().padStart(4, '0')}</Text>
-					<Text>Net Pay: ${payPeriod.netPay.toFixed(2)}</Text>
+}: PaystubPDFProps) {
+	return (
+		<Document>
+			<Page size="LETTER" style={styles.page}>
+				{/* Header */}
+				<View style={styles.header}>
+					<Text style={styles.employerName}>{employeeData.employerName}</Text>
+					<View style={styles.payInfo}>
+						<Text>Pay Date: {payPeriod.payDate}</Text>
+						<Text>Check #: {payPeriod.period.toString().padStart(4, '0')}</Text>
+						<Text>Net Pay: ${payPeriod.netPay.toFixed(2)}</Text>
+					</View>
 				</View>
-			</View>
 
-			{/* Employee Info */}
-			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Employee Information</Text>
-				<View style={styles.row}>
-					<Text style={styles.label}>Name:</Text>
-					<Text style={styles.value}>{employeeData.employeeName}</Text>
+				{/* Employee Info */}
+				<View style={styles.section}>
+					<Text style={styles.sectionTitle}>Employee Information</Text>
+					<View style={styles.row}>
+						<Text style={styles.label}>Name:</Text>
+						<Text style={styles.value}>{employeeData.employeeName}</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Employee ID:</Text>
+						<Text style={styles.value}>{employeeData.employeeId}</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Period:</Text>
+						<Text style={styles.value}>{payPeriod.period} of 26</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Tax Year:</Text>
+						<Text style={styles.value}>{employeeData.taxYear}</Text>
+					</View>
 				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Employee ID:</Text>
-					<Text style={styles.value}>{employeeData.employeeId}</Text>
-				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Period:</Text>
-					<Text style={styles.value}>{payPeriod.period} of 26</Text>
-				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Tax Year:</Text>
-					<Text style={styles.value}>{employeeData.taxYear}</Text>
-				</View>
-			</View>
 
-			{/* Earnings */}
-			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Earnings</Text>
-				<View style={styles.table}>
-					<View style={[styles.tableRow, styles.tableHeader]}>
-						<Text style={styles.tableCell}>Description</Text>
-						<Text style={styles.tableCell}>Hours</Text>
-						<Text style={styles.tableCell}>Rate</Text>
-						<Text style={styles.tableCell}>Amount</Text>
-					</View>
-					<View style={styles.tableRow}>
-						<Text style={styles.tableCell}>Regular Pay</Text>
-						<Text style={styles.tableCell}>{payPeriod.hours.toFixed(2)}</Text>
-						<Text style={styles.tableCell}>
-							${(payPeriod.grossPay / payPeriod.hours).toFixed(2)}
-						</Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.grossPay.toFixed(2)}
-						</Text>
-					</View>
-					<View style={[styles.tableRow, styles.total]}>
-						<Text style={styles.tableCell}>Gross Pay</Text>
-						<Text style={styles.tableCell}></Text>
-						<Text style={styles.tableCell}></Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.grossPay.toFixed(2)}
-						</Text>
-					</View>
-				</View>
-			</View>
-
-			{/* Deductions */}
-			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Deductions</Text>
-				<View style={styles.table}>
-					<View style={[styles.tableRow, styles.tableHeader]}>
-						<Text style={styles.tableCell}>Description</Text>
-						<Text style={styles.tableCell}>Amount</Text>
-					</View>
-					<View style={styles.tableRow}>
-						<Text style={styles.tableCell}>Federal Tax</Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.federalTax.toFixed(2)}
-						</Text>
-					</View>
-					<View style={styles.tableRow}>
-						<Text style={styles.tableCell}>Social Security</Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.socialSecurity.toFixed(2)}
-						</Text>
-					</View>
-					<View style={styles.tableRow}>
-						<Text style={styles.tableCell}>Medicare</Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.medicare.toFixed(2)}
-						</Text>
-					</View>
-					<View style={styles.tableRow}>
-						<Text style={styles.tableCell}>State Tax</Text>
-						<Text style={styles.tableCell}>
-							${payPeriod.stateTax.toFixed(2)}
-						</Text>
-					</View>
-					{payPeriod.otherDeductions > 0 && (
+				{/* Earnings */}
+				<View style={styles.section}>
+					<Text style={styles.sectionTitle}>Earnings</Text>
+					<View style={styles.table}>
+						<View style={[styles.tableRow, styles.tableHeader]}>
+							<Text style={styles.tableCell}>Description</Text>
+							<Text style={styles.tableCell}>Hours</Text>
+							<Text style={styles.tableCell}>Rate</Text>
+							<Text style={styles.tableCell}>Amount</Text>
+						</View>
 						<View style={styles.tableRow}>
-							<Text style={styles.tableCell}>Other Deductions</Text>
+							<Text style={styles.tableCell}>Regular Pay</Text>
+							<Text style={styles.tableCell}>{payPeriod.hours.toFixed(2)}</Text>
 							<Text style={styles.tableCell}>
-								${payPeriod.otherDeductions.toFixed(2)}
+								${(payPeriod.grossPay / payPeriod.hours).toFixed(2)}
+							</Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.grossPay.toFixed(2)}
 							</Text>
 						</View>
-					)}
-					<View style={[styles.tableRow, styles.total]}>
-						<Text style={styles.tableCell}>Total Deductions</Text>
-						<Text style={styles.tableCell}>
-							$
-							{(
-								payPeriod.federalTax +
-								payPeriod.socialSecurity +
-								payPeriod.medicare +
-								payPeriod.stateTax +
-								payPeriod.otherDeductions
-							).toFixed(2)}
-						</Text>
+						<View style={[styles.tableRow, styles.total]}>
+							<Text style={styles.tableCell}>Gross Pay</Text>
+							<Text style={styles.tableCell}></Text>
+							<Text style={styles.tableCell}></Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.grossPay.toFixed(2)}
+							</Text>
+						</View>
 					</View>
 				</View>
-			</View>
 
-			{/* Net Pay */}
-			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Net Pay</Text>
-				<View style={styles.row}>
-					<Text style={styles.label}>Net Pay:</Text>
-					<Text style={styles.value}>${payPeriod.netPay.toFixed(2)}</Text>
+				{/* Deductions */}
+				<View style={styles.section}>
+					<Text style={styles.sectionTitle}>Deductions</Text>
+					<View style={styles.table}>
+						<View style={[styles.tableRow, styles.tableHeader]}>
+							<Text style={styles.tableCell}>Description</Text>
+							<Text style={styles.tableCell}>Amount</Text>
+						</View>
+						<View style={styles.tableRow}>
+							<Text style={styles.tableCell}>Federal Tax</Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.federalTax.toFixed(2)}
+							</Text>
+						</View>
+						<View style={styles.tableRow}>
+							<Text style={styles.tableCell}>Social Security</Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.socialSecurity.toFixed(2)}
+							</Text>
+						</View>
+						<View style={styles.tableRow}>
+							<Text style={styles.tableCell}>Medicare</Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.medicare.toFixed(2)}
+							</Text>
+						</View>
+						<View style={styles.tableRow}>
+							<Text style={styles.tableCell}>State Tax</Text>
+							<Text style={styles.tableCell}>
+								${payPeriod.stateTax.toFixed(2)}
+							</Text>
+						</View>
+						{payPeriod.otherDeductions > 0 && (
+							<View style={styles.tableRow}>
+								<Text style={styles.tableCell}>Other Deductions</Text>
+								<Text style={styles.tableCell}>
+									${payPeriod.otherDeductions.toFixed(2)}
+								</Text>
+							</View>
+						)}
+						<View style={[styles.tableRow, styles.total]}>
+							<Text style={styles.tableCell}>Total Deductions</Text>
+							<Text style={styles.tableCell}>
+								$
+								{(
+									payPeriod.federalTax +
+									payPeriod.socialSecurity +
+									payPeriod.medicare +
+									payPeriod.stateTax +
+									payPeriod.otherDeductions
+								).toFixed(2)}
+							</Text>
+						</View>
+					</View>
 				</View>
-			</View>
 
-			{/* YTD Totals */}
-			<View style={styles.section}>
-				<Text style={styles.sectionTitle}>Year to Date Totals</Text>
-				<View style={styles.row}>
-					<Text style={styles.label}>Gross Pay:</Text>
-					<Text style={styles.value}>${ytdTotals.grossPay.toFixed(2)}</Text>
+				{/* Net Pay */}
+				<View style={styles.section}>
+					<Text style={styles.sectionTitle}>Net Pay</Text>
+					<View style={styles.row}>
+						<Text style={styles.label}>Net Pay:</Text>
+						<Text style={styles.value}>${payPeriod.netPay.toFixed(2)}</Text>
+					</View>
 				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Federal Tax:</Text>
-					<Text style={styles.value}>${ytdTotals.federalTax.toFixed(2)}</Text>
+
+				{/* YTD Totals */}
+				<View style={styles.section}>
+					<Text style={styles.sectionTitle}>Year to Date Totals</Text>
+					<View style={styles.row}>
+						<Text style={styles.label}>Gross Pay:</Text>
+						<Text style={styles.value}>${ytdTotals.grossPay.toFixed(2)}</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Federal Tax:</Text>
+						<Text style={styles.value}>${ytdTotals.federalTax.toFixed(2)}</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Social Security:</Text>
+						<Text style={styles.value}>
+							${ytdTotals.socialSecurity.toFixed(2)}
+						</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Medicare:</Text>
+						<Text style={styles.value}>${ytdTotals.medicare.toFixed(2)}</Text>
+					</View>
+					<View style={styles.row}>
+						<Text style={styles.label}>Net Pay:</Text>
+						<Text style={styles.value}>${ytdTotals.netPay.toFixed(2)}</Text>
+					</View>
 				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Social Security:</Text>
-					<Text style={styles.value}>
-						${ytdTotals.socialSecurity.toFixed(2)}
-					</Text>
-				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Medicare:</Text>
-					<Text style={styles.value}>${ytdTotals.medicare.toFixed(2)}</Text>
-				</View>
-				<View style={styles.row}>
-					<Text style={styles.label}>Net Pay:</Text>
-					<Text style={styles.value}>${ytdTotals.netPay.toFixed(2)}</Text>
-				</View>
-			</View>
-		</Page>
-	</Document>
-)
+			</Page>
+		</Document>
+	)
+}

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -211,15 +211,3 @@ export function getUnifiedRateLimiter(): UnifiedRateLimiter {
 	}
 	return _unifiedRateLimiter
 }
-
-// Legacy export for backwards compatibility (lazy initialized)
-export const unifiedRateLimiter = {
-	checkLimit: (identifier: string, limitType?: RateLimitType) =>
-		getUnifiedRateLimiter().checkLimit(identifier, limitType),
-	getLimitInfo: (identifier: string, limitType?: RateLimitType) =>
-		getUnifiedRateLimiter().getLimitInfo(identifier, limitType),
-	destroy: () => getUnifiedRateLimiter().destroy()
-}
-
-// Re-export getClientIp from centralized location for backwards compatibility
-export { getClientIp } from './request'

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -1,3 +1,4 @@
+import { env } from '@/env'
 import type { RateLimitEntry } from '@/types/api'
 import { logger } from './logger'
 
@@ -67,9 +68,7 @@ export class UnifiedRateLimiter {
 
 	constructor() {
 		// Use KV when env vars are present (production/preview), fall back to in-memory
-		this.useKv = !!(
-			process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN
-		)
+		this.useKv = !!(env.KV_REST_API_URL && env.KV_REST_API_TOKEN)
 		if (!this.useKv) {
 			this.initializeInMemory()
 		} else {

--- a/src/lib/scheduled-emails.tsx
+++ b/src/lib/scheduled-emails.tsx
@@ -20,7 +20,7 @@ import { type ScheduledEmail, scheduledEmails } from '@/lib/schemas/emails'
 import { resendEmailResponseSchema } from '@/lib/schemas/external'
 import type { EmailProcessResult, EmailQueueStats } from '@/types/utils'
 import { BUSINESS_INFO } from './constants/business'
-import { getEmailSequences, processEmailTemplate } from './email-utils'
+import { getEmailSequences, replaceTemplateVariables } from './email-utils'
 import { sanitizeEmailHeader } from './utils'
 
 // Create logger instance for email operations
@@ -242,8 +242,8 @@ async function sendScheduledEmail(
 
 	// Process template variables
 	const variables = (scheduledEmail.variables as Record<string, string>) || {}
-	const processedSubject = processEmailTemplate(sequence.subject, variables)
-	const processedContent = processEmailTemplate(sequence.content, variables)
+	const processedSubject = replaceTemplateVariables(sequence.subject, variables)
+	const processedContent = replaceTemplateVariables(sequence.content, variables)
 
 	try {
 		const emailResponse = await getResendClient().emails.send({
@@ -424,23 +424,5 @@ export async function processEmailsEndpoint(): Promise<EmailProcessResult> {
 			processed: 0,
 			errors: 1
 		}
-	}
-}
-
-// Export queue stats for backwards compatibility
-export async function getScheduledEmailsQueue() {
-	try {
-		const data = await db
-			.select()
-			.from(scheduledEmails)
-			.where(eq(scheduledEmails.status, 'pending'))
-			.orderBy(asc(scheduledEmails.scheduledFor))
-
-		return data
-	} catch (error) {
-		emailLogger.error('Exception fetching scheduled emails queue', {
-			error: error instanceof Error ? error.message : String(error)
-		})
-		return []
 	}
 }

--- a/src/types/paystub.ts
+++ b/src/types/paystub.ts
@@ -17,9 +17,6 @@ export interface PaystubValidationResult {
 	message?: string
 }
 
-// Re-export from common.ts to maintain backwards compatibility
-export type { FormErrors } from './common'
-
 // Paystub core types
 export type FilingStatus =
 	| 'single'

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -1,6 +1,6 @@
 // Performance optimization utilities
 
-import analytics from '@/lib/analytics'
+import { trackEvent } from '@/lib/analytics'
 import { logger } from '@/lib/logger'
 import type { CLSEntry } from '@/types/performance'
 
@@ -104,8 +104,8 @@ export function trackWebVitals() {
 			})
 
 			// Send to analytics for performance tracking
-			if (typeof window !== 'undefined' && analytics) {
-				analytics.trackEvent('web_vitals_cls', {
+			if (typeof window !== 'undefined') {
+				trackEvent('web_vitals_cls', {
 					cls_value: _clsValue,
 					performance_rating:
 						_clsValue > 0.1

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -265,10 +265,11 @@ export function setupContactFormMocks() {
 	// Complete rate-limiter mock with all exports
 	mock.module('@/lib/rate-limiter', () => ({
 		UnifiedRateLimiter: createMockUnifiedRateLimiterClass(),
-		unifiedRateLimiter: mockRateLimiter,
 		getUnifiedRateLimiter: () => mockRateLimiter,
-		getClientIp: createMockGetClientIp(),
 		RATE_LIMIT_CONFIGS: MOCK_RATE_LIMIT_CONFIGS
+	}))
+	mock.module('@/lib/request', () => ({
+		getClientIp: createMockGetClientIp()
 	}))
 
 	mock.module('@/lib/metrics', () => ({

--- a/tests/unit/api-routes.test.ts
+++ b/tests/unit/api-routes.test.ts
@@ -205,12 +205,11 @@ describe('Newsletter Subscribe API', () => {
 
 describe('API Route Security', () => {
 	it('should apply rate limiting to all critical endpoints', async () => {
-		const { unifiedRateLimiter, getClientIp } = await import(
-			'@/lib/rate-limiter'
-		)
+		const { getUnifiedRateLimiter } = await import('@/lib/rate-limiter')
+		const { getClientIp } = await import('@/lib/request')
 
 		// Verify rate limiter is being called
-		expect(unifiedRateLimiter.checkLimit).toBeDefined()
+		expect(getUnifiedRateLimiter().checkLimit).toBeDefined()
 		expect(getClientIp).toBeDefined()
 	})
 

--- a/tests/unit/layout.test.tsx
+++ b/tests/unit/layout.test.tsx
@@ -19,7 +19,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should render children when there is no error', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 
@@ -33,7 +33,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should catch and display errors', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 
@@ -57,7 +57,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should have a reset mechanism', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 
@@ -86,7 +86,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should log errors to console or analytics', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 		// Note: Bun doesn't have built-in spy support, just verify error UI renders
@@ -116,7 +116,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should handle copy error details functionality', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 
@@ -140,7 +140,7 @@ describe('ErrorBoundary Component', () => {
 	})
 
 	it('should handle report error functionality', async () => {
-		const { default: ErrorBoundary } = await import(
+		const { ErrorBoundary } = await import(
 			'@/components/utilities/ErrorBoundary'
 		)
 

--- a/tests/unit/rate-limiter.test.ts
+++ b/tests/unit/rate-limiter.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'bun:test'
 import type { NextRequest } from 'next/server'
 import {
-	getClientIp,
 	RATE_LIMIT_CONFIGS,
 	type RateLimitType,
 	UnifiedRateLimiter
 } from '@/lib/rate-limiter'
+import { getClientIp } from '@/lib/request'
 
 describe('UnifiedRateLimiter', () => {
 	let limiter: UnifiedRateLimiter

--- a/tests/unit/security.test.ts
+++ b/tests/unit/security.test.ts
@@ -12,6 +12,7 @@ import type { NextRequest } from 'next/server'
 // Import types for use in tests (type-only imports don't load modules)
 import type * as CsrfTypes from '@/lib/csrf'
 import type * as RateLimiterTypes from '@/lib/rate-limiter'
+import type * as RequestTypes from '@/lib/request'
 
 // ================================
 // CSRF Token Tests
@@ -178,10 +179,12 @@ describe('CSRF Token Utilities', () => {
 
 describe('Rate Limiter', () => {
 	let rateLimiterModule: typeof RateLimiterTypes
+	let requestModule: typeof RequestTypes
 
 	beforeEach(async () => {
 		// Dynamic import to get the module (mocked or real depending on execution order)
 		rateLimiterModule = await import('@/lib/rate-limiter')
+		requestModule = await import('@/lib/request')
 	})
 
 	afterEach(() => {
@@ -280,7 +283,7 @@ describe('Rate Limiter', () => {
 				}
 			} as unknown as NextRequest
 
-			const ip = rateLimiterModule.getClientIp(mockRequest)
+			const ip = requestModule.getClientIp(mockRequest)
 			expect(ip).toBe('192.168.1.1')
 		})
 
@@ -296,7 +299,7 @@ describe('Rate Limiter', () => {
 				}
 			} as unknown as NextRequest
 
-			const ip = rateLimiterModule.getClientIp(mockRequest)
+			const ip = requestModule.getClientIp(mockRequest)
 			expect(ip).toBe('192.168.1.2')
 		})
 
@@ -307,7 +310,7 @@ describe('Rate Limiter', () => {
 				}
 			} as unknown as NextRequest
 
-			const ip = rateLimiterModule.getClientIp(mockRequest)
+			const ip = requestModule.getClientIp(mockRequest)
 			expect(ip).toBe('127.0.0.1')
 		})
 
@@ -323,7 +326,7 @@ describe('Rate Limiter', () => {
 				}
 			} as unknown as NextRequest
 
-			const ip = rateLimiterModule.getClientIp(mockRequest)
+			const ip = requestModule.getClientIp(mockRequest)
 			expect(ip).toBe('127.0.0.1')
 		})
 	})


### PR DESCRIPTION
     [1mSTDIN[0m
[38;5;8m   1[0m [37m## Summary[0m
[38;5;8m   2[0m 
[38;5;8m   3[0m [37mComprehensive sweep migrating remaining legacy React/Next.js patterns across `src/` to React 19 + Next.js 16 idioms. No behavior change — every callsite remained type-compatible and 442/442 tests still pass.[0m
[38;5;8m   4[0m 
[38;5;8m   5[0m [37m## Migrations applied[0m
[38;5;8m   6[0m 
[38;5;8m   7[0m [37m| Pattern | Count | Outcome |[0m
[38;5;8m   8[0m [37m|---------|-------|---------|[0m
[38;5;8m   9[0m [37m| `forwardRef` → ref-as-prop | 26 instances / 12 files | React 19 ref-as-prop API |[0m
[38;5;8m  10[0m [37m| `import * as React` → named imports | 10 files | Modern type-only imports |[0m
[38;5;8m  11[0m [37m| `React.FC<P>` → `function C(props: P)` | 9 files (paystub + PDF) | Plain function components |[0m
[38;5;8m  12[0m [37m| `useMemo` over static JSON | 4 in ContactForm | Hoisted to module-level |[0m
[38;5;8m  13[0m [37m| `console.*` → `logger` | 5 (WebVitals + ErrorBoundary) | Per CLAUDE.md convention |[0m
[38;5;8m  14[0m [37m| `process.env.X` → `env.X` | 1 (rate-limiter KV) | Typed env barrel |[0m
[38;5;8m  15[0m [37m| `<a href="/...">` → `<Link>` | 1 (CalculatorResults CTA) | Client-side routing |[0m
[38;5;8m  16[0m 
[38;5;8m  17[0m [37m## Intentionally NOT touched (audited)[0m
[38;5;8m  18[0m 
[38;5;8m  19[0m [37m- `useMemo`/`useCallback` elsewhere (45 sites) — React Compiler not enabled, so they remain meaningful[0m
[38;5;8m  20[0m [37m- `next/dynamic { ssr: false }` (3 in PDF tool generators) — required for client-only @react-pdf/renderer[0m
[38;5;8m  21[0m [37m- `document.createElement` (13 sites) — actual browser DOM API, not React[0m
[38;5;8m  22[0m [37m- `error.tsx` / `global-error.tsx` `console.*` — server-rendered boundaries; logger isn't reachable[0m
[38;5;8m  23[0m [37m- `useEffect` for data fetching (testimonial-collector) — admin-token-gated flow needs client orchestration[0m
[38;5;8m  24[0m 
[38;5;8m  25[0m [37m## Test plan[0m
[38;5;8m  26[0m 
[38;5;8m  27[0m [37m- [x] `bun run typecheck` — clean[0m
[38;5;8m  28[0m [37m- [x] `bun run lint` — clean[0m
[38;5;8m  29[0m [37m- [x] `bun test tests/` — 442/442 pass[0m
[38;5;8m  30[0m [37m- [x] `bun run build` — compiled successfully[0m
[38;5;8m  31[0m [37m- [ ] Vercel preview — verify all UI surfaces render (forms, paystub, calculator, blog, navbar)[0m
[38;5;8m  32[0m [37m- [ ] PDF generation still works on calculator-results, paystub, contract/invoice/proposal generators[0m
[38;5;8m  33[0m 
[38;5;8m  34[0m [37m[hudsor01][0m