### PR TITLE
fix(seo): drop stale priceRange from LocalBusiness schema

### DIFF
--- a/src/lib/seo-utils.ts
+++ b/src/lib/seo-utils.ts
@@ -67,7 +67,6 @@ export function generateLocalBusinessSchema() {
 		url: SITE_URL,
 		image: LOGO_URL,
 		description: 'Web development and business automation for small businesses',
-		priceRange: '$497 - $5000+',
 		address: {
 			'@type': 'PostalAddress',
 			streetAddress: BUSINESS_INFO.location.streetAddress,


### PR DESCRIPTION
## Summary

\`src/lib/seo-utils.ts:70\` still had \`priceRange: '\$497 - \$5000+'\` in the LocalBusiness JSON-LD schema — the same placeholder prices that drove PR #181 to take down the entire \`/pricing\` page.

The user-facing pricing was removed but the **Google-facing structured-data exposure** of those uncommitted numbers wasn't. This PR drops the field.

## Why drop instead of substitute

\`priceRange\` is optional per \`schema.org/LocalBusiness\` spec. Three options were considered:

| Option | Outcome |
|---|---|
| Keep \`'\$497 - \$5000+'\` | Continues claiming uncommitted prices to Google (status quo before this PR) |
| Substitute \`'\$\$\$'\` or \`'Contact for quote'\` | Still implies a price range/tier we haven't agreed to |
| **Drop the field entirely** | Honest — Google has no price hint to display, matches the user-facing site state |

Going with drop.

## Test plan

- [x] \`bun run typecheck\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test:unit\` — **516 / 0**
- [x] \`bun run build\` — clean
- [x] \`grep -rn 'priceRange' src/\` — zero remaining hits
- [ ] After deploy: validate the homepage's LocalBusiness rich-result via Google Rich Results Test (https://search.google.com/test/rich-results) — confirm no \`priceRange\` is reported

[hudsor01]