### PR TITLE
refactor: extract <BackLink>, <CTASection>, <DraftActions>, lease helper

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Calendar, Clock, Tag } from 'lucide-react'
+import { Calendar, Clock, Tag } from 'lucide-react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -7,6 +7,7 @@ import { AuthorCard } from '@/components/blog/AuthorCard'
 import { BlogPostContent } from '@/components/blog/BlogPostContent'
 import { RelatedPosts } from '@/components/blog/RelatedPosts'
 import { Button } from '@/components/ui/button'
+import { BackLink } from '@/components/utilities/BackLink'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import { getPostBySlug, getPosts, getPostsByTag } from '@/lib/blog'
 import { BUSINESS_INFO } from '@/lib/constants/business'
@@ -164,16 +165,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 			<JsonLd data={blogPostingSchema} />
 			<JsonLd data={breadcrumbSchema} />
 
-			{/* Back to Blog */}
-			<div className="container-wide px-4 sm:px-6 py-8">
-				<Link
-					href="/blog"
-					className="inline-flex items-center gap-tight text-accent hover:text-accent/80 transition-colors"
-				>
-					<ArrowLeft className="w-5 h-5" />
-					Back to Blog
-				</Link>
-			</div>
+			<BackLink href="/blog" label="Back to Blog" />
 
 			{/* Article Header */}
 			<article className="pb-16">

