### PR TITLE
chore: use canonical UPSTASH_REDIS_REST_* env var names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@
 - All env access goes through `src/env.ts` (T3 env). Never read `process.env.X` directly.
 - Schema-required when `VERCEL_ENV === 'production'` (enforced by a `.optional().refine(...)` pair; unset elsewhere): `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
 - Always defined (have defaults): `BASE_URL` (default `http://localhost:3000`), `NEXT_PUBLIC_BASE_URL` (default `http://localhost:3000`), `NODE_ENV` (default `development`)
-- Truly optional / feature-gated: `RESEND_API_KEY`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `NEXT_PUBLIC_SITE_URL`
+- Truly optional / feature-gated: `RESEND_API_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `NEXT_PUBLIC_SITE_URL`
 
 ## DEVELOPMENT COMMANDS
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -85,9 +85,9 @@ export const env = createEnv({
 			),
 
 		// Upstash Redis for distributed rate limiting (optional)
-		// Vercel injects these env var names when an Upstash Redis integration is attached.
-		KV_REST_API_URL: z.string().url().optional(),
-		KV_REST_API_TOKEN: z.string().optional(),
+		// Set automatically when an Upstash Redis integration is attached via Vercel Marketplace.
+		UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+		UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
 
 		// Sentry error tracking (optional; no-op when unset)
 		SENTRY_DSN: z.string().url().optional(),
@@ -131,8 +131,8 @@ export const env = createEnv({
 		ADMIN_SECRET: process.env.ADMIN_SECRET,
 		CRON_SECRET: process.env.CRON_SECRET,
 		DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
-		KV_REST_API_URL: process.env.KV_REST_API_URL,
-		KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN,
+		UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+		UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
 		SENTRY_DSN: process.env.SENTRY_DSN,
 		SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
 

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -45,8 +45,8 @@ async function checkWithRedis(
 	maxRequests: number,
 	windowSeconds: number
 ): Promise<boolean | null> {
-	const url = env.KV_REST_API_URL
-	const token = env.KV_REST_API_TOKEN
+	const url = env.UPSTASH_REDIS_REST_URL
+	const token = env.UPSTASH_REDIS_REST_TOKEN
 	if (!url || !token) {
 		return null
 	}
@@ -74,12 +74,14 @@ export class UnifiedRateLimiter {
 	// @types/node was implicitly in scope. Edge runtime would have
 	// surfaced this as `any` without that implicit include.
 	private cleanupInterval: ReturnType<typeof setInterval> | null = null
-	private useKv: boolean
+	private useRedis: boolean
 
 	constructor() {
-		// Use KV when env vars are present (production/preview), fall back to in-memory
-		this.useKv = !!(env.KV_REST_API_URL && env.KV_REST_API_TOKEN)
-		if (!this.useKv) {
+		// Use Upstash Redis when env vars are present (production/preview), fall back to in-memory
+		this.useRedis = !!(
+			env.UPSTASH_REDIS_REST_URL && env.UPSTASH_REDIS_REST_TOKEN
+		)
+		if (!this.useRedis) {
 			this.initializeInMemory()
 		} else {
 			logger.info('Distributed rate limiter initialized (Upstash Redis)')
@@ -120,7 +122,7 @@ export class UnifiedRateLimiter {
 		const key = this.buildKey(identifier, limitType)
 		const windowSeconds = Math.ceil(config.windowMs / 1000)
 
-		if (this.useKv) {
+		if (this.useRedis) {
 			const redisResult = await checkWithRedis(
 				key,
 				config.maxRequests,


### PR DESCRIPTION
## Summary
- Rename \`KV_REST_API_URL\` / \`KV_REST_API_TOKEN\` → \`UPSTASH_REDIS_REST_URL\` / \`UPSTASH_REDIS_REST_TOKEN\`.
- Matches the names Upstash injects via the Vercel Marketplace integration; aligns with the dep swap to \`@upstash/redis\` in #195.
- CLAUDE.md env-var reference updated.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun test tests/\` — 516 pass / 0 fail
- [x] \`next build --webpack\` succeeds
- [ ] Vercel env vars confirmed set as \`UPSTASH_REDIS_REST_URL\` / \`UPSTASH_REDIS_REST_TOKEN\` before merging

[hudsor01]