### PR TITLE
chore(planning): mark phase 01 closed in STATE/ROADMAP

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,6 +3,7 @@
 ## Milestone v3.0 — Showcase & conversion polish
 
 > Started 2026-05-21. Site copy was repositioned in v2.x (PR #206). v3.0 focuses on visual storytelling and conversion surfaces.
+> Phase 01 shipped as PR #208 (squashed to `59e5e70` on `main`, 2026-05-22).
 
 ### Phases
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,32 +1,41 @@
 # STATE — Current GSD Position
 
-**Last updated:** 2026-05-21
-**Branch:** `showcase-ui-enhance`
+**Last updated:** 2026-05-22
+**Branch:** `main`
 **Current milestone:** v3.0 (Showcase & conversion polish)
-**Current phase:** `01-showcase-ui-redesign` (Complete)
-**Current plan:** none — phase 01 closed; awaiting human visual smoke + PR
+**Current phase:** none active — Phase 01 closed and merged
+**Current plan:** none
 
 ## What just happened
 
-- Plan 01-01 shipped: 4 image-backed rows in Neon `showcase` table (commit 22e84ed).
-- Plan 01-02 shipped: `Card variant="project"` accepts optional `imageUrl` / `imageAlt` (commit ac0dab7).
-- Plan 01-03 shipped: `/showcase` rewritten with featured-first layout, image-led cards, inline mid-scroll CTA. All em/en-dash characters removed. 4 homepage screenshots added under `public/images/showcase/` (commit 1df250f).
-- Plan 01-04 verification PASSED: lint + typecheck + build all exit 0; `/showcase` static-prerendered; em-dash sweep clean in-scope (4 pre-existing JSX comments in card.tsx out of scope per plan); en-dash sweep clean; all 4 JPGs tracked under 500K; `getShowcaseItems()` query path verified (no `imageUrl` filter). Human visual smoke deferred to operator. See `.planning/phases/01-showcase-ui-redesign/01-04-VERIFICATION.md` and `01-SUMMARY.md`.
-- Phase 01 complete (4/4 plans).
+- Phase 01 (`showcase-ui-redesign`) shipped to production:
+  - 4 plans across 3 waves, all executed with atomic commits
+  - 2-iteration code review loop (14 findings to 0 defects)
+  - Squash-merged as `59e5e70` on `2026-05-22T21:50Z` via PR #208
+- Original feature-branch commits: `22e84ed` (data), `ac0dab7` (Card), `1df250f` (page+images), `b25c72c` (planning metadata), `356ad1e` (verification), `983e4d7` (review-fix). All collapsed into the squash commit on main.
+- `/showcase` now renders 1 featured (JirahShop) + 3 support cards (Ink 37, TenantFlow, RevOps) with real homepage screenshots, plus a new mid-scroll CTA between the grid and the closing CTA.
 
-## Active decisions
+## Active decisions (still in force)
 
-- Featured selection uses `items.find(i => i.featured)` so the first featured item by `displayOrder` renders full-width (currently JirahShop).
-- Inline CTA placed inside `ShowcaseProjects` (inside Suspense) so it streams with the project grid; existing closing CTA outside Suspense stays static.
+- Featured-first rendering: `items.find(i => i.featured)` picks the lowest-displayOrder featured row for the full-width slot; remaining items render in a 3-col support grid with `featured={false}` forced at the call site so `md:col-span-2` / `priority` / the "Featured" overlay badge never fire on a support card.
+- Inline CTA lives inside `ShowcaseProjects` (under Suspense) so it streams with the grid; closing CTA stays outside Suspense.
 - Trust signal separators use U+00B7 MIDDLE DOT, never em-dash.
-- All accent body copy on light backgrounds uses `text-accent-text` (WCAG-safe) per globals.css.
-- Em/en-dash ban codified in CLAUDE.md as a global copy rule; enforced per-file on touch (no global sweep).
+- Accent body copy on light backgrounds uses `text-accent-text` (WCAG-safe).
+- Em/en-dash ban (CLAUDE.md) applies to user-facing text only; code comments and developer-only strings are exempt.
 
 ## Deferred / known issues
 
-- The earlier `v1.0/v1.1/v2.0` milestones are referenced in user memory but no `.planning/` artifacts remain. Treating those as historical only.
+- Earlier `v1.0` / `v1.1` / `v2.0` milestones are referenced in user memory but no `.planning/` artifacts remain. Treating those as historical only.
 - 4 location pages (75 cities) shipped in PR #206; no follow-up planned yet.
+- 4 pre-existing em-dashes in `src/components/ui/card.tsx` JSX block comments (lines 392, 397, 413, 427) are out of scope per the v3.0/01 verification (CLAUDE.md exempts code comments).
+- `industry` prop on `ProjectCardProps` is declared but never destructured/rendered. Pre-existing on `main` before phase 01. Candidate for a small cleanup PR if the next phase touches the Card component.
 
 ## Next action
 
-Operator: spin up `bun run dev`, hard-reload `http://localhost:3000/showcase`, walk through the 11 visual checks in `01-04-PLAN.md` Task 2 (typewriter, stats bar, section header, featured card, support grid, inline CTA, closing CTA, mobile stacking at ~375px, WebP serving in Network tab, keyboard focus rings). If green, open the PR against `main` with a squashed commit `feat(showcase): image-led redesign with featured card, support grid, and mid-scroll CTA`. Then pick the next v3.0 phase (none defined yet — roadmap currently lists only phase 01).
+Pick the next v3.0 phase. Roadmap currently lists only phase 01 (closed). Candidates surfaced during phase 01:
+- Global em/en-dash sweep across the rest of the site (PR-#206 copy still has scattered em-dashes)
+- `/services` page visual upgrade (currently text-heavy, no imagery)
+- Drop the unused `industry` prop on `ProjectCardProps`
+- Polish the closing CTA on `/showcase` (still uses `text-section-title` despite being demoted to h3)
+
+Run `/gsd-add-phase` to add a phase once direction is chosen.


### PR DESCRIPTION
Sync `.planning/STATE.md` and `.planning/ROADMAP.md` to post-merge truth after PR #208 (showcase UI redesign) shipped to main as 59e5e70.

- STATE: current phase set to 'none active'; branch updated to main; next-action rewritten as a candidate list for the next v3.0 phase
- ROADMAP: v3.0 header notes phase 01 shipped via PR #208

No code changes. Planning docs only.

[hudsor01]