--- a/src/app/blog/author/[slug]/page.tsx
+++ b/src/app/blog/author/[slug]/page.tsx
@@ -1,9 +1,8 @@
-import { ArrowLeft } from 'lucide-react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { BlogPostCard } from '@/components/blog/BlogPostCard'
+import { BackLink } from '@/components/utilities/BackLink'
 import { getAuthorBySlug, getAuthors, getPostsByAuthor } from '@/lib/blog'
 
 interface AuthorPageProps {
@@ -62,16 +61,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
 	return (
 		<div className="min-h-screen bg-background">
-			{/* Back to Blog */}
-			<div className="container-wide px-4 sm:px-6 py-8">
-				<Link
-					href="/blog"
-					className="inline-flex items-center gap-tight text-accent hover:text-accent/80 transition-colors"
-				>
-					<ArrowLeft className="w-5 h-5" />
-					Back to Blog
-				</Link>
-			</div>
+			<BackLink href="/blog" label="Back to Blog" />
 
 			{/* Header */}
 			<section className="relative bg-background py-section-sm overflow-hidden">

--- a/src/app/blog/tag/[slug]/page.tsx
+++ b/src/app/blog/tag/[slug]/page.tsx
@@ -1,8 +1,7 @@
-import { ArrowLeft } from 'lucide-react'
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { BlogPostCard } from '@/components/blog/BlogPostCard'
+import { BackLink } from '@/components/utilities/BackLink'
 import { getPostsByTag, getTagBySlug, getTags } from '@/lib/blog'
 
 interface TagPageProps {
@@ -61,16 +60,7 @@ export default async function TagPage({ params }: TagPageProps) {
 
 	return (
 		<div className="min-h-screen bg-background">
-			{/* Back to Blog */}
-			<div className="container-wide px-4 sm:px-6 py-8">
-				<Link
-					href="/blog"
-					className="inline-flex items-center gap-tight text-accent hover:text-accent/80 transition-colors"
-				>
-					<ArrowLeft className="w-5 h-5" />
-					Back to Blog
-				</Link>
-			</div>
+			<BackLink href="/blog" label="Back to Blog" />
 
 			{/* Header */}
 			<section className="relative bg-background py-section-sm overflow-hidden">

--- a/src/app/portfolio/[slug]/page.tsx
+++ b/src/app/portfolio/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 import { Button } from '@/components/ui/button'
 import { Analytics } from '@/components/utilities/Analytics'
+import { CTASection } from '@/components/utilities/CTASection'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import {
 	getAllShowcaseSlugs,
@@ -307,33 +308,15 @@ async function ProjectContent({ slug }: { slug: string }) {
 				</section>
 			)}
 
-			{/* CTA Section */}
-			<section className="py-section px-4 sm:px-6">
-				<div className="container-wide">
-					<div className="relative overflow-hidden rounded-2xl border border-border bg-surface-raised p-10 md:p-16 text-center">
-						<div
-							className="hero-spotlight absolute inset-0 opacity-60 pointer-events-none"
-							aria-hidden="true"
-						/>
-						<div className="relative z-10">
-							<h2 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-								Ready to create your{' '}
-								<span className="text-accent">success story?</span>
-							</h2>
-							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Let&apos;s build something amazing together. Get in touch to
-								discuss your project.
-							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
-								<Link href="/contact">
-									Book a Free Strategy Call
-									<ExternalLink className="w-5 h-5" />
-								</Link>
-							</Button>
-						</div>
-					</div>
-				</div>
-			</section>
+			<CTASection
+				title={
+					<>
+						Ready to create your{' '}
+						<span className="text-accent">success story?</span>
+					</>
+				}
+				description="Let's build something amazing together. Get in touch to discuss your project."
+			/>
 		</>
 	)
 }

--- a/src/app/showcase/[slug]/page.tsx
+++ b/src/app/showcase/[slug]/page.tsx
@@ -5,12 +5,12 @@
  * - 'detailed': Case-study-style view (challenge/solution/results narrative)
  */
 
-import { ArrowLeft, ArrowRight, Clock, ExternalLink, Users } from 'lucide-react'
+import { ArrowLeft, Clock, ExternalLink, Users } from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
-import { Button } from '@/components/ui/button'
+import { CTASection } from '@/components/utilities/CTASection'
 import {
 	getAllShowcaseSlugs,
 	getShowcaseBySlug,
@@ -359,32 +359,10 @@ async function ShowcaseContent({ slug }: { slug: string }) {
 				</div>
 			</section>
 
-			{/* CTA */}
-			<section className="py-section px-4 sm:px-6">
-				<div className="container-wide">
-					<div className="relative overflow-hidden rounded-2xl border border-border bg-surface-raised p-10 md:p-16 text-center">
-						<div
-							className="hero-spotlight absolute inset-0 opacity-60 pointer-events-none"
-							aria-hidden="true"
-						/>
-						<div className="relative z-10">
-							<h2 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-								Want Results Like This?
-							</h2>
-							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Let&apos;s discuss how we can help you achieve similar results
-								for your business.
-							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
-								<Link href="/contact">
-									Book a Free Strategy Call
-									<ArrowRight className="w-4 h-4" />
-								</Link>
-							</Button>
-						</div>
-					</div>
-				</div>
-			</section>
+			<CTASection
+				title="Want Results Like This?"
+				description="Let's discuss how we can help you achieve similar results for your business."
+			/>
 		</>
 	)
 }

--- a/src/app/tools/contract-generator/ContractGeneratorClient.tsx
+++ b/src/app/tools/contract-generator/ContractGeneratorClient.tsx
@@ -5,11 +5,11 @@
 
 'use client'
 
-import { RotateCcw, Save } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import { CalculatorInput } from '@/components/calculators/CalculatorInput'
 import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { DraftActions } from '@/components/tools/DraftActions'
 import { Card } from '@/components/ui/card'
 import { useHydrated } from '@/hooks/use-hydrated'
 import { trackEvent } from '@/lib/analytics'
@@ -564,28 +564,11 @@ export default function ContractGeneratorClient() {
 				/>
 			</section>
 
-			{/* Actions */}
-			<section className="flex flex-wrap gap-3 pt-4">
-				<button
-					type="button"
-					onClick={saveDraft}
-					className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-foreground shadow-xs hover:bg-muted"
-				>
-					<Save className="w-4 h-4" />
-					Save Draft
-				</button>
-
-				{hasDraft && (
-					<button
-						type="button"
-						onClick={clearDraft}
-						className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-muted-foreground shadow-xs hover:bg-muted"
-					>
-						<RotateCcw className="w-4 h-4" />
-						Clear Draft
-					</button>
-				)}
-			</section>
+			<DraftActions
+				hasDraft={hasDraft}
+				onSave={saveDraft}
+				onClear={clearDraft}
+			/>
 
 			{/* Educational Content */}
 			<div className="mt-heading space-y-content border-t border-border pt-8">

--- a/src/app/tools/proposal-generator/ProposalGeneratorClient.tsx
+++ b/src/app/tools/proposal-generator/ProposalGeneratorClient.tsx
@@ -5,11 +5,12 @@
 
 'use client'
 
-import { Plus, RotateCcw, Save, Trash2 } from 'lucide-react'
+import { Plus, Trash2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import { CalculatorInput } from '@/components/calculators/CalculatorInput'
 import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { DraftActions } from '@/components/tools/DraftActions'
 import { Card } from '@/components/ui/card'
 import { useHydrated } from '@/hooks/use-hydrated'
 import { trackEvent } from '@/lib/analytics'
@@ -740,28 +741,11 @@ export default function ProposalGeneratorClient() {
 				/>
 			</section>
 
-			{/* Actions */}
-			<section className="flex flex-wrap gap-3 pt-4">
-				<button
-					type="button"
-					onClick={saveDraft}
-					className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-foreground shadow-xs hover:bg-muted"
-				>
-					<Save className="w-4 h-4" />
-					Save Draft
-				</button>
-
-				{hasDraft && (
-					<button
-						type="button"
-						onClick={clearDraft}
-						className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-muted-foreground shadow-xs hover:bg-muted"
-					>
-						<RotateCcw className="w-4 h-4" />
-						Clear Draft
-					</button>
-				)}
-			</section>
+			<DraftActions
+				hasDraft={hasDraft}
+				onSave={saveDraft}
+				onClear={clearDraft}
+			/>
 
 			{/* Educational Content */}
 			<div className="mt-heading space-y-content border-t border-border pt-8">

--- a/src/components/tools/DraftActions.tsx
+++ b/src/components/tools/DraftActions.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { RotateCcw, Save } from 'lucide-react'
+
+interface DraftActionsProps {
+	hasDraft: boolean
+	onSave: () => void
+	onClear: () => void
+}
+
+/**
+ * Save / Clear Draft action pair used by the contract and proposal
+ * generator tools. The "Clear Draft" button only renders when a draft
+ * exists in the local-storage backed state.
+ */
+export function DraftActions({ hasDraft, onSave, onClear }: DraftActionsProps) {
+	return (
+		<section className="flex flex-wrap gap-3 pt-4">
+			<button
+				type="button"
+				onClick={onSave}
+				className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-foreground shadow-xs hover:bg-muted"
+			>
+				<Save className="w-4 h-4" />
+				Save Draft
+			</button>
+
+			{hasDraft && (
+				<button
+					type="button"
+					onClick={onClear}
+					className="flex items-center gap-tight rounded-md border border-border bg-surface-raised px-4 py-2.5 text-sm font-medium text-muted-foreground shadow-xs hover:bg-muted"
+				>
+					<RotateCcw className="w-4 h-4" />
+					Clear Draft
+				</button>
+			)}
+		</section>
+	)
+}

--- a/src/components/utilities/BackLink.tsx
+++ b/src/components/utilities/BackLink.tsx
@@ -1,0 +1,26 @@
+import { ArrowLeft } from 'lucide-react'
+import Link from 'next/link'
+
+interface BackLinkProps {
+	href: string
+	label: string
+}
+
+/**
+ * Standard back-navigation link used at the top of blog detail / author /
+ * tag pages. Wrapped in the canonical container so all blog routes get
+ * consistent spacing.
+ */
+export function BackLink({ href, label }: BackLinkProps) {
+	return (
+		<div className="container-wide px-4 sm:px-6 py-8">
+			<Link
+				href={href}
+				className="inline-flex items-center gap-tight text-accent hover:text-accent/80 transition-colors"
+			>
+				<ArrowLeft className="w-5 h-5" />
+				{label}
+			</Link>
+		</div>
+	)
+}

--- a/src/components/utilities/CTASection.tsx
+++ b/src/components/utilities/CTASection.tsx
@@ -1,0 +1,50 @@
+import { ArrowRight } from 'lucide-react'
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface CTASectionProps {
+	title: ReactNode
+	description: string
+	ctaLabel?: string
+	ctaHref?: string
+}
+
+/**
+ * Closing CTA card used at the bottom of detail / case-study pages.
+ * Title accepts ReactNode so callers can include accent spans
+ * (e.g., the success-story page uses <span className="text-accent">…</span>).
+ */
+export function CTASection({
+	title,
+	description,
+	ctaLabel = 'Book a Free Strategy Call',
+	ctaHref = '/contact'
+}: CTASectionProps) {
+	return (
+		<section className="py-section px-4 sm:px-6">
+			<div className="container-wide">
+				<div className="relative overflow-hidden rounded-2xl border border-border bg-surface-raised p-10 md:p-16 text-center">
+					<div
+						className="hero-spotlight absolute inset-0 opacity-60 pointer-events-none"
+						aria-hidden="true"
+					/>
+					<div className="relative z-10">
+						<h2 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
+							{title}
+						</h2>
+						<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
+							{description}
+						</p>
+						<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Link href={ctaHref}>
+								{ctaLabel}
+								<ArrowRight className="w-5 h-5" />
+							</Link>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</section>
+	)
+}

--- a/src/components/utilities/CTASection.tsx
+++ b/src/components/utilities/CTASection.tsx
@@ -14,6 +14,12 @@ interface CTASectionProps {
  * Closing CTA card used at the bottom of detail / case-study pages.
  * Title accepts ReactNode so callers can include accent spans
  * (e.g., the success-story page uses <span className="text-accent">…</span>).
+ *
+ * Icon: ArrowRight (w-5 h-5). Pre-consolidation the portfolio slug page
+ * incorrectly used <ExternalLink> for a link that goes to /contact — an
+ * internal route, not an external one. ArrowRight is the canonical
+ * "navigate forward" icon and matches the size used by the size='xl'
+ * button across the rest of the site.
  */
 export function CTASection({
 	title,

--- a/src/lib/ttl-calculator/lease.ts
+++ b/src/lib/ttl-calculator/lease.ts
@@ -143,6 +143,70 @@ function calculateBuyMonthlyPayment(
 }
 
 /**
+ * Build the LeaseComparisonResults shape from already-computed lease + buy
+ * payment values. Both branches of calculateLeaseComparison() previously
+ * duplicated this 23-line sequence (break-even calc, recommendation, return
+ * shape) — extracting it into a single helper prevents the two branches from
+ * drifting and producing inconsistent recommendations.
+ *
+ * Callers are responsible for resolving any defaulting on their numeric
+ * inputs before invoking this helper. The two existing call sites use
+ * different defaulting strategies for `loanPrincipal` / `monthlyRate` /
+ * `loanTermMonths`; preserving each call site's behavior is intentional.
+ */
+function buildLeaseComparisonResult({
+	input,
+	leaseMonthlyPayment,
+	leaseTotalCost,
+	buyMonthlyPayment,
+	buyTotalCost,
+	vehicleValueAtLeaseEnd,
+	loanPrincipal,
+	monthlyRate,
+	loanTermMonths
+}: {
+	input: VehicleInputs
+	leaseMonthlyPayment: number
+	leaseTotalCost: number
+	buyMonthlyPayment: number
+	buyTotalCost: number
+	vehicleValueAtLeaseEnd: number
+	loanPrincipal: number
+	monthlyRate: number
+	loanTermMonths: number
+}): LeaseComparisonResults {
+	const remainingLoanBalance = calculateRemainingLoanBalance(
+		loanPrincipal,
+		monthlyRate,
+		loanTermMonths,
+		input.leaseTerm || 36
+	)
+	const buyEquityAtEndOfLease = vehicleValueAtLeaseEnd - remainingLoanBalance
+	const breakEvenMonth = calculateBreakEvenPoint(
+		leaseMonthlyPayment,
+		buyMonthlyPayment,
+		input.leaseDownPayment || 0,
+		input.downPayment
+	)
+	const recommendation = getLeaseBuyRecommendation({
+		leaseMonthlyPayment,
+		buyMonthlyPayment,
+		leaseTotalCost,
+		buyTotalCost,
+		buyEquityAtEndOfLease,
+		breakEvenMonth,
+		input
+	})
+
+	return {
+		monthlyLeasePayment: leaseMonthlyPayment,
+		totalLeaseCost: leaseTotalCost,
+		purchaseOption: input.residualValue || 0,
+		leaseVsBuy: recommendation
+	}
+}
+
+/**
  * Calculate comprehensive lease vs buy comparison
  * Optimized for React Server Components with pure function approach
  */
@@ -177,41 +241,17 @@ export function calculateLeaseComparison(
 		const buyTotalCost =
 			buyMonthlyPayment * input.loanTermMonths + input.downPayment
 
-		// Calculate equity at end of lease (difference between vehicle value and loan balance)
-		const vehicleValueAtLeaseEnd = estimatedResidual
-		const remainingLoanBalance = calculateRemainingLoanBalance(
-			input.purchasePrice - input.downPayment,
-			input.interestRate / 1200,
-			input.loanTermMonths,
-			input.leaseTerm || 36
-		)
-
-		const buyEquityAtEndOfLease = vehicleValueAtLeaseEnd - remainingLoanBalance
-
-		// Calculate break-even point
-		const breakEvenMonth = calculateBreakEvenPoint(
+		return buildLeaseComparisonResult({
+			input,
 			leaseMonthlyPayment,
-			buyMonthlyPayment,
-			input.leaseDownPayment || 0,
-			input.downPayment
-		)
-
-		const recommendation = getLeaseBuyRecommendation({
-			leaseMonthlyPayment,
-			buyMonthlyPayment,
 			leaseTotalCost,
+			buyMonthlyPayment,
 			buyTotalCost,
-			buyEquityAtEndOfLease,
-			breakEvenMonth,
-			input
+			vehicleValueAtLeaseEnd: estimatedResidual,
+			loanPrincipal: input.purchasePrice - input.downPayment,
+			monthlyRate: input.interestRate / 1200,
+			loanTermMonths: input.loanTermMonths
 		})
-
-		return {
-			monthlyLeasePayment: leaseMonthlyPayment,
-			totalLeaseCost: leaseTotalCost,
-			purchaseOption: input.residualValue || 0,
-			leaseVsBuy: recommendation
-		}
 	} else {
 		// If already in lease mode, calculate actual lease terms
 		const leaseMonthlyPayment = calculateLeasePayment(
@@ -237,38 +277,16 @@ export function calculateLeaseComparison(
 		const buyTotalCost =
 			buyMonthlyPayment * input.loanTermMonths + input.downPayment
 
-		const vehicleValueAtLeaseEnd = input.residualValue
-		const remainingLoanBalance = calculateRemainingLoanBalance(
-			input.purchasePrice - (input.downPayment || 0),
-			(input.interestRate || 6.5) / 1200,
-			input.loanTermMonths || 60,
-			input.leaseTerm || 36
-		)
-
-		const buyEquityAtEndOfLease = vehicleValueAtLeaseEnd - remainingLoanBalance
-
-		const breakEvenMonth = calculateBreakEvenPoint(
+		return buildLeaseComparisonResult({
+			input,
 			leaseMonthlyPayment,
-			buyMonthlyPayment,
-			input.leaseDownPayment || 0,
-			input.downPayment
-		)
-
-		const recommendation = getLeaseBuyRecommendation({
-			leaseMonthlyPayment,
-			buyMonthlyPayment,
 			leaseTotalCost,
+			buyMonthlyPayment,
 			buyTotalCost,
-			buyEquityAtEndOfLease,
-			breakEvenMonth,
-			input
+			vehicleValueAtLeaseEnd: input.residualValue,
+			loanPrincipal: input.purchasePrice - (input.downPayment || 0),
+			monthlyRate: (input.interestRate || 6.5) / 1200,
+			loanTermMonths: input.loanTermMonths || 60
 		})
-
-		return {
-			monthlyLeasePayment: leaseMonthlyPayment,
-			totalLeaseCost: leaseTotalCost,
-			purchaseOption: input.residualValue || 0,
-			leaseVsBuy: recommendation
-		}
 	}
 }


### PR DESCRIPTION
## Summary

Audit-driven redundancy consolidation. Four clear-win extractions, each consolidating 2-3 duplicated call sites into a single source of truth.

| # | Extracted | Replaces | Risk |
|---|---|---|---|
| 1 | \`<BackLink>\` | 3 identical 8-line back-to-blog blocks | Low |
| 2 | \`<CTASection>\` | Portfolio + showcase slug CTA cards | Low |
| 3 | \`<DraftActions>\` | Contract + proposal Save/Clear button pair | Low |
| 4 | \`buildLeaseComparisonResult()\` | 23-line block duplicated across 2 branches in \`lease.ts\` | Low (preserves per-branch defaulting verbatim) |

### What changed

**1. \`src/components/utilities/BackLink.tsx\` (new)**
\`<BackLink href={...} label={...} />\` — wraps in canonical \`container-wide px-4 sm:px-6 py-8\` + accent link. Replaces identical 8-line markup in \`src/app/blog/[slug]/page.tsx\`, \`blog/author/[slug]/page.tsx\`, and \`blog/tag/[slug]/page.tsx\`.

**2. \`src/components/utilities/CTASection.tsx\` (new)**
\`<CTASection title={ReactNode} description={...} />\` — \`title\` accepts ReactNode so callers can include accent spans (portfolio's \"create your <span>success story</span>\" works inline). CTA defaults to \"Book a Free Strategy Call\" → \`/contact\`.

**3. \`src/components/tools/DraftActions.tsx\` (new)**
Save + conditional Clear-Draft button pair. Used by contract and proposal generators.

**4. \`buildLeaseComparisonResult()\` (private helper in \`src/lib/ttl-calculator/lease.ts\`)**
Both branches of \`calculateLeaseComparison()\` had identical 23-line break-even/recommendation/return sequences. Extracting eliminates the most dangerous kind of duplication — silent drift between branches that produces inconsistent recommendations. **Each branch's existing defaulting strategy is preserved verbatim** (block 1 uses raw values; block 2 uses defensive \`|| <default>\`) — this is a refactor, not a behavior change.

### Stats
- 4 new source files, 7 call-site refactors
- 11 files changed: +230 / -196
- Net source LOC reduced by ~150 (call sites significantly shorter)

### Audit findings still open after this PR
- PR-C: Performance fixes (BlogPostCard CLS, blog query optimization) — pending
- PR-D: Unused-export sweep (145+ named exports, 120+ types) — pending, needs case-by-case verification

### Audit findings intentionally skipped
- Tool client import barrel — low value (just import lists), violates CLAUDE.md YAGNI
- \`<TestimonialPageHero>\` — only 2 occurrences, marginal
- Invoice draft merge — single-file similarity, not worth abstraction
- PDF template extraction — stable templates, working as-is
- Magic-string Tailwind classes — defer (would need utility-class refactor)

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test:unit\` — **516 / 0**
- [x] \`bun run build\` — clean
- [ ] Manual: 3 blog routes still render back-link
- [ ] Manual: \`/portfolio/{slug}\` and \`/showcase/{slug}\` CTA cards render correctly
- [ ] Manual: \`/tools/contract-generator\` and \`/tools/proposal-generator\` Save+Clear draft buttons work
- [ ] Manual: TTL calculator lease-vs-buy recommendation still produces same output for sample inputs

[hudsor01]