### PR TITLE
chore: add LICENSE, SECURITY.md, PR template, CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every PR auto-requests review from @hudsor01.
+# More specific patterns below override this fallback.
+
+*       @hudsor01

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- 1-3 bullets describing what changed and why. Focus on the why. -->
+
+## Test plan
+
+- [ ] `bun run typecheck` clean
+- [ ] `bun run lint` clean
+- [ ] `bun test tests/` passes
+- [ ] `next build --webpack` succeeds (if production code changed)
+- [ ] Manual smoke test on affected pages (if UI changed)
+
+## Notes
+
+<!-- Anything reviewer should know: deferred follow-ups, env var changes,
+     migration steps, breaking changes, or things you tried that didn't work. -->

--- a/.gitignore
+++ b/.gitignore
@@ -79,9 +79,11 @@ playwright-report/
 *.md
 !CLAUDE.md
 !README.md
+!SECURITY.md
 !master_todo.md
 !docs/plans/*.md
 !.planning/**/*.md
+!.github/**/*.md
 
 # Log files
 *.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2025-2026 Hudson Digital Solutions. All Rights Reserved.
+
+This repository contains the source code for the Hudson Digital Solutions
+business website (https://hudsondigitalsolutions.com).
+
+No license is granted, express or implied, to copy, modify, distribute,
+sublicense, or use any portion of this codebase for any purpose without
+the prior written consent of Hudson Digital Solutions.
+
+The code is published publicly for transparency and reference only.
+Forking, reusing, or republishing any part of this codebase — including
+content, branding, layout, or implementation patterns — is not permitted.
+
+To request a license, contact: hello@hudsondigitalsolutions.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this codebase or in the live site at
+https://hudsondigitalsolutions.com, please report it privately.
+
+**Do not** open a public GitHub issue for security reports.
+
+### How to report
+
+- Email: **hello@hudsondigitalsolutions.com**
+- Subject line: `Security: <brief summary>`
+- Include:
+  - Affected URL, endpoint, or file path
+  - Reproduction steps
+  - Impact assessment (data exposure, privilege escalation, etc.)
+  - Any proof-of-concept code or screenshots
+
+You should expect an acknowledgement within **3 business days** and a status
+update within **10 business days**.
+
+### Scope
+
+In scope:
+
+- The production site (`hudsondigitalsolutions.com`) and its subdomains
+- API routes under `/api/*`
+- Any application code in this repository
+
+Out of scope:
+
+- Third-party services (Vercel, Neon, Resend, Upstash) — report directly to the
+  vendor
+- Denial-of-service or volumetric attacks
+- Social engineering or phishing
+- Issues already triaged in this repository's Dependabot alerts
+
+### Disclosure
+
+After a fix is deployed, public disclosure is welcomed once 90 days have passed
+or the issue is otherwise patched, whichever is sooner. We're happy to credit
+the reporter unless you'd prefer to remain anonymous.


### PR DESCRIPTION
## Summary

Standard public-repo hygiene files surfaced by the repo audit:

- \`LICENSE\` — explicit all-rights-reserved declaration. Repo is published for transparency, not reuse; this removes the ambiguity of "no license = no rights granted, but also no machine-readable notice."
- \`SECURITY.md\` — private disclosure channel (hello@hudsondigitalsolutions.com) + scope so vulnerability reports don't land in public issues.
- \`.github/PULL_REQUEST_TEMPLATE.md\` — codifies the summary + test plan format already used in recent PRs.
- \`.github/CODEOWNERS\` — auto-request \`@hudsor01\` review on every PR.
- \`.gitignore\` — add exceptions for \`SECURITY.md\` and \`.github/**/*.md\` so the new template files aren't swallowed by the blanket \`*.md\` rule.

Settings-level audit findings (required status checks, secret scanning, deleting unused Supabase secret, locking to squash-only, etc.) are not part of this PR — they require admin-level repo settings changes you'll do via the GitHub UI.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test tests/\` — 516 pass / 0 fail
- [x] \`next build --webpack\` succeeds
- [x] PR template renders correctly (you'll see it on the next new PR opened against \`main\`)

[hudsor01]