### PR TITLE
chore: drop dead generate-sitemap script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,6 @@ public/sitemap.xml
 # Development documentation with sensitive info
 docs/cloudflare-tunnel-config.yml
 docs/docker-compose-grafana.yml
-scripts/generate-sitemap.ts
 scripts/generate-metrics-token.js
 scripts/test-discord-webhook.sh
 .trae/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"lint": "biome check src/",
 		"lint:fix": "biome check src/ --write",
 		"format": "biome format --write src/",
-		"generate-sitemap": "bun run scripts/generate-sitemap.ts",
 		"typecheck": "tsc --noEmit",
 		"test:e2e": "playwright test",
 		"test:e2e:ui": "playwright test --ui",


### PR DESCRIPTION
## Summary
\`package.json\` declared a \`generate-sitemap\` script pointing at \`scripts/generate-sitemap.ts\`, but the file is gitignored and has not been in the repo. The App Router's \`src/app/sitemap.ts\` is the live sitemap source.

Remove both the script entry and the stale ignore line so the package surface matches what's actually committed.

## Test plan
- [x] \`bun run typecheck\` clean
- [x] \`bun test tests/\` — 516 pass / 0 fail
- [x] \`next build --webpack\` — \`/sitemap.xml\` still emitted from \`src/app/sitemap.ts\`

[hudsor01]