### PR TITLE
perf: blog image priority + drop unused count query + tag LIMIT

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -57,8 +57,8 @@ async function FeaturedSection() {
 				</div>
 
 				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-					{featuredPosts.map(post => (
-						<BlogPostCard key={post.id} post={post} featured />
+					{featuredPosts.map((post, i) => (
+						<BlogPostCard key={post.id} post={post} featured priority={i < 2} />
 					))}
 				</div>
 			</div>

--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -8,9 +8,19 @@ import { formatDate } from '@/lib/utils'
 interface BlogPostCardProps {
 	post: BlogPost
 	featured?: boolean
+	/**
+	 * Set on the LCP-candidate card(s) above the fold (e.g. the first
+	 * 1-2 featured cards on /blog). Passes through to next/image priority
+	 * so the browser preloads the image during the critical path.
+	 */
+	priority?: boolean
 }
 
-export function BlogPostCard({ post, featured = false }: BlogPostCardProps) {
+export function BlogPostCard({
+	post,
+	featured = false,
+	priority = false
+}: BlogPostCardProps) {
 	return (
 		<article className={`group ${featured ? 'md:col-span-2' : ''}`}>
 			<Link href={`/blog/${post.slug}`} className="block">
@@ -27,6 +37,7 @@ export function BlogPostCard({ post, featured = false }: BlogPostCardProps) {
 								src={post.feature_image}
 								alt={post.title}
 								fill
+								priority={priority}
 								className="object-cover group-hover:scale-105 transition-transform duration-500"
 								sizes={
 									featured

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -142,7 +142,7 @@ function mapPost(
 export async function getPosts(options?: {
 	limit?: number
 	page?: number
-}): Promise<{ posts: BlogPost[]; total: number }> {
+}): Promise<{ posts: BlogPost[] }> {
 	const limit = options?.limit ?? 10
 	const page = options?.page ?? 1
 	return getPostsCached(limit, page)
@@ -151,7 +151,7 @@ export async function getPosts(options?: {
 async function getPostsCached(
 	limit: number,
 	page: number
-): Promise<{ posts: BlogPost[]; total: number }> {
+): Promise<{ posts: BlogPost[] }> {
 	'use cache'
 	cacheLife('hours')
 	cacheTag('blog-posts')
@@ -175,19 +175,13 @@ async function getPostsCached(
 			mapPost(r.blog_posts, r.blog_authors, tagsByPost[r.blog_posts.id] ?? [])
 		)
 
-		// Count total published posts
-		const allPublished = await db
-			.select({ id: blogPosts.id })
-			.from(blogPosts)
-			.where(eq(blogPosts.published, true))
-
-		return { posts, total: allPublished.length }
+		return { posts }
 	} catch (error) {
 		logger.error('Failed to fetch blog posts', error, {
 			metadata: { limit, page }
 		})
 		reportError(error, { module: 'blog', op: 'getPosts' })
-		return { posts: [], total: 0 }
+		return { posts: [] }
 	}
 }
 
@@ -266,7 +260,14 @@ export async function getTags(): Promise<BlogTag[]> {
 	cacheTag('blog-tags')
 
 	try {
-		const rows = await db.select().from(blogTags).orderBy(blogTags.name)
+		// Safety bound — tags are user-curated and should never grow past
+		// a few dozen, but cap unbounded reads in case the table is ever
+		// polluted (e.g., n8n importer bug producing duplicate tags).
+		const rows = await db
+			.select()
+			.from(blogTags)
+			.orderBy(blogTags.name)
+			.limit(500)
 		return rows.map(mapTag)
 	} catch (error) {
 		logger.error('Failed to fetch blog tags', error)

--- a/tests/unit/blog.test.ts
+++ b/tests/unit/blog.test.ts
@@ -378,17 +378,15 @@ describe('Blog Data Layer', () => {
 	})
 
 	describe('getPosts', () => {
-		test('returns posts with total count', async () => {
+		test('returns posts', async () => {
 			resetMockDb(
 				[makeJoinedRow()], // main query
-				[], // loadTagsForPosts (no tags)
-				[{ id: 'post-1' }] // count query
+				[] // loadTagsForPosts (no tags)
 			)
 
 			const result = await getPosts({ limit: 10, page: 1 })
 
 			expect(result.posts).toHaveLength(1)
-			expect(result.total).toBe(1)
 			expect(result.posts[0]?.slug).toBe('test-post')
 		})
 
@@ -398,7 +396,6 @@ describe('Blog Data Layer', () => {
 			const result = await getPosts()
 
 			expect(result.posts).toEqual([])
-			expect(result.total).toBe(0)
 		})
 	})
 


### PR DESCRIPTION
## Summary

Three audit findings from the performance pass, all MED severity.

### 1. BlogPostCard image priority (LCP)
\`<BlogPostCard>\` gained an optional \`priority\` prop forwarded to \`next/image\`. The blog index now passes \`priority={i < 2}\` for the first two featured cards — they're the LCP candidates above the fold. The aspect-ratio container + \`fill\` mode already prevents CLS; \`priority\` just gets the browser to preload during the critical path.

### 2. Drop unused count query in \`getPostsCached()\`
Every paginated \`getPosts()\` call ran a second \`SELECT id FROM blog_posts WHERE published = true\` to populate a \`total\` field that **zero consumers ever read** — verified via grep across \`src/app/blog/\`, \`src/app/api/\`, \`src/lib/\`, sitemap, and the RSS feed. Dropped the count query and changed the public return shape from \`{ posts, total }\` to just \`{ posts }\`. Saves an entire DB round-trip per pagination request.

\`tests/unit/blog.test.ts\` had two assertions on \`result.total\` — simplified.

### 3. \`getTags()\` LIMIT safety bound
\`getTags()\` previously did \`SELECT * FROM blog_tags ORDER BY name\` with no limit. Tags should never grow past a few dozen, but a defensive \`.limit(500)\` prevents an unbounded read if the table is ever polluted (n8n importer bug, accidental seed data, etc.).

## Files
- \`src/components/blog/BlogPostCard.tsx\` — added priority prop
- \`src/app/blog/page.tsx\` — passes priority for first 2 featured cards
- \`src/lib/blog.ts\` — dropped count query, return type narrowed, tag LIMIT 500
- \`tests/unit/blog.test.ts\` — simplified two assertions

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test:unit\` — **516 / 0**
- [x] \`bun run build\` — clean
- [ ] Manual: load \`/blog\` and confirm first 2 featured images preload (Network panel, fetchpriority=high on \`/_next/image?...\`)
- [ ] Manual: verify pagination still works after dropping \`total\` (no consumer should care, but worth a smoke test)

[hudsor01]