### PR TITLE
feat: closing-CTA polish + harden exit-intent modal

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -705,21 +705,28 @@ button,
 /* Dialog */
 @layer components {
 	.dialog-overlay {
-		background-color: var(--bg-overlay);
+		background-color: var(--color-bg-overlay);
 		position: fixed;
 		inset: 0;
+		z-index: 50;
 	}
 	.dialog-content {
-		background-color: var(--popover);
-		border: 1px solid var(--border);
-		border-radius: 0.5rem;
+		background-color: var(--color-surface-elevated);
+		color: var(--color-foreground);
+		border: 1px solid var(--color-border);
+		border-radius: 0.75rem;
+		box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
 		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 		position: fixed;
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%);
 		width: 90vw;
-		max-width: 48rem;
+		max-width: 28rem;
+		z-index: 51;
 	}
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,7 +7,6 @@ import Footer from '@/components/layout/Footer'
 import NavbarLight from '@/components/layout/Navbar'
 import { Analytics } from '@/components/utilities/Analytics'
 import { ErrorBoundary } from '@/components/utilities/ErrorBoundary'
-import { ExitIntentModal } from '@/components/utilities/ExitIntentModal'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import ScrollToTop from '@/components/utilities/ScrollToTop'
 import { WebVitalsReporting } from '@/components/utilities/WebVitalsReporting'
@@ -185,7 +184,6 @@ export default function RootLayout({
 							</main>
 							<Footer />
 							<ScrollToTop />
-							<ExitIntentModal />
 							<Analytics />
 							<SpeedInsights />
 							<WebVitalsReporting />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import {
 	ArrowRight,
 	Calculator,
 	Check,
+	Clock,
 	Code2,
 	Settings,
 	TrendingUp,
@@ -11,6 +12,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { NewsletterSignup } from '@/components/forms/NewsletterSignup'
 import { Button } from '@/components/ui/button'
+import { ExitIntentModal } from '@/components/utilities/ExitIntentModal'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import { ROUTES, TOOL_ROUTES } from '@/lib/constants/routes'
 import { SEO_CONFIG } from '@/lib/seo-config'
@@ -350,42 +352,87 @@ export default function HomePage() {
 			</section>
 
 			{/* ── CLOSING CTA ────────────────────────────────────── */}
-			<section className="py-section px-4 sm:px-6 bg-surface-raised">
-				<div className="container-wide text-center">
-					<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-						Let&apos;s talk
-					</p>
-					<h2 className="text-section-title text-foreground mb-comfortable max-w-3xl mx-auto text-balance">
-						Ready to stop running your business manually?
-					</h2>
-
-					<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-						Every week without automation is another week of manual follow-ups,
-						missed leads, and time you won&apos;t get back.
-					</p>
-
-					<div className="flex flex-col sm:flex-row gap-3 justify-center mt-8">
-						<Button asChild variant="accent" size="xl" trackConversion={true}>
-							<Link href={ROUTES.CONTACT}>
-								Book a Free Strategy Call
-								<ArrowRight className="w-4 h-4" />
-							</Link>
-						</Button>
-						<Button
-							asChild
-							variant="outline"
-							size="xl"
-							className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
-						>
-							<Link href={ROUTES.SHOWCASE}>View Showcase</Link>
-						</Button>
+			<section className="relative py-section px-4 sm:px-6 bg-surface-raised overflow-hidden">
+				{/* Soft radial accent for depth — pure CSS, no extra DOM weight */}
+				<div
+					aria-hidden="true"
+					className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-[radial-gradient(ellipse_at_top,_color-mix(in_oklch,_var(--color-accent)_12%,_transparent),_transparent_70%)]"
+				/>
+				<div className="relative max-w-3xl mx-auto">
+					<div className="text-center">
+						<div className="inline-flex items-center gap-3 mb-4">
+							<span aria-hidden="true" className="h-px w-8 bg-accent/40" />
+							<p className="text-xs font-semibold uppercase tracking-widest text-accent">
+								Let&apos;s talk
+							</p>
+							<span aria-hidden="true" className="h-px w-8 bg-accent/40" />
+						</div>
+						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
+							Ready to stop running your business manually?
+						</h2>
+						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
+							Every week without automation is another week of manual
+							follow-ups, missed leads, and time you won&apos;t get back.
+						</p>
 					</div>
 
-					<div className="mt-12">
+					{/* Primary CTA card — visually contains the action + trust signals */}
+					<div className="mt-10 rounded-2xl border border-border bg-background p-6 sm:p-8 shadow-sm">
+						<div className="flex flex-col sm:flex-row gap-3 justify-center">
+							<Button asChild variant="accent" size="xl" trackConversion={true}>
+								<Link href={ROUTES.CONTACT}>
+									Book a Free Strategy Call
+									<ArrowRight className="w-4 h-4" />
+								</Link>
+							</Button>
+							<Button
+								asChild
+								variant="outline"
+								size="xl"
+								className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
+							>
+								<Link href={ROUTES.SHOWCASE}>View Showcase</Link>
+							</Button>
+						</div>
+
+						<ul
+							className="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground"
+							role="list"
+						>
+							<li className="flex items-center gap-1.5">
+								<Clock className="w-4 h-4 text-accent" aria-hidden="true" />
+								<span>30-minute call</span>
+							</li>
+							<li className="flex items-center gap-1.5">
+								<Check className="w-4 h-4 text-accent" aria-hidden="true" />
+								<span>No commitment</span>
+							</li>
+							<li className="flex items-center gap-1.5">
+								<Zap className="w-4 h-4 text-accent" aria-hidden="true" />
+								<span>Reply within 2 hours</span>
+							</li>
+						</ul>
+					</div>
+
+					{/* OR divider for the alternative path */}
+					<div
+						aria-hidden="true"
+						className="mt-12 flex items-center gap-4 max-w-md mx-auto"
+					>
+						<span className="h-px flex-1 bg-border" />
+						<span className="text-xs uppercase tracking-widest text-muted-foreground">
+							or
+						</span>
+						<span className="h-px flex-1 bg-border" />
+					</div>
+
+					<div className="mt-8">
 						<NewsletterSignup dynamic variant="compact" />
 					</div>
 				</div>
 			</section>
+
+			<ExitIntentModal />
 		</div>
 	)
 }

--- a/src/components/utilities/ExitIntentModal.tsx
+++ b/src/components/utilities/ExitIntentModal.tsx
@@ -57,6 +57,13 @@ export function ExitIntentModal() {
 				return
 			}
 
+			// Suppress when the document is not focused. Opening DevTools or
+			// alt-tabbing fires mouseleave through the same code path; we
+			// only want true viewport-exit gestures while the page is focused.
+			if (!document.hasFocus()) {
+				return
+			}
+
 			const now = Date.now()
 			if (now - armedAtRef.current < MIN_DWELL_MS) {
 				return
@@ -69,11 +76,17 @@ export function ExitIntentModal() {
 			setOpen(true)
 		}
 
-		document.body.addEventListener('mouseleave', handleMouseLeave)
+		// Listen on <html> rather than <body>. mouseleave on body is
+		// unreliable in Safari for true viewport exits; documentElement
+		// is the direct parent and consistently fires across browsers.
+		document.documentElement.addEventListener('mouseleave', handleMouseLeave)
 		document.addEventListener('click', handleClick, { capture: true })
 
 		return () => {
-			document.body.removeEventListener('mouseleave', handleMouseLeave)
+			document.documentElement.removeEventListener(
+				'mouseleave',
+				handleMouseLeave
+			)
 			document.removeEventListener('click', handleClick, { capture: true })
 		}
 	}, [])

--- a/src/components/utilities/ExitIntentModal.tsx
+++ b/src/components/utilities/ExitIntentModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { NewsletterSignup } from '@/components/forms/NewsletterSignup'
 import {
 	Dialog,
@@ -11,10 +11,22 @@ import {
 } from '@/components/ui/dialog'
 
 const STORAGE_KEY = 'hds-exit-intent-shown'
-const TOP_THRESHOLD_PX = 50
+const MIN_DWELL_MS = 30_000
+const POST_CLICK_SUPPRESS_MS = 2_000
 
+/**
+ * Exit-intent modal scoped to the homepage. Fires once per session when
+ * the cursor truly exits the document via the top edge (clientY <= 0
+ * with relatedTarget=null on a body mouseleave), the user has been on
+ * the page at least 30s, and they haven't clicked anything in the
+ * preceding 2s. The browser cannot distinguish "user is closing the
+ * tab" from "user is moving cursor to the URL bar" — these heuristics
+ * minimize false positives for the second case.
+ */
 export function ExitIntentModal() {
 	const [open, setOpen] = useState(false)
+	const lastClickAtRef = useRef<number>(0)
+	const armedAtRef = useRef<number>(0)
 
 	useEffect(() => {
 		// Skip on touch / coarse-pointer devices — mouseleave at viewport top
@@ -31,33 +43,53 @@ export function ExitIntentModal() {
 			return
 		}
 
-		const handleMouseOut = (event: MouseEvent) => {
-			// Only when the cursor exits via the top edge AND has actually
-			// left the document (relatedTarget=null means it left the window).
-			if (event.clientY < TOP_THRESHOLD_PX && event.relatedTarget === null) {
-				window.sessionStorage.setItem(STORAGE_KEY, '1')
-				setOpen(true)
-			}
+		armedAtRef.current = Date.now()
+
+		const handleClick = () => {
+			lastClickAtRef.current = Date.now()
 		}
 
-		document.addEventListener('mouseout', handleMouseOut)
-		return () => document.removeEventListener('mouseout', handleMouseOut)
+		const handleMouseLeave = (event: MouseEvent) => {
+			// Cursor must have actually crossed the top edge of the viewport,
+			// not merely approached the navbar. clientY is 0 or negative when
+			// the pointer has truly left via the top.
+			if (event.clientY > 0 || event.relatedTarget !== null) {
+				return
+			}
+
+			const now = Date.now()
+			if (now - armedAtRef.current < MIN_DWELL_MS) {
+				return
+			}
+			if (now - lastClickAtRef.current < POST_CLICK_SUPPRESS_MS) {
+				return
+			}
+
+			window.sessionStorage.setItem(STORAGE_KEY, '1')
+			setOpen(true)
+		}
+
+		document.body.addEventListener('mouseleave', handleMouseLeave)
+		document.addEventListener('click', handleClick, { capture: true })
+
+		return () => {
+			document.body.removeEventListener('mouseleave', handleMouseLeave)
+			document.removeEventListener('click', handleClick, { capture: true })
+		}
 	}, [])
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
-			<DialogContent className="sm:max-w-md">
+			<DialogContent>
 				<DialogHeader>
-					<DialogTitle>
-						Wait — one practical playbook before you go.
-					</DialogTitle>
+					<DialogTitle>One practical playbook before you go.</DialogTitle>
 					<DialogDescription>
-						If you&apos;re weighing whether a website is worth the cost, get the
-						short list of decisions that actually move the needle for small
-						businesses. One email, no follow-ups, unsubscribe anytime.
+						The short list of decisions that actually move the needle for small
+						businesses building or rebuilding their website. One email, no
+						follow-ups, unsubscribe anytime.
 					</DialogDescription>
 				</DialogHeader>
-				<NewsletterSignup variant="modal" title="" description="" />
+				<NewsletterSignup variant="compact" title="" description="" />
 			</DialogContent>
 		</Dialog>
 	)


### PR DESCRIPTION
## Summary

Two homepage UX fixes from a user review:

### 1. Closing-CTA section enhancements
- CTA buttons wrapped in a bordered card so they have visual weight instead of floating
- Added trust-signal row under primary CTA: \`30-minute call · No commitment · Reply within 2 hours\`
- Subtle line flourish on the 'Let's talk' eyebrow
- Soft radial accent gradient at the section top for depth
- Explicit \`or\` divider between primary CTA and the newsletter alternative
- Tightened layout from \`container-wide\` to \`max-w-3xl\` for focus

### 2. Exit-intent modal — fix layout regression + scope down trigger

**Layout bug found and fixed:**
- \`globals.css\` was using \`var(--bg-overlay)\` but the design token is \`--color-bg-overlay\` — variable lookup failed, overlay scrim rendered transparent. That's why the user reported the modal as 'congested and messed up' on fire.
- \`dialog-content\` was using undefined \`--popover\` and had no z-index. Replaced with explicit surface-elevated bg, border, shadow, and z:51.

**Trigger hardening:**
- Switched from document \`mouseout\` (bubbles on every element transition) to body \`mouseleave\` with \`clientY <= 0\` — cursor must truly cross the viewport top edge, not just approach the navbar.
- Added 30s minimum dwell time before arming.
- Added 2s post-click suppression — if the user just clicked an internal link, the modal won't fire when their cursor naturally drifts up.
- Kept once-per-session guard via \`sessionStorage\`.
- **Moved from \`src/app/layout.tsx\` (site-wide) to \`src/app/page.tsx\` (homepage only).** Internal navigation between feature pages no longer arms the modal at all.

**Why this is still a heuristic:** browsers can't distinguish 'user is closing the tab' from 'user is moving cursor to the URL bar'. Both produce \`relatedTarget === null\`. The mitigations make false positives much less likely but cannot eliminate them entirely — that's a fundamental limit of mouse-based exit-intent detection.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test:unit\` — **504 pass / 0 fail**
- [x] \`bun run build\` — clean
- [ ] Homepage closing CTA renders the new card with trust signals at desktop + mobile
- [ ] Modal fires only on true cursor exit (move cursor up past the top edge of the browser window) after 30s on the homepage
- [ ] Modal does NOT fire when navigating between site pages
- [ ] Modal scrim is visibly dimmed (not transparent) when it does open

[hudsor01]