### PR TITLE
feat(auth): Better Auth foundation - users, sessions, /admin role guard, AccountMenu

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -36,7 +36,7 @@ Plans:
 
 | # | Slug | Status | Plans | Description |
 |---|---|---|---|---|
-| 02 | `auth-foundation` | planning | 0 | Better Auth wired to Neon. Users + sessions tables. Sign-in / sign-up pages. `/admin/*` route group + middleware guard. Account menu primitive. Everything downstream depends on this. |
+| 02 | `auth-foundation` | complete (5/5) | 5 | Better Auth wired to Neon. Users + sessions + accounts + verifications tables. Sign-in / sign-up pages. `/admin/*` server-component role guard + `proxy.ts` edge cookie short-circuit. AccountMenu primitive. Phase summary at `.planning/phases/02-auth-foundation/02-SUMMARY.md`. |
 | 03 | `admin-shell-and-dashboard` | pending | 0 | Sidebar + layout adapted from Efferd Dashboard 5. `/admin` dashboard page wired to real data (web vitals, PageSpeed history, recent contact submissions). |
 | 04 | `admin-content-crud` | pending | 0 | `/admin/showcase`, `/admin/blog`, `/admin/testimonials` list + create + edit + delete. Replaces direct-SQL / Neon MCP workflow. |
 | 05 | `admin-ops` | pending | 0 | `/admin/leads` (contact submissions), `/admin/newsletter` (subscribers), `/admin/emails` (scheduled queue health). |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,8 +1,8 @@
 # ROADMAP — Hudson Digital Solutions
 
-## Milestone v3.0 — Showcase & conversion polish
+## Milestone v3 — Showcase & conversion polish
 
-> Started 2026-05-21. Site copy was repositioned in v2.x (PR #206). v3.0 focuses on visual storytelling and conversion surfaces.
+> Started 2026-05-21. Site copy was repositioned in v2 (PR #206). v3 focuses on visual storytelling and conversion surfaces.
 > Phase 01 shipped as PR #208 (squashed to `59e5e70` on `main`, 2026-05-22).
 
 ### Phases
@@ -28,8 +28,21 @@ Plans:
 - Wave 2: 01-03 (page rewrite, depends on data and component)
 - Wave 3: 01-04 (verification, depends on all)
 
+## Milestone v4 — Admin Panel
+
+> Started 2026-05-22. Built around Efferd Dashboard 5 (web analytics) shell. Auth is Better Auth (full sessions/users, users table in Neon). Scope is comprehensive admin: dashboard + content CRUD + leads/ops.
+
+### Phases
+
+| # | Slug | Status | Plans | Description |
+|---|---|---|---|---|
+| 02 | `auth-foundation` | planning | 0 | Better Auth wired to Neon. Users + sessions tables. Sign-in / sign-up pages. `/admin/*` route group + middleware guard. Account menu primitive. Everything downstream depends on this. |
+| 03 | `admin-shell-and-dashboard` | pending | 0 | Sidebar + layout adapted from Efferd Dashboard 5. `/admin` dashboard page wired to real data (web vitals, PageSpeed history, recent contact submissions). |
+| 04 | `admin-content-crud` | pending | 0 | `/admin/showcase`, `/admin/blog`, `/admin/testimonials` list + create + edit + delete. Replaces direct-SQL / Neon MCP workflow. |
+| 05 | `admin-ops` | pending | 0 | `/admin/leads` (contact submissions), `/admin/newsletter` (subscribers), `/admin/emails` (scheduled queue health). |
+
 ## Earlier milestones (archived)
 
-- v1.0 — 10 phases, shipped
-- v1.1 — 2/7 phases done, rest deferred
-- v2.0 — 8 phases, shipped (final phase: copy repositioning, PR #206)
+- v1 — initial 10 phases, shipped
+- v1 (later) — 2/7 phases done, rest deferred
+- v2 — 8 phases, shipped (final phase: copy repositioning, PR #206)

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,41 +1,39 @@
 # STATE — Current GSD Position
 
 **Last updated:** 2026-05-22
-**Branch:** `main`
-**Current milestone:** v3.0 (Showcase & conversion polish)
-**Current phase:** none active — Phase 01 closed and merged
-**Current plan:** none
+**Branch:** `admin-panel-auth`
+**Current milestone:** v4 (Admin Panel)
+**Current phase:** `02-auth-foundation` (planning)
+**Current plan:** none yet
 
 ## What just happened
 
-- Phase 01 (`showcase-ui-redesign`) shipped to production:
-  - 4 plans across 3 waves, all executed with atomic commits
-  - 2-iteration code review loop (14 findings to 0 defects)
-  - Squash-merged as `59e5e70` on `2026-05-22T21:50Z` via PR #208
-- Original feature-branch commits: `22e84ed` (data), `ac0dab7` (Card), `1df250f` (page+images), `b25c72c` (planning metadata), `356ad1e` (verification), `983e4d7` (review-fix). All collapsed into the squash commit on main.
-- `/showcase` now renders 1 featured (JirahShop) + 3 support cards (Ink 37, TenantFlow, RevOps) with real homepage screenshots, plus a new mid-scroll CTA between the grid and the closing CTA.
+- Milestone v4 (Admin Panel) opened. Built around Efferd Dashboard 5 (web analytics) as the shell. Auth = Better Auth (full sessions/users). Scope = comprehensive admin: dashboard + content CRUD + leads/ops.
+- 4 phases queued in ROADMAP: `02-auth-foundation` (in progress), `03-admin-shell-and-dashboard`, `04-admin-content-crud`, `05-admin-ops`.
+- Milestone v3 closed: Phase 01 (`showcase-ui-redesign`) shipped to main as `59e5e70` via PR #208; planning sync as `60175b3` via PR #209.
 
-## Active decisions (still in force)
+## Active decisions (still in force from v3)
 
-- Featured-first rendering: `items.find(i => i.featured)` picks the lowest-displayOrder featured row for the full-width slot; remaining items render in a 3-col support grid with `featured={false}` forced at the call site so `md:col-span-2` / `priority` / the "Featured" overlay badge never fire on a support card.
-- Inline CTA lives inside `ShowcaseProjects` (under Suspense) so it streams with the grid; closing CTA stays outside Suspense.
+- Featured-first rendering on `/showcase`: `items.find(i => i.featured)` picks the lowest-displayOrder featured row for the full-width slot; support cards force `featured={false}` at the call site.
 - Trust signal separators use U+00B7 MIDDLE DOT, never em-dash.
 - Accent body copy on light backgrounds uses `text-accent-text` (WCAG-safe).
-- Em/en-dash ban (CLAUDE.md) applies to user-facing text only; code comments and developer-only strings are exempt.
+- Em/en-dash ban (CLAUDE.md) applies to user-facing text only.
+- Milestone versions use whole numbers only (v3, v4), never decimals.
+
+## Active decisions (v4)
+
+- Auth library = **Better Auth** (npm `better-auth`). Multi-user sessions, password + OAuth-capable.
+- Users live in Neon Postgres (new `users` + `sessions` tables; managed via Better Auth's Drizzle adapter).
+- Admin gating = middleware-protected `/admin/*` route group. First user signed up gets `role: 'admin'`; later users default to `role: 'user'` and need promotion.
+- Dashboard visual reference = Efferd Dashboard 5 (web analytics layout). Adapt under MIT-friendly assumption (we're copying patterns, not lifting copyrighted code verbatim).
 
 ## Deferred / known issues
 
-- Earlier `v1.0` / `v1.1` / `v2.0` milestones are referenced in user memory but no `.planning/` artifacts remain. Treating those as historical only.
-- 4 location pages (75 cities) shipped in PR #206; no follow-up planned yet.
-- 4 pre-existing em-dashes in `src/components/ui/card.tsx` JSX block comments (lines 392, 397, 413, 427) are out of scope per the v3.0/01 verification (CLAUDE.md exempts code comments).
-- `industry` prop on `ProjectCardProps` is declared but never destructured/rendered. Pre-existing on `main` before phase 01. Candidate for a small cleanup PR if the next phase touches the Card component.
+- Earlier `v1` / `v1` deferred / `v2` milestones are historical (no `.planning/` artifacts remain).
+- 4 location pages (75 cities) shipped in PR #206; no follow-up planned.
+- 4 pre-existing em-dashes in `src/components/ui/card.tsx` JSX block comments — out of scope per v3.0/01 verification.
+- `industry` prop on `ProjectCardProps` is dead surface (pre-existing); candidate for cleanup if v4 phase 04 touches Card again.
 
 ## Next action
 
-Pick the next v3.0 phase. Roadmap currently lists only phase 01 (closed). Candidates surfaced during phase 01:
-- Global em/en-dash sweep across the rest of the site (PR-#206 copy still has scattered em-dashes)
-- `/services` page visual upgrade (currently text-heavy, no imagery)
-- Drop the unused `industry` prop on `ProjectCardProps`
-- Polish the closing CTA on `/showcase` (still uses `text-section-title` despite being demoted to h3)
-
-Run `/gsd-add-phase` to add a phase once direction is chosen.
+Write `02-CONTEXT.md` for `auth-foundation` (the design spec for Better Auth setup, users/sessions schema, sign-in/sign-up routes, `/admin` middleware, account menu primitive). Then run `gsd-plan-phase 02-auth-foundation`.

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,13 +3,14 @@
 **Last updated:** 2026-05-22
 **Branch:** `admin-panel-auth`
 **Current milestone:** v4 (Admin Panel)
-**Current phase:** `02-auth-foundation` (planning)
-**Current plan:** none yet
+**Current phase:** `02-auth-foundation` (complete 5/5)
+**Current plan:** none (phase closed)
 
 ## What just happened
 
-- Milestone v4 (Admin Panel) opened. Built around Efferd Dashboard 5 (web analytics) as the shell. Auth = Better Auth (full sessions/users). Scope = comprehensive admin: dashboard + content CRUD + leads/ops.
-- 4 phases queued in ROADMAP: `02-auth-foundation` (in progress), `03-admin-shell-and-dashboard`, `04-admin-content-crud`, `05-admin-ops`.
+- Phase 02 (`auth-foundation`) closed. 5 plans, 5 commits on `admin-panel-auth`. Better Auth wired end to end: 4 Neon tables (users/sessions/accounts/verifications), `/auth/sign-in` + `/auth/sign-up`, `/admin` role-guarded layout, AccountMenu primitive, and `proxy.ts` edge cookie short-circuit for anonymous `/admin/*`. First signup auto-promoted to admin; later signups get `role: 'user'` + 403 on `/admin`. All automated gates green (lint, typecheck, build, em/en-dash sweep, admin.ts Bearer guard untouched). Manual 6-step smoke deferred to operator pre-PR.
+- Milestone v4 (Admin Panel) opened earlier. Built around Efferd Dashboard 5 (web analytics) as the shell. Auth = Better Auth (full sessions/users). Scope = comprehensive admin: dashboard + content CRUD + leads/ops.
+- 4 phases queued in ROADMAP: `02-auth-foundation` (complete), `03-admin-shell-and-dashboard` (next), `04-admin-content-crud`, `05-admin-ops`.
 - Milestone v3 closed: Phase 01 (`showcase-ui-redesign`) shipped to main as `59e5e70` via PR #208; planning sync as `60175b3` via PR #209.
 
 ## Active decisions (still in force from v3)
@@ -36,4 +37,4 @@
 
 ## Next action
 
-Write `02-CONTEXT.md` for `auth-foundation` (the design spec for Better Auth setup, users/sessions schema, sign-in/sign-up routes, `/admin` middleware, account menu primitive). Then run `gsd-plan-phase 02-auth-foundation`.
+Operator runs the 6-step manual smoke checklist in `.planning/phases/02-auth-foundation/02-SUMMARY.md` against `bun run dev`, then opens the PR for `admin-panel-auth` (squash recommended: `feat(auth): Better Auth foundation - users, sessions, /admin role guard, AccountMenu`). After merge, kick off Phase 03 (`admin-shell-and-dashboard`): write `03-CONTEXT.md` (sidebar + Efferd Dashboard 5 layout, real-data wiring for web vitals / PageSpeed history / recent contact submissions) and run `gsd-plan-phase 03-admin-shell-and-dashboard`.

--- a/.planning/phases/02-auth-foundation/02-01-PLAN.md
+++ b/.planning/phases/02-auth-foundation/02-01-PLAN.md
@@ -1,0 +1,205 @@
+---
+phase: 02-auth-foundation
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - package.json
+  - bun.lock
+  - src/env.ts
+  - CLAUDE.md
+autonomous: true
+requirements:
+  - AUTH-ENV
+  - AUTH-DEP
+  - AUTH-DOC
+user_setup:
+  - service: better-auth
+    why: "BETTER_AUTH_SECRET must be generated locally and (later) added to Vercel for production"
+    env_vars:
+      - name: BETTER_AUTH_SECRET
+        source: "Generate locally with `openssl rand -base64 32`; add to .env.local for dev; add to Vercel project env for production"
+      - name: BETTER_AUTH_URL
+        source: "Optional; defaults to BASE_URL. Set in Vercel if production URL differs from BASE_URL."
+      - name: BETTER_AUTH_TRUSTED_ORIGINS
+        source: "Optional; comma-separated list. Leave unset unless cross-origin sign-in is wanted."
+
+must_haves:
+  truths:
+    - "better-auth is a runtime dependency in package.json"
+    - "src/env.ts validates BETTER_AUTH_SECRET (>=32 chars, required in production), BETTER_AUTH_URL (optional URL), BETTER_AUTH_TRUSTED_ORIGINS (optional string)"
+    - "All three new env vars are wired into runtimeEnv mapping in src/env.ts"
+    - "CLAUDE.md Auth section documents Better Auth and the manual admin promotion SQL"
+  artifacts:
+    - path: "package.json"
+      provides: "better-auth dependency"
+      contains: "\"better-auth\""
+    - path: "src/env.ts"
+      provides: "BETTER_AUTH_SECRET / BETTER_AUTH_URL / BETTER_AUTH_TRUSTED_ORIGINS validation"
+      contains: "BETTER_AUTH_SECRET"
+    - path: "CLAUDE.md"
+      provides: "Auth section note about Better Auth + admin promotion SQL"
+      contains: "Better Auth"
+  key_links:
+    - from: "src/env.ts"
+      to: "@t3-oss/env-nextjs"
+      via: "createEnv server schema entry for BETTER_AUTH_SECRET"
+      pattern: "BETTER_AUTH_SECRET:.*z\\.string"
+---
+
+<objective>
+Install the `better-auth` package, add the three Better Auth env vars to the T3 env schema, and document admin promotion in CLAUDE.md.
+
+Purpose: Subsequent plans (schema, server wiring, UI) all need the package installed and `env.BETTER_AUTH_SECRET` to be a valid typed reference. This plan provides the foundation in one wave with zero file overlap with later plans.
+
+Output: Updated `package.json` + `bun.lock`, env schema with three new entries, single-line CLAUDE.md update.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/02-auth-foundation/02-CONTEXT.md
+@CLAUDE.md
+@src/env.ts
+
+<interfaces>
+Existing pattern in src/env.ts for production-required secrets (mirror exactly):
+
+```typescript
+ADMIN_SECRET: z
+    .string()
+    .min(32, 'ADMIN_SECRET must be at least 32 characters')
+    .optional()
+    .refine(
+        val => process.env.VERCEL_ENV !== 'production' || !!val,
+        'ADMIN_SECRET is required in production'
+    ),
+```
+
+Existing pattern for optional URL with default (mirror for BETTER_AUTH_URL):
+
+```typescript
+BASE_URL: z.string().url().optional().default('http://localhost:3000'),
+```
+
+Existing runtimeEnv mapping shape (every env entry MUST be added here):
+
+```typescript
+runtimeEnv: {
+    ADMIN_SECRET: process.env.ADMIN_SECRET,
+    ...
+}
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Install better-auth as a runtime dependency</name>
+  <files>package.json, bun.lock</files>
+  <read_first>
+    - package.json (confirm not already present; check current dependency style)
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 3, library choice)
+  </read_first>
+  <action>
+Run `bun add better-auth` from the project root. Do not pin a version manually; let bun resolve the latest stable. Do not add `--dev` (this is a runtime dependency). Do not add any peer packages (`@better-auth/cli` is invoked via `npx`, not installed). Verify `bun.lock` updated.
+  </action>
+  <verify>
+    <automated>grep -q '"better-auth"' package.json && bun pm ls better-auth 2>&1 | grep -q 'better-auth@'</automated>
+  </verify>
+  <acceptance_criteria>
+    - `package.json` `dependencies` block contains `"better-auth"` entry (not in `devDependencies`)
+    - `bun.lock` contains a `better-auth` entry resolving to a concrete version
+    - `bun pm ls better-auth` prints a non-empty version line (exit 0)
+    - No other dependency added or modified
+  </acceptance_criteria>
+  <done>better-auth is resolvable via `import { betterAuth } from 'better-auth'` (typecheck not required yet; verified in 02-03).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add BETTER_AUTH_SECRET / BETTER_AUTH_URL / BETTER_AUTH_TRUSTED_ORIGINS to src/env.ts</name>
+  <files>src/env.ts</files>
+  <read_first>
+    - src/env.ts (full file; mirror the existing ADMIN_SECRET production-required pattern and the BASE_URL default pattern)
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 5 "Modified files" and section 8 "Security checklist")
+  </read_first>
+  <action>
+Add to the `server` schema block (place near `ADMIN_SECRET` for cohesion):
+
+1. `BETTER_AUTH_SECRET`: `z.string().min(32, 'BETTER_AUTH_SECRET must be at least 32 characters').optional().refine(val => process.env.VERCEL_ENV !== 'production' || !!val, 'BETTER_AUTH_SECRET is required in production')`
+2. `BETTER_AUTH_URL`: `z.string().url().optional()` (no default; auth config falls back to `BASE_URL` at the call site).
+3. `BETTER_AUTH_TRUSTED_ORIGINS`: `z.string().optional()` (comma-separated; parsed at the call site in 02-03).
+
+Then add all three to the `runtimeEnv` block using `process.env.BETTER_AUTH_SECRET`, `process.env.BETTER_AUTH_URL`, `process.env.BETTER_AUTH_TRUSTED_ORIGINS`. Do not touch the `client` block. Do not change `emptyStringAsUndefined` or `skipValidation`.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c 'BETTER_AUTH_SECRET' src/env.ts` returns 3 (server schema + runtimeEnv + error message)
+    - `grep -c 'BETTER_AUTH_URL' src/env.ts` returns 2 (server schema + runtimeEnv)
+    - `grep -c 'BETTER_AUTH_TRUSTED_ORIGINS' src/env.ts` returns 2 (server schema + runtimeEnv)
+    - `BETTER_AUTH_SECRET` uses `.min(32, ...)` and the production `.refine(...)` pair from the existing ADMIN_SECRET pattern
+    - `bun run typecheck` exits 0
+    - No changes to the `client` block, `runtimeEnv` keys for other vars, or top-level options
+  </acceptance_criteria>
+  <done>Typed `env.BETTER_AUTH_SECRET`, `env.BETTER_AUTH_URL`, `env.BETTER_AUTH_TRUSTED_ORIGINS` are usable from server code (compile-time verified).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Document Better Auth + admin promotion SQL in CLAUDE.md</name>
+  <files>CLAUDE.md</files>
+  <read_first>
+    - CLAUDE.md (lines 161-183 — INTEGRATIONS > Auth + Env vars sections)
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 5 "Modified files" — exact line specified)
+  </read_first>
+  <action>
+Edit the `**Auth:**` block under `## INTEGRATIONS` (currently two bullets):
+
+1. Keep both existing bullets (no user auth claim is now stale, but rewrite it).
+2. Replace the first bullet ("No user-auth system in this app") with: `User auth: Better Auth, session cookies, see src/lib/auth/. Admin promotion is currently SQL-only - first signup gets it; later admins via UPDATE users SET role='admin' WHERE email='...'.`
+3. Keep the second bullet about ADMIN_SECRET / CRON_SECRET unchanged (the Bearer guard still exists for `/api/process-emails` and cron).
+
+Also extend the `**Env vars:**` schema-required bullet to include `BETTER_AUTH_SECRET` in the production-required list (append to the existing list: POSTGRES_URL, CSRF_SECRET, ADMIN_SECRET, CRON_SECRET, BETTER_AUTH_SECRET).
+
+No em-dash, no en-dash, no emoji in the new copy. Use hyphen-minus (-) or rephrase.
+  </action>
+  <verify>
+    <automated>grep -F "Better Auth, session cookies" CLAUDE.md && grep -F "BETTER_AUTH_SECRET" CLAUDE.md && ! grep -nP '[\x{2014}\x{2013}]' <(grep -F "Better Auth, session cookies" CLAUDE.md)</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -F "User auth: Better Auth" CLAUDE.md` returns one match in the INTEGRATIONS > Auth section
+    - `grep -F "UPDATE users SET role='admin'" CLAUDE.md` returns one match
+    - `grep -F "BETTER_AUTH_SECRET" CLAUDE.md` returns at least one match in the Env vars section
+    - The new lines added contain zero U+2014 (em-dash) and zero U+2013 (en-dash); only hyphen-minus (-)
+    - ADMIN_SECRET / CRON_SECRET Bearer-guard bullet is preserved verbatim
+  </acceptance_criteria>
+  <done>CLAUDE.md reflects the new auth reality; future Claude sessions will see Better Auth on first read.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` passes
+- `bun pm ls better-auth` resolves a version
+- `grep -F "Better Auth" CLAUDE.md` matches the new line
+- No file outside `files_modified` is touched
+</verification>
+
+<success_criteria>
+- better-auth installed and lockfile updated
+- Three env vars schema-validated and runtimeEnv-mapped
+- CLAUDE.md documents Better Auth + admin promotion SQL with no em/en-dashes
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-auth-foundation/02-01-SUMMARY.md` per the standard summary template.
+</output>

--- a/.planning/phases/02-auth-foundation/02-01-SUMMARY.md
+++ b/.planning/phases/02-auth-foundation/02-01-SUMMARY.md
@@ -1,0 +1,125 @@
+---
+phase: 02-auth-foundation
+plan: 01
+subsystem: auth
+tags: [auth, env, dependencies, better-auth]
+requires:
+  - none (foundation plan, no upstream dependencies)
+provides:
+  - better-auth runtime dependency
+  - env.BETTER_AUTH_SECRET (typed, production-required)
+  - env.BETTER_AUTH_URL (typed, optional)
+  - env.BETTER_AUTH_TRUSTED_ORIGINS (typed, optional)
+  - CLAUDE.md auth-section narrative for future sessions
+affects:
+  - All subsequent 02-auth-foundation plans (02-02 schema, 02-03 server wiring, 02-04 UI)
+tech-stack:
+  added:
+    - better-auth@1.6.11
+  patterns:
+    - Production-required secret pattern via .optional().refine() (mirrors ADMIN_SECRET / CRON_SECRET)
+key-files:
+  created:
+    - .planning/phases/02-auth-foundation/02-01-SUMMARY.md
+  modified:
+    - package.json (added better-auth 1.6.11 to dependencies)
+    - bun.lock (lockfile updated)
+    - src/env.ts (3 new server schema entries + 3 new runtimeEnv mappings)
+    - CLAUDE.md (Auth integration bullet rewritten; Env vars production-required list extended)
+decisions:
+  - better-auth version pinned to 1.6.11 by bun resolver (no manual pin in plan; latest stable at install time)
+  - BETTER_AUTH_URL has no default in env.ts; call sites in 02-03 will fall back to BASE_URL
+  - BETTER_AUTH_TRUSTED_ORIGINS stays a raw string in env.ts; comma-split happens at the call site (keeps env schema simple)
+metrics:
+  duration: ~4m
+  completed: 2026-05-22T22:49:57Z
+  tasks_completed: 3/3
+  files_modified: 4
+---
+
+# Phase 02 Plan 01: Install Better Auth and Add Env Vars Summary
+
+Installed `better-auth@1.6.11` as a runtime dependency, added three typed environment variables (`BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`) to the T3 env schema following the existing `ADMIN_SECRET` production-required pattern, and rewrote the CLAUDE.md Auth integration section to reflect that the project now has user auth via Better Auth (with manual admin promotion via SQL).
+
+## What Changed
+
+### Dependency
+
+`bun add better-auth` resolved `better-auth@1.6.11` into `dependencies` (not devDependencies). 21 packages installed total (better-auth + its transitive deps). `bun.lock` updated.
+
+### Env schema entries added to `src/env.ts`
+
+Three new entries in the `server` block (placed immediately after `CRON_SECRET`):
+
+```typescript
+// Better Auth - session-signing secret (required in Vercel production)
+BETTER_AUTH_SECRET: z
+    .string()
+    .min(32, 'BETTER_AUTH_SECRET must be at least 32 characters')
+    .optional()
+    .refine(
+        val => process.env.VERCEL_ENV !== 'production' || !!val,
+        'BETTER_AUTH_SECRET is required in production'
+    ),
+
+// Better Auth - canonical app URL (optional; falls back to BASE_URL at call site)
+BETTER_AUTH_URL: z.string().url().optional(),
+
+// Better Auth - extra trusted origins (optional; comma-separated, parsed at call site)
+BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
+```
+
+`BETTER_AUTH_SECRET` mirrors the canonical `ADMIN_SECRET` / `CRON_SECRET` pattern exactly: optional + `.refine()` that requires a value when `VERCEL_ENV === 'production'`, with a 32-char minimum.
+
+Three matching entries appended to `runtimeEnv` mapping:
+
+```typescript
+BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+BETTER_AUTH_TRUSTED_ORIGINS: process.env.BETTER_AUTH_TRUSTED_ORIGINS,
+```
+
+Placed immediately after the `CRON_SECRET` line. No changes to the `client` block, `skipValidation`, or `emptyStringAsUndefined`.
+
+### CLAUDE.md additions
+
+1. `## INTEGRATIONS > **Auth:**` first bullet replaced:
+   - Old: `No user-auth system in this app`
+   - New: `User auth: Better Auth, session cookies, see src/lib/auth/. Admin promotion is currently SQL-only - first signup gets it; later admins via UPDATE users SET role='admin' WHERE email='...'.`
+2. ADMIN_SECRET / CRON_SECRET Bearer-guard bullet preserved verbatim.
+3. `**Env vars:**` schema-required bullet appended: `BETTER_AUTH_SECRET` added to the production-required list (now: `POSTGRES_URL, CSRF_SECRET, ADMIN_SECRET, CRON_SECRET, BETTER_AUTH_SECRET`).
+
+No em-dash, no en-dash, no emoji in any added copy.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `grep -q '"better-auth"' package.json` | pass |
+| `bun pm ls better-auth` | `better-auth@1.6.11` |
+| `grep -c 'BETTER_AUTH_SECRET' src/env.ts` | 4 (schema + 2 error messages + runtimeEnv) — matches ADMIN_SECRET count exactly |
+| `grep -c 'BETTER_AUTH_URL' src/env.ts` | 2 (schema + runtimeEnv) |
+| `grep -c 'BETTER_AUTH_TRUSTED_ORIGINS' src/env.ts` | 2 (schema + runtimeEnv) |
+| `bun run lint` | pass (Biome: 275 files, no fixes) |
+| `bun run typecheck` | pass (`tsc --noEmit` exit 0) |
+| `grep -F "User auth: Better Auth" CLAUDE.md` | one match |
+| `grep -F "UPDATE users SET role='admin'" CLAUDE.md` | one match |
+| `grep -F "BETTER_AUTH_SECRET" CLAUDE.md` | one match (in Env vars production-required list) |
+
+## Deviations from Plan
+
+**1. [Doc - Acceptance criteria off-by-one] `BETTER_AUTH_SECRET` count in env.ts is 4, not 3**
+
+- Found during: Task 2 verification
+- Issue: Plan acceptance criterion said `grep -c 'BETTER_AUTH_SECRET' src/env.ts` should return 3 ("server schema + runtimeEnv + error message"), but the canonical ADMIN_SECRET pattern has two error message strings (one for `.min(...)`, one for `.refine(...)`) plus the schema key plus the runtimeEnv key = 4.
+- Resolution: Followed the canonical ADMIN_SECRET pattern verbatim (which the plan's `<interfaces>` block also explicitly says to mirror). `grep -c 'ADMIN_SECRET' src/env.ts` returns 4 for the same reason. The plan's grep-count expectation was off by one; the structural requirement (mirror ADMIN_SECRET exactly) supersedes.
+- Files modified: src/env.ts (Task 2, no extra changes beyond plan scope)
+
+No other deviations. Plan executed as written.
+
+## Self-Check: PASSED
+
+- `.planning/phases/02-auth-foundation/02-01-SUMMARY.md` exists (this file)
+- `package.json` contains `"better-auth": "1.6.11"`
+- `src/env.ts` typechecks clean
+- `CLAUDE.md` contains the new auth line and the updated env-vars list

--- a/.planning/phases/02-auth-foundation/02-02-PLAN.md
+++ b/.planning/phases/02-auth-foundation/02-02-PLAN.md
@@ -1,0 +1,253 @@
+---
+phase: 02-auth-foundation
+plan: 02
+type: execute
+wave: 2
+depends_on: [02-01]
+files_modified:
+  - src/lib/schemas/auth.ts
+  - src/lib/schemas/schema.ts
+autonomous: true
+requirements:
+  - AUTH-SCHEMA-USERS
+  - AUTH-SCHEMA-SESSIONS
+  - AUTH-SCHEMA-ACCOUNTS
+  - AUTH-SCHEMA-VERIFICATIONS
+  - AUTH-DDL-NEON
+
+must_haves:
+  truths:
+    - "Drizzle table definitions for users, sessions, accounts, verifications exist in src/lib/schemas/auth.ts"
+    - "src/lib/schemas/schema.ts re-exports the new auth schema file"
+    - "Neon database (neondb, branch br-rough-shape-afdj4aqj) has all four tables created with the column shapes from CONTEXT section 4"
+    - "users.role defaults to 'user' (text, default 'user'); the value 'admin' is set by application code, not a DB CHECK"
+    - "sessions.userId has ON DELETE CASCADE foreign key to users.id"
+    - "sessions.token has a UNIQUE constraint"
+    - "users.email has a UNIQUE constraint"
+  artifacts:
+    - path: "src/lib/schemas/auth.ts"
+      provides: "Drizzle pgTable definitions: users, sessions, accounts, verifications + type exports"
+      min_lines: 60
+      contains: "pgTable('users'"
+    - path: "src/lib/schemas/schema.ts"
+      provides: "Barrel re-export including the new auth file"
+      contains: "./auth"
+  key_links:
+    - from: "src/lib/schemas/schema.ts"
+      to: "src/lib/schemas/auth.ts"
+      via: "export * from './auth'"
+      pattern: "export \\* from '\\./auth'"
+    - from: "Neon Postgres (neondb)"
+      to: "users / sessions / accounts / verifications tables"
+      via: "mcp__Neon__run_sql DDL"
+      pattern: "CREATE TABLE.*(users|sessions|accounts|verifications)"
+---
+
+<objective>
+Define the Better Auth Drizzle schema (users, sessions, accounts, verifications) and create the corresponding tables in Neon Postgres via the Neon MCP. This is a pure schema/DDL plan; no application code is wired yet.
+
+Purpose: Plan 02-03 cannot run `betterAuth({ database: drizzleAdapter(db, { provider: 'pg', schema: { user, session, account, verification } }) })` until the tables exist in both Drizzle schema and Neon. drizzle-kit push is broken on this project (pg_cron + hypopg installed), so DDL goes through Neon MCP `run_sql`.
+
+Output: New `src/lib/schemas/auth.ts` exporting four pgTables + types, barrel updated, four tables live in Neon.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/STATE.md
+@.planning/phases/02-auth-foundation/02-CONTEXT.md
+@CLAUDE.md
+@src/lib/schemas/schema.ts
+@src/lib/schemas/system.ts
+
+<interfaces>
+Existing Drizzle conventions in this project (from src/lib/schemas/system.ts):
+
+- `pgTable('snake_case_name', { ... })`
+- Column identifier in camelCase; column name string in snake_case (Drizzle auto-maps via the string)
+- `id` is typically `uuid('id').primaryKey().defaultRandom()` or `text('id').primaryKey()` (Better Auth uses text IDs — use `text('id').primaryKey()`)
+- Timestamps: `timestamp('created_at', { withTimezone: true }).notNull().defaultNow()`
+- Type exports at the bottom: `export type User = typeof users.$inferSelect` and `export type NewUser = typeof users.$inferInsert`
+
+Barrel pattern (src/lib/schemas/schema.ts):
+```typescript
+export * from './analytics'
+export * from './blog'
+// add: export * from './auth'
+```
+
+CONTEXT.md section 4 has the exact column shapes. Better Auth's CLI (`npx @better-auth/cli generate --config src/lib/auth/index.ts --output src/lib/schemas/auth.ts`) can emit this file, but auth/index.ts does not exist until 02-03, so this plan hand-writes the schema per CONTEXT section 4 (and 02-03 will validate the shapes match Better Auth's expectations at runtime).
+</interfaces>
+
+<neon_context>
+- MCP server: `mcp__Neon__run_sql`
+- Project ID: `soft-bush-38066584`
+- Database: `neondb`
+- Branch: `br-rough-shape-afdj4aqj` (default)
+- Use `mcp__Neon__list_tables` to verify table creation.
+- Use `mcp__Neon__describe_table_schema` to verify column shapes if uncertain.
+- drizzle-kit push is broken on this project due to pg_cron + hypopg extensions. Do NOT attempt `bun run db:push`.
+</neon_context>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Write src/lib/schemas/auth.ts with users, sessions, accounts, verifications</name>
+  <files>src/lib/schemas/auth.ts</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 4 — exact column shapes)
+    - src/lib/schemas/system.ts (style reference: timestamp/text/uuid usage, type exports pattern)
+    - src/lib/schemas/blog.ts (additional reference if foreign keys / unique constraints needed)
+  </read_first>
+  <action>
+Create `src/lib/schemas/auth.ts`. Define four `pgTable` constants in this order:
+
+1. `users` (table name `'users'`):
+   - `id` text primary key (no `defaultRandom()`; Better Auth supplies the id)
+   - `email` text, `.notNull().unique()`
+   - `emailVerified` (column `'email_verified'`) boolean, `.notNull().default(false)`
+   - `name` text (nullable)
+   - `image` text (nullable)
+   - `role` text, `.notNull().default('user')` (values 'admin' | 'user' enforced in app, not DB)
+   - `createdAt` (column `'created_at'`) timestamp with timezone, `.notNull().defaultNow()`
+   - `updatedAt` (column `'updated_at'`) timestamp with timezone, `.notNull().defaultNow()`
+
+2. `sessions` (table name `'sessions'`):
+   - `id` text primary key
+   - `userId` (column `'user_id'`) text, `.notNull().references(() => users.id, { onDelete: 'cascade' })`
+   - `expiresAt` (column `'expires_at'`) timestamp with timezone, `.notNull()`
+   - `token` text, `.notNull().unique()`
+   - `ipAddress` (column `'ip_address'`) text (nullable)
+   - `userAgent` (column `'user_agent'`) text (nullable)
+   - `createdAt` timestamp with timezone, `.notNull().defaultNow()`
+   - `updatedAt` timestamp with timezone, `.notNull().defaultNow()`
+
+3. `accounts` (table name `'accounts'`):
+   - `id` text primary key
+   - `userId` text, `.notNull().references(() => users.id, { onDelete: 'cascade' })`
+   - `accountId` (column `'account_id'`) text, `.notNull()` (Better Auth: provider's user id for OAuth, the user.id for credentials)
+   - `providerId` (column `'provider_id'`) text, `.notNull()` (e.g., 'credential', 'github')
+   - `accessToken` (column `'access_token'`) text (nullable)
+   - `refreshToken` (column `'refresh_token'`) text (nullable)
+   - `idToken` (column `'id_token'`) text (nullable)
+   - `accessTokenExpiresAt` (column `'access_token_expires_at'`) timestamp with timezone (nullable)
+   - `refreshTokenExpiresAt` (column `'refresh_token_expires_at'`) timestamp with timezone (nullable)
+   - `scope` text (nullable)
+   - `password` text (nullable) — argon2id hash for credential accounts
+   - `createdAt` timestamp with timezone, `.notNull().defaultNow()`
+   - `updatedAt` timestamp with timezone, `.notNull().defaultNow()`
+
+4. `verifications` (table name `'verifications'`):
+   - `id` text primary key
+   - `identifier` text, `.notNull()` (email being verified)
+   - `value` text, `.notNull()` (token / hashed token)
+   - `expiresAt` timestamp with timezone, `.notNull()`
+   - `createdAt` timestamp with timezone, `.notNull().defaultNow()`
+   - `updatedAt` timestamp with timezone, `.notNull().defaultNow()`
+
+After the tables, export inferred types for each: `User` / `NewUser`, `Session` / `NewSession`, `Account` / `NewAccount`, `Verification` / `NewVerification`. Mirror the style in `src/lib/schemas/system.ts`.
+
+Imports: from `'drizzle-orm/pg-core'` only (`pgTable`, `text`, `boolean`, `timestamp`). Do not import `uuid`. Do not add Zod schemas in this file; those (if needed for forms) come in 02-04.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - File `src/lib/schemas/auth.ts` exists with ≥60 lines
+    - `grep -c "pgTable('users'" src/lib/schemas/auth.ts` returns 1
+    - `grep -c "pgTable('sessions'" src/lib/schemas/auth.ts` returns 1
+    - `grep -c "pgTable('accounts'" src/lib/schemas/auth.ts` returns 1
+    - `grep -c "pgTable('verifications'" src/lib/schemas/auth.ts` returns 1
+    - `grep -c "onDelete: 'cascade'" src/lib/schemas/auth.ts` returns 2 (sessions.userId, accounts.userId)
+    - `grep -c "\\.unique()" src/lib/schemas/auth.ts` returns at least 2 (users.email, sessions.token)
+    - `grep -c "export type" src/lib/schemas/auth.ts` returns 8 (User, NewUser, Session, NewSession, Account, NewAccount, Verification, NewVerification)
+    - No `import` from `'@/lib/db'`, `'zod'`, or anything beyond `'drizzle-orm/pg-core'`
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>Drizzle table definitions exist and typecheck; ready to be re-exported and pushed to Neon.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Re-export auth schema from src/lib/schemas/schema.ts</name>
+  <files>src/lib/schemas/schema.ts</files>
+  <read_first>
+    - src/lib/schemas/schema.ts (current barrel; preserve alphabetical export order)
+  </read_first>
+  <action>
+Insert a single line `export * from './auth'` into `src/lib/schemas/schema.ts`, maintaining the existing alphabetical order (insert immediately after `export * from './analytics'` and before `export * from './blog'`). Do not modify any other export line.
+  </action>
+  <verify>
+    <automated>grep -F "export * from './auth'" src/lib/schemas/schema.ts && bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "export \\* from './auth'" src/lib/schemas/schema.ts` returns 1
+    - The new line sits between `./analytics` and `./blog` exports (verify with `grep -n` listing)
+    - No other export line removed or reordered
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>`import { users, sessions, accounts, verifications } from '@/lib/schemas/schema'` works.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Apply DDL to Neon via Neon MCP and verify tables exist</name>
+  <files>(no source files; database-only operation)</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 4 — column shapes)
+    - src/lib/schemas/auth.ts (just written; the SQL must match these column types and constraints exactly)
+    - CLAUDE.md (integrations section: pg_cron warning and the directive to use Neon MCP for DDL)
+  </read_first>
+  <action>
+Apply DDL to Neon project `soft-bush-38066584`, database `neondb`, branch `br-rough-shape-afdj4aqj`, using `mcp__Neon__run_sql` (do NOT use `bun run db:push`).
+
+Issue four `CREATE TABLE IF NOT EXISTS` statements in dependency order (users first; sessions and accounts reference users; verifications has no FKs). Each table must mirror the columns/types/constraints in `src/lib/schemas/auth.ts` exactly:
+
+1. `users` — `id text PRIMARY KEY`, `email text NOT NULL UNIQUE`, `email_verified boolean NOT NULL DEFAULT false`, `name text`, `image text`, `role text NOT NULL DEFAULT 'user'`, `created_at timestamptz NOT NULL DEFAULT now()`, `updated_at timestamptz NOT NULL DEFAULT now()`.
+
+2. `sessions` — `id text PRIMARY KEY`, `user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE`, `expires_at timestamptz NOT NULL`, `token text NOT NULL UNIQUE`, `ip_address text`, `user_agent text`, `created_at timestamptz NOT NULL DEFAULT now()`, `updated_at timestamptz NOT NULL DEFAULT now()`.
+
+3. `accounts` — `id text PRIMARY KEY`, `user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE`, `account_id text NOT NULL`, `provider_id text NOT NULL`, `access_token text`, `refresh_token text`, `id_token text`, `access_token_expires_at timestamptz`, `refresh_token_expires_at timestamptz`, `scope text`, `password text`, `created_at timestamptz NOT NULL DEFAULT now()`, `updated_at timestamptz NOT NULL DEFAULT now()`.
+
+4. `verifications` — `id text PRIMARY KEY`, `identifier text NOT NULL`, `value text NOT NULL`, `expires_at timestamptz NOT NULL`, `created_at timestamptz NOT NULL DEFAULT now()`, `updated_at timestamptz NOT NULL DEFAULT now()`.
+
+After running the DDL, call `mcp__Neon__list_tables` and confirm all four table names appear in the response.
+
+Then call `mcp__Neon__describe_table_schema` for `users` and verify the `role` column has default `'user'` and the `email` column has a UNIQUE constraint. (Spot-check; the DDL above is correct by construction, this is a sanity confirm.)
+
+Do not seed any rows. Do not create indexes beyond the PK/unique already present (additional perf indexes are out of scope for this plan).
+  </action>
+  <verify>
+    <automated>MISSING - DB state verified via Neon MCP describe_table_schema call output; no local CLI</automated>
+  </verify>
+  <acceptance_criteria>
+    - `mcp__Neon__list_tables` response includes `users`, `sessions`, `accounts`, `verifications`
+    - `mcp__Neon__describe_table_schema` for `users` shows: `id` (text, NOT NULL, PK), `email` (text, NOT NULL, UNIQUE), `role` (text, NOT NULL, DEFAULT 'user'), `created_at` and `updated_at` (timestamptz, NOT NULL, DEFAULT now())
+    - `mcp__Neon__describe_table_schema` for `sessions` shows the `user_id` FK to `users(id)` with `ON DELETE CASCADE`, and `token` UNIQUE
+    - No additional tables created in this operation
+    - No data rows inserted
+  </acceptance_criteria>
+  <done>All four Better Auth tables live in Neon `neondb` and match the Drizzle schema definitions. Verified via MCP responses.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` passes (Drizzle types compile)
+- `mcp__Neon__list_tables` shows users, sessions, accounts, verifications
+- `mcp__Neon__describe_table_schema users` confirms `role text NOT NULL DEFAULT 'user'`
+- `grep -F "export * from './auth'" src/lib/schemas/schema.ts` matches
+</verification>
+
+<success_criteria>
+- Drizzle schema file authored and typechecks
+- Barrel updated
+- Four tables exist in Neon with the documented shape (PK, UNIQUE, FK CASCADE, role default)
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-auth-foundation/02-02-SUMMARY.md` per the standard summary template. Include the exact DDL statements applied and the Neon MCP describe responses for users + sessions.
+</output>

--- a/.planning/phases/02-auth-foundation/02-02-SUMMARY.md
+++ b/.planning/phases/02-auth-foundation/02-02-SUMMARY.md
@@ -1,0 +1,278 @@
+---
+phase: 02-auth-foundation
+plan: 02
+subsystem: auth
+tags: [auth, drizzle, neon, schema, better-auth]
+requires:
+  - 02-01 (better-auth installed, env vars added)
+provides:
+  - "src/lib/schemas/auth.ts: users, sessions, accounts, verifications Drizzle tables + type exports"
+  - "neondb.public.users, sessions, accounts, verifications (live tables)"
+  - "src/lib/schemas/schema.ts barrel re-export for the auth schema"
+affects:
+  - src/lib/schemas/schema.ts
+tech-stack:
+  added: []
+  patterns:
+    - "Better Auth standard schema shape (text IDs, no defaultRandom on PKs)"
+    - "DDL via psql (Neon MCP unavailable in this env; equivalent to mcp__Neon__run_sql)"
+key-files:
+  created:
+    - src/lib/schemas/auth.ts
+    - .planning/phases/02-auth-foundation/02-02-SUMMARY.md
+  modified:
+    - src/lib/schemas/schema.ts
+decisions:
+  - "Hand-wrote Drizzle tables per CONTEXT section 4 instead of running @better-auth/cli generate, because src/lib/auth/index.ts does not exist yet (it lands in 02-03). The CLI requires a betterAuth({...}) config to read from, so the chicken-and-egg is solved by authoring the schema first."
+  - "Applied DDL with psql against $DATABASE_URL_UNPOOLED. The plan's nominal mechanism is mcp__Neon__run_sql, but that MCP server is not connected in this environment. psql against the unpooled Neon endpoint is functionally identical (same database, same branch, same DDL semantics). drizzle-kit push was NOT used (broken on this project due to pg_cron + hypopg)."
+  - "users.role text NOT NULL DEFAULT 'user'. No DB CHECK constraint on values. The 'admin' value is set by the Better Auth databaseHook in 02-03 (first signup wins)."
+metrics:
+  duration: "~54m wall clock (mostly idle); ~5m active execution"
+  tasks-completed: 3
+  files-created: 2
+  files-modified: 1
+  completed: 2026-05-22
+---
+
+# Phase 02 Plan 02: Better Auth Drizzle Schema + Neon DDL Summary
+
+Defined the Better Auth Drizzle schema (users, sessions, accounts, verifications) in `src/lib/schemas/auth.ts`, wired it into the barrel, and created the four tables in Neon `neondb` via direct SQL.
+
+## What changed
+
+- **Created** `src/lib/schemas/auth.ts` (94 lines) — four `pgTable` definitions plus 8 inferred type exports (User/NewUser, Session/NewSession, Account/NewAccount, Verification/NewVerification). Only imports from `'drizzle-orm/pg-core'` (boolean, pgTable, text, timestamp). No zod, no @/lib/db dependency.
+- **Modified** `src/lib/schemas/schema.ts` — inserted `export * from './auth'` between `./analytics` and `./blog` (alphabetical order preserved).
+- **Database** — created 4 tables in `neondb.public` via psql DDL transaction.
+
+## Approach taken
+
+Hand-wrote the Drizzle schema per CONTEXT.md section 4. The Better Auth CLI generator (`npx @better-auth/cli generate`) was not used because it requires a `betterAuth({...})` config object to introspect, and `src/lib/auth/index.ts` doesn't exist until 02-03. The hand-written schema matches Better Auth's standard column shapes (text IDs, `email_verified` boolean, OAuth-friendly accounts table) and will be validated against the Drizzle adapter at runtime in 02-03.
+
+## DDL applied
+
+A single transaction with four `CREATE TABLE IF NOT EXISTS` statements in dependency order (users first; sessions and accounts reference users; verifications standalone):
+
+```sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS users (
+  id text PRIMARY KEY,
+  email text NOT NULL UNIQUE,
+  email_verified boolean NOT NULL DEFAULT false,
+  name text,
+  image text,
+  role text NOT NULL DEFAULT 'user',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id text PRIMARY KEY,
+  user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  expires_at timestamptz NOT NULL,
+  token text NOT NULL UNIQUE,
+  ip_address text,
+  user_agent text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id text PRIMARY KEY,
+  user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  account_id text NOT NULL,
+  provider_id text NOT NULL,
+  access_token text,
+  refresh_token text,
+  id_token text,
+  access_token_expires_at timestamptz,
+  refresh_token_expires_at timestamptz,
+  scope text,
+  password text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS verifications (
+  id text PRIMARY KEY,
+  identifier text NOT NULL,
+  value text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMIT;
+```
+
+psql output: `BEGIN / CREATE TABLE x4 / COMMIT`.
+
+**Why psql rather than `mcp__Neon__run_sql`:** the Neon MCP server is not registered in this Claude Code environment (only context7, supabase, n8n-mcp are listed by `claude mcp list`, and the Neon one isn't connected). psql against `$DATABASE_URL_UNPOOLED` is functionally equivalent — same Neon project `soft-bush-38066584`, same branch `br-rough-shape-afdj4aqj`, same database `neondb`. `drizzle-kit push` was NOT used: it remains broken on this project because pg_cron + hypopg are installed (per CLAUDE.md and project memory).
+
+## Post-change verification
+
+### Table list (equivalent of `mcp__Neon__list_tables` filtered to the 4 new tables)
+
+```
+  table_name
+---------------
+ accounts
+ sessions
+ users
+ verifications
+(4 rows)
+```
+
+### users — columns
+
+```
+  column_name   |        data_type         | is_nullable | column_default
+----------------+--------------------------+-------------+----------------
+ id             | text                     | NO          |
+ email          | text                     | NO          |
+ email_verified | boolean                  | NO          | false
+ name           | text                     | YES         |
+ image          | text                     | YES         |
+ role           | text                     | NO          | 'user'::text
+ created_at     | timestamp with time zone | NO          | now()
+ updated_at     | timestamp with time zone | NO          | now()
+```
+
+### users — constraints
+
+```
+     conname     | contype | pg_get_constraintdef
+-----------------+---------+----------------------
+ users_pkey      | p       | PRIMARY KEY (id)
+ users_email_key | u       | UNIQUE (email)
+```
+
+### sessions — columns
+
+```
+ column_name |        data_type         | is_nullable | column_default
+-------------+--------------------------+-------------+----------------
+ id          | text                     | NO          |
+ user_id     | text                     | NO          |
+ expires_at  | timestamp with time zone | NO          |
+ token       | text                     | NO          |
+ ip_address  | text                     | YES         |
+ user_agent  | text                     | YES         |
+ created_at  | timestamp with time zone | NO          | now()
+ updated_at  | timestamp with time zone | NO          | now()
+```
+
+### sessions — constraints
+
+```
+        conname        | contype |                     pg_get_constraintdef
+-----------------------+---------+--------------------------------------------------------------
+ sessions_user_id_fkey | f       | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+ sessions_pkey         | p       | PRIMARY KEY (id)
+ sessions_token_key    | u       | UNIQUE (token)
+```
+
+### accounts — columns
+
+```
+       column_name        |        data_type         | is_nullable | column_default
+--------------------------+--------------------------+-------------+----------------
+ id                       | text                     | NO          |
+ user_id                  | text                     | NO          |
+ account_id               | text                     | NO          |
+ provider_id              | text                     | NO          |
+ access_token             | text                     | YES         |
+ refresh_token            | text                     | YES         |
+ id_token                 | text                     | YES         |
+ access_token_expires_at  | timestamp with time zone | YES         |
+ refresh_token_expires_at | timestamp with time zone | YES         |
+ scope                    | text                     | YES         |
+ password                 | text                     | YES         |
+ created_at               | timestamp with time zone | NO          | now()
+ updated_at               | timestamp with time zone | NO          | now()
+```
+
+### accounts — constraints
+
+```
+        conname        | contype |                     pg_get_constraintdef
+-----------------------+---------+--------------------------------------------------------------
+ accounts_user_id_fkey | f       | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+ accounts_pkey         | p       | PRIMARY KEY (id)
+```
+
+### verifications — columns
+
+```
+ column_name |        data_type         | is_nullable | column_default
+-------------+--------------------------+-------------+----------------
+ id          | text                     | NO          |
+ identifier  | text                     | NO          |
+ value       | text                     | NO          |
+ expires_at  | timestamp with time zone | NO          |
+ created_at  | timestamp with time zone | NO          | now()
+ updated_at  | timestamp with time zone | NO          | now()
+```
+
+## Barrel re-export
+
+`src/lib/schemas/schema.ts` now reads:
+
+```typescript
+export * from './analytics'
+export * from './auth'      // <- new
+export * from './blog'
+export * from './content'
+export * from './emails'
+export * from './leads'
+export * from './showcase'
+export * from './system'
+export * from './ttl'
+```
+
+`import { users, sessions, accounts, verifications } from '@/lib/schemas/schema'` resolves cleanly.
+
+## Acceptance criteria
+
+All criteria from the plan pass:
+
+| Criterion                                            | Status |
+| ---------------------------------------------------- | ------ |
+| `src/lib/schemas/auth.ts` ≥ 60 lines                 | 94 lines |
+| `pgTable('users' / 'sessions' / 'accounts' / 'verifications')` each present once | 4/4 |
+| `onDelete: 'cascade'` count = 2                      | 2 |
+| `.unique()` count = 2 (users.email, sessions.token)  | 2 |
+| `export type` count = 8                              | 8 |
+| Only imports from `'drizzle-orm/pg-core'`            | yes |
+| 4 tables exist in Neon                               | yes |
+| `users.role` text NOT NULL DEFAULT `'user'`          | confirmed |
+| `users.email` UNIQUE                                 | confirmed |
+| `sessions.user_id` FK to users(id) ON DELETE CASCADE | confirmed |
+| `sessions.token` UNIQUE                              | confirmed |
+| Barrel re-exports `./auth` between `./analytics` and `./blog` | confirmed |
+| `bun run lint` exits 0                               | yes |
+| `bun run typecheck` exits 0                          | yes |
+
+## Deviations from plan
+
+**1. [Rule 3 - Blocking issue] Neon MCP unavailable in this Claude Code environment; used psql instead.**
+- **Found during:** Task 3
+- **Issue:** The plan instructs DDL via `mcp__Neon__run_sql`. `claude mcp list` shows only context7, supabase (unauthenticated), and n8n-mcp (failed) — no Neon MCP server connected.
+- **Fix:** Used `psql "$DATABASE_URL_UNPOOLED"` to run the same DDL transactionally. This targets the same Neon project (`soft-bush-38066584`), same branch (`br-rough-shape-afdj4aqj`), same database (`neondb`). The DDL is byte-identical to what the MCP would have issued.
+- **Why not `drizzle-kit push`:** Still broken on this project due to pg_cron + hypopg installation; no change there.
+- **Files modified:** none (DB-only operation).
+
+No other deviations. Code, types, and SQL match the spec.
+
+## Notes for downstream plans
+
+- Plan 02-03 wires `auth = betterAuth({ database: drizzleAdapter(db, { provider: 'pg', schema: { user: users, session: sessions, account: accounts, verification: verifications } }) })`. The Drizzle adapter expects singular-cased map keys; the table identifiers exported from `auth.ts` are plural, so the mapping is `user: users`, `session: sessions`, etc.
+- The first-signup-becomes-admin behavior is a databaseHook in `betterAuth({...})` config, not a DB-level trigger. The `role` column default `'user'` is correct.
+- No indexes beyond PK/UNIQUE were added. If query patterns later need `sessions(user_id)` or `accounts(user_id, provider_id)` lookups outside the FK, add them in a perf-tuning plan.
+
+## Self-Check: PASSED
+
+- `src/lib/schemas/auth.ts` exists: FOUND
+- `src/lib/schemas/schema.ts` contains `export * from './auth'`: FOUND
+- 4 tables in Neon `neondb.public`: FOUND (users, sessions, accounts, verifications)
+- Lint + typecheck clean: FOUND

--- a/.planning/phases/02-auth-foundation/02-03-PLAN.md
+++ b/.planning/phases/02-auth-foundation/02-03-PLAN.md
@@ -1,0 +1,316 @@
+---
+phase: 02-auth-foundation
+plan: 03
+type: execute
+wave: 3
+depends_on: [02-01, 02-02]
+files_modified:
+  - src/lib/auth/index.ts
+  - src/lib/auth/client.ts
+  - src/lib/auth/get-session.ts
+  - src/app/api/auth/[...all]/route.ts
+autonomous: true
+requirements:
+  - AUTH-SERVER-CONFIG
+  - AUTH-CLIENT
+  - AUTH-GET-SESSION
+  - AUTH-CATCHALL-ROUTE
+  - AUTH-FIRST-SIGNUP-ADMIN-HOOK
+
+must_haves:
+  truths:
+    - "betterAuth instance is exported from src/lib/auth/index.ts, configured with the Drizzle adapter on the existing db client"
+    - "The drizzle adapter is wired with the auth schema (users, sessions, accounts, verifications)"
+    - "Email/password is enabled; OAuth providers are NOT enabled"
+    - "nextCookies plugin is registered for Next.js cookie handling"
+    - "authClient is exported from src/lib/auth/client.ts using better-auth/react createAuthClient"
+    - "getSession() server helper reads cookies from next/headers and returns { user, session } | null with typed user (includes role)"
+    - "src/app/api/auth/[...all]/route.ts exports GET and POST via toNextJsHandler(auth) and is NOT wrapped in withMutationGuards"
+    - "A databaseHooks.user.create.after hook promotes the first user to role='admin' atomically (count users === 1 → update)"
+    - "src/lib/auth/admin.ts (existing Bearer-token guard) is NOT modified"
+  artifacts:
+    - path: "src/lib/auth/index.ts"
+      provides: "Server-side auth config; exports `auth`"
+      contains: "betterAuth("
+      min_lines: 30
+    - path: "src/lib/auth/client.ts"
+      provides: "Client-side auth helpers; exports `authClient` (and named helpers like signIn/signUp/signOut/useSession)"
+      contains: "createAuthClient"
+    - path: "src/lib/auth/get-session.ts"
+      provides: "Server-only `getSession()` helper returning { user, session } | null"
+      contains: "auth.api.getSession"
+    - path: "src/app/api/auth/[...all]/route.ts"
+      provides: "Better Auth catch-all GET/POST route handler"
+      contains: "toNextJsHandler"
+  key_links:
+    - from: "src/lib/auth/index.ts"
+      to: "src/lib/db.ts"
+      via: "drizzleAdapter(db, { provider: 'pg', schema })"
+      pattern: "drizzleAdapter\\(\\s*db"
+    - from: "src/lib/auth/index.ts"
+      to: "src/lib/schemas/auth.ts"
+      via: "schema imports of users, sessions, accounts, verifications"
+      pattern: "from '@/lib/schemas/(schema|auth)'"
+    - from: "src/app/api/auth/[...all]/route.ts"
+      to: "src/lib/auth/index.ts"
+      via: "import { auth } and toNextJsHandler"
+      pattern: "toNextJsHandler\\(auth\\)"
+    - from: "src/lib/auth/get-session.ts"
+      to: "next/headers"
+      via: "await headers() passed into auth.api.getSession"
+      pattern: "auth\\.api\\.getSession\\(\\s*\\{\\s*headers"
+---
+
+<objective>
+Wire Better Auth into the running app: server config, client SDK, server-side session helper, and the catch-all API route. Register a databaseHooks `user.create.after` hook that promotes the first signup to `role='admin'`.
+
+Purpose: Plans 02-04 (UI) and 02-05 (middleware) both consume `auth`, `authClient`, and `getSession()`. This plan is the bridge between schema (02-02) and UI (02-04).
+
+Output: Four new files — server config, client, get-session helper, catch-all route — all typechecking and importing from the live schema in Neon.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/STATE.md
+@.planning/phases/02-auth-foundation/02-CONTEXT.md
+@CLAUDE.md
+@src/env.ts
+@src/lib/schemas/auth.ts
+@src/lib/auth/admin.ts
+
+<interfaces>
+Better Auth API surface (verified against current docs):
+
+```typescript
+// Server config (src/lib/auth/index.ts)
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { nextCookies } from 'better-auth/next-js'
+import { db } from '@/lib/db'
+import { users, sessions, accounts, verifications } from '@/lib/schemas/schema'
+
+export const auth = betterAuth({
+    database: drizzleAdapter(db, {
+        provider: 'pg',
+        schema: { user: users, session: sessions, account: accounts, verification: verifications }
+    }),
+    emailAndPassword: { enabled: true },
+    secret: env.BETTER_AUTH_SECRET,
+    baseURL: env.BETTER_AUTH_URL ?? env.BASE_URL,
+    trustedOrigins: env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',').map(s => s.trim()).filter(Boolean) ?? [],
+    user: { additionalFields: { role: { type: 'string', defaultValue: 'user' } } },
+    databaseHooks: {
+        user: {
+            create: {
+                after: async (createdUser) => { /* first-signup-admin */ }
+            }
+        }
+    },
+    plugins: [nextCookies()]
+})
+```
+
+```typescript
+// Client (src/lib/auth/client.ts)
+import { createAuthClient } from 'better-auth/react'
+export const authClient = createAuthClient({ baseURL: process.env.NEXT_PUBLIC_BASE_URL })
+export const { signIn, signUp, signOut, useSession } = authClient
+```
+Note: client.ts is the ONLY file where we read `process.env.NEXT_PUBLIC_BASE_URL` directly via the typed env. Actually we MUST go through `env` — `import { env } from '@/env'` and use `env.NEXT_PUBLIC_BASE_URL`. T3 env exposes client vars to the browser bundle.
+
+```typescript
+// Catch-all route (src/app/api/auth/[...all]/route.ts)
+import { auth } from '@/lib/auth'
+import { toNextJsHandler } from 'better-auth/next-js'
+export const { GET, POST } = toNextJsHandler(auth)
+```
+
+```typescript
+// getSession (src/lib/auth/get-session.ts)
+import 'server-only'
+import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
+export async function getSession() {
+    return auth.api.getSession({ headers: await headers() })
+}
+```
+Return type is inferred by Better Auth; user includes the `role` additional field.
+
+Existing `src/lib/db.ts` is the Drizzle client (lazy-init, mocked when POSTGRES_URL is unset). `src/lib/auth/admin.ts` is the Bearer-token guard and must NOT be touched by this plan.
+</interfaces>
+
+<first_signup_admin_logic>
+Inside the `user.create.after` hook, query the live database to count users. Pseudo-shape:
+
+```typescript
+import { count } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
+
+after: async (createdUser) => {
+    const [{ value }] = await db.select({ value: count() }).from(users)
+    if (value === 1) {
+        await db.update(users).set({ role: 'admin', updatedAt: new Date() }).where(eq(users.id, createdUser.id))
+        logger.info('First user promoted to admin', { userId: createdUser.id, email: createdUser.email })
+    }
+}
+```
+
+Race-condition note: in this app there is exactly one operator who runs the first signup before announcing the URL. A true atomic "only one admin ever" guard is not in scope (CONTEXT section 2 explicitly states later admins are SQL UPDATEs). The count===1 check is sufficient for the intended flow.
+</first_signup_admin_logic>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Write src/lib/auth/index.ts (server config + first-signup-admin hook)</name>
+  <files>src/lib/auth/index.ts</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 5 new files + section 8 security checklist)
+    - src/env.ts (confirm BETTER_AUTH_SECRET / BETTER_AUTH_URL / BETTER_AUTH_TRUSTED_ORIGINS are present)
+    - src/lib/schemas/auth.ts (the table identifiers to wire into the adapter schema)
+    - src/lib/db.ts (the Drizzle client to pass into drizzleAdapter)
+    - src/lib/logger.ts (the logger import for the admin-promotion info line)
+  </read_first>
+  <action>
+Create `src/lib/auth/index.ts` with:
+
+1. Top-of-file `import 'server-only'` (mirrors `src/lib/db.ts` server-only guard).
+2. Imports: `betterAuth` from `'better-auth'`, `drizzleAdapter` from `'better-auth/adapters/drizzle'`, `nextCookies` from `'better-auth/next-js'`, `count`, `eq` from `'drizzle-orm'`, `db` from `'@/lib/db'`, `users, sessions, accounts, verifications` from `'@/lib/schemas/schema'`, `env` from `'@/env'`, `logger` from `'@/lib/logger'`.
+3. Export `const auth = betterAuth({ ... })` with the config shape from the interfaces block:
+   - `database: drizzleAdapter(db, { provider: 'pg', schema: { user: users, session: sessions, account: accounts, verification: verifications } })`
+   - `emailAndPassword: { enabled: true }` (do NOT enable autoSignIn unless Better Auth defaults to it — keep config minimal)
+   - `secret: env.BETTER_AUTH_SECRET` (the env schema enforces 32-char min in production; in dev it can be undefined — Better Auth will warn)
+   - `baseURL: env.BETTER_AUTH_URL ?? env.BASE_URL`
+   - `trustedOrigins: env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',').map(s => s.trim()).filter(Boolean) ?? []`
+   - `user: { additionalFields: { role: { type: 'string', defaultValue: 'user' } } }` — this tells Better Auth the role column exists and to type it on the returned user
+   - `databaseHooks` with the `user.create.after` hook implementing the first-signup-admin logic (see `<first_signup_admin_logic>` above). Use `logger.info` on success and `logger.error` on any failure inside a try/catch — never throw out of the hook (a thrown hook will roll back the user create; we want the signup to succeed even if the promotion fails).
+   - `plugins: [nextCookies()]`
+4. No default export. Only the named `auth` export.
+
+Type safety: do NOT use `as any`. If Better Auth's types complain about `additionalFields` shape, narrow with a typed object literal — do not cast. If there is a genuine third-party type gap, add `// @ts-expect-error` with a one-line reason; do not silence.
+
+The file must typecheck without TS errors via `bun run typecheck`.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - File exists with ≥30 lines
+    - `grep -c "import 'server-only'" src/lib/auth/index.ts` returns 1
+    - `grep -F "betterAuth(" src/lib/auth/index.ts` matches once
+    - `grep -F "drizzleAdapter(db" src/lib/auth/index.ts` matches once
+    - `grep -F "emailAndPassword:" src/lib/auth/index.ts` matches once
+    - `grep -F "nextCookies()" src/lib/auth/index.ts` matches once
+    - `grep -F "databaseHooks" src/lib/auth/index.ts` matches once
+    - `grep -F "role: 'admin'" src/lib/auth/index.ts` matches at least once (inside the after hook)
+    - `grep -F "count()" src/lib/auth/index.ts` matches at least once
+    - `grep -c "as any" src/lib/auth/index.ts` returns 0
+    - `grep -c "console\\." src/lib/auth/index.ts` returns 0
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>`import { auth } from '@/lib/auth'` works server-side; auth is configured with the Drizzle adapter and the first-signup-admin hook.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write src/lib/auth/client.ts (browser SDK) and src/lib/auth/get-session.ts (server helper)</name>
+  <files>src/lib/auth/client.ts, src/lib/auth/get-session.ts</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 5 — client.ts and get-session.ts descriptions)
+    - src/env.ts (NEXT_PUBLIC_BASE_URL is the client-side base URL; goes through env, not process.env)
+    - src/lib/auth/index.ts (just written; get-session.ts imports `auth` from here)
+  </read_first>
+  <action>
+**Create `src/lib/auth/client.ts`** (client-safe; no 'server-only' directive):
+
+1. Import `createAuthClient` from `'better-auth/react'`.
+2. Import `env` from `'@/env'` (T3 env exposes `NEXT_PUBLIC_BASE_URL` to the browser bundle).
+3. Export `const authClient = createAuthClient({ baseURL: env.NEXT_PUBLIC_BASE_URL })`.
+4. Export named helpers via destructure: `export const { signIn, signUp, signOut, useSession } = authClient`.
+
+**Create `src/lib/auth/get-session.ts`** (server-only):
+
+1. Top-of-file `import 'server-only'`.
+2. Import `headers` from `'next/headers'`.
+3. Import `auth` from `'./index'` (or `'@/lib/auth'` — pick one and be consistent).
+4. Export `async function getSession()` that returns `auth.api.getSession({ headers: await headers() })`. Do not wrap in try/catch — Better Auth returns null for invalid/missing sessions, and any genuine throw is something the caller (admin layout, middleware) should see.
+5. Export a derived type `export type SessionData = Awaited<ReturnType<typeof getSession>>` so consumers in 02-04/02-05 can type their props without re-deriving.
+
+Neither file may import from the other's runtime concerns: `client.ts` must not import anything `'server-only'`; `get-session.ts` must not import from `'better-auth/react'`.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - `src/lib/auth/client.ts` exists
+      - `grep -F "createAuthClient" src/lib/auth/client.ts` matches once
+      - `grep -F "env.NEXT_PUBLIC_BASE_URL" src/lib/auth/client.ts` matches once
+      - `grep -F "export const { signIn, signUp, signOut, useSession }" src/lib/auth/client.ts` matches once
+      - `grep -c "'server-only'" src/lib/auth/client.ts` returns 0
+    - `src/lib/auth/get-session.ts` exists
+      - `grep -c "import 'server-only'" src/lib/auth/get-session.ts` returns 1
+      - `grep -F "auth.api.getSession" src/lib/auth/get-session.ts` matches once
+      - `grep -F "await headers()" src/lib/auth/get-session.ts` matches once
+      - `grep -F "export type SessionData" src/lib/auth/get-session.ts` matches once
+      - `grep -c "better-auth/react" src/lib/auth/get-session.ts` returns 0
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>Client components can `import { signIn, signUp, signOut, useSession } from '@/lib/auth/client'`. Server components can `import { getSession, type SessionData } from '@/lib/auth/get-session'`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Write src/app/api/auth/[...all]/route.ts (catch-all handler)</name>
+  <files>src/app/api/auth/[...all]/route.ts</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (sections 5 and 8 — note: this route does NOT use withMutationGuards)
+    - src/lib/auth/index.ts (just written; supplies the `auth` instance)
+    - src/lib/api/guards.ts (just to confirm the existence of withMutationGuards; do NOT import it here)
+  </read_first>
+  <action>
+Create `src/app/api/auth/[...all]/route.ts`. The entire file:
+
+1. Import `auth` from `'@/lib/auth'`.
+2. Import `toNextJsHandler` from `'better-auth/next-js'`.
+3. Export `const { GET, POST } = toNextJsHandler(auth)`.
+
+Do NOT add `withMutationGuards`. Do NOT add CSRF handling (Better Auth handles it). Do NOT add rate limiting on this route (out of scope for this plan; can be revisited if abuse appears). Do NOT add `'use server'` (this is a route handler, not a server action).
+
+Make sure the directory `src/app/api/auth/[...all]/` is created (the literal brackets are part of the path).
+  </action>
+  <verify>
+    <automated>bun run typecheck && test -f "src/app/api/auth/[...all]/route.ts"</automated>
+  </verify>
+  <acceptance_criteria>
+    - File exists at exact path `src/app/api/auth/[...all]/route.ts` (literal brackets)
+    - File is ≤6 non-blank lines (this is intentionally trivial; bloat = wrong)
+    - `grep -F "toNextJsHandler(auth)" "src/app/api/auth/[...all]/route.ts"` matches once
+    - `grep -F "withMutationGuards" "src/app/api/auth/[...all]/route.ts"` returns 0 matches
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>`GET /api/auth/session`, `POST /api/auth/sign-in/email`, `POST /api/auth/sign-up/email`, `POST /api/auth/sign-out`, etc., are all routed to Better Auth via the catch-all.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck` passes
+- `bun run lint` passes (Biome)
+- `src/lib/auth/admin.ts` is unchanged (Bearer guard preserved): `git diff src/lib/auth/admin.ts` is empty
+- Catch-all route exists at the literal `[...all]` path
+</verification>
+
+<success_criteria>
+- `auth` is importable server-side and configured against the live Neon schema
+- `authClient` and named helpers are importable in client components
+- `getSession()` returns typed session data including `user.role`
+- First-signup-admin hook is in place and logs the promotion
+- Catch-all route delegates to Better Auth's handler with zero wrappers
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-auth-foundation/02-03-SUMMARY.md` per the standard summary template. Note any TS friction with `additionalFields` shape and how it was resolved.
+</output>

--- a/.planning/phases/02-auth-foundation/02-03-SUMMARY.md
+++ b/.planning/phases/02-auth-foundation/02-03-SUMMARY.md
@@ -1,0 +1,201 @@
+---
+phase: 02-auth-foundation
+plan: 03
+subsystem: auth
+tags: [better-auth, drizzle, sessions, server-only]
+requires:
+  - 02-01 (better-auth dependency + env vars)
+  - 02-02 (Drizzle auth tables live in Neon)
+provides:
+  - "@/lib/auth": configured Better Auth server instance (`auth`)
+  - "@/lib/auth/client": browser SDK + named helpers (signIn, signUp, signOut, useSession)
+  - "@/lib/auth/get-session": server-only `getSession()` + `SessionData` type
+  - "/api/auth/*": catch-all route handling all Better Auth endpoints
+affects:
+  - Plan 02-04 (UI) consumes authClient and signUp/signIn helpers
+  - Plan 02-05 (proxy middleware) consumes getSession
+tech-stack:
+  added: []
+  patterns:
+    - "Server-only module guard (`import 'server-only'`) on `index.ts` and `get-session.ts`"
+    - "Drizzle adapter explicit model mapping ({ user: users, ... }) to bridge plural Drizzle identifiers and Better Auth's singular model names"
+    - "databaseHooks.user.create.after with count() guard for first-signup-admin promotion"
+    - "Catch-all route via toNextJsHandler(auth); no withMutationGuards wrapper (Better Auth handles its own CSRF)"
+key-files:
+  created:
+    - src/lib/auth/index.ts
+    - src/lib/auth/client.ts
+    - src/lib/auth/get-session.ts
+    - src/app/api/auth/[...all]/route.ts
+  modified: []
+decisions:
+  - "Explicit `schema: { user: users, session: sessions, account: accounts, verification: verifications }` instead of `usePlural: true`. Reason: explicit mapping is self-documenting and survives renames; usePlural is a global flag with no clear ownership."
+  - "First-signup-admin hook wraps the count + update in try/catch. Reason: a thrown after-hook surfaces as a 500 to the user even though the user row was already committed. Logging the failure and continuing lets the operator self-promote via SQL (the documented fallback in CLAUDE.md > Auth) without the signup looking broken."
+  - "No `autoSignIn` toggle on emailAndPassword config. Reason: keep the config minimal; Better Auth's defaults are correct for our flow (the sign-in form redirects to /admin after a successful signup)."
+  - "No try/catch around `auth.api.getSession` in get-session.ts. Reason: Better Auth returns null for missing/invalid sessions; any genuine throw is something the caller needs to see (middleware would 500, but that surfaces the bug instead of hiding it)."
+metrics:
+  duration: "35 minutes"
+  tasks_completed: "3/3"
+  files_created: 4
+  files_modified: 0
+  completed_date: "2026-05-23"
+---
+
+# Phase 02 Plan 03: Better Auth wiring (server + client + catch-all) Summary
+
+One-liner: Wires Better Auth into the app with a Drizzle-adapter-backed `auth` instance, a server-only `getSession()` helper, a browser SDK with named helpers, a catch-all API route, and a databaseHooks `user.create.after` hook that promotes the first signup to `role='admin'`.
+
+## What shipped
+
+Four new files. Zero modifications to existing files.
+
+### `src/lib/auth/index.ts` (105 lines)
+
+Server-only Better Auth config. The full hook plus adapter wiring:
+
+```typescript
+import 'server-only'
+
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { nextCookies } from 'better-auth/next-js'
+import { count, eq } from 'drizzle-orm'
+import { env } from '@/env'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { accounts, sessions, users, verifications } from '@/lib/schemas/schema'
+
+const trustedOrigins =
+    env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',')
+        .map(value => value.trim())
+        .filter(Boolean) ?? []
+
+export const auth = betterAuth({
+    database: drizzleAdapter(db, {
+        provider: 'pg',
+        schema: {
+            user: users,
+            session: sessions,
+            account: accounts,
+            verification: verifications
+        }
+    }),
+    emailAndPassword: { enabled: true },
+    secret: env.BETTER_AUTH_SECRET,
+    baseURL: env.BETTER_AUTH_URL ?? env.BASE_URL,
+    trustedOrigins,
+    user: {
+        additionalFields: {
+            role: { type: 'string', defaultValue: 'user' }
+        }
+    },
+    databaseHooks: {
+        user: {
+            create: {
+                after: async createdUser => {
+                    try {
+                        const [row] = await db.select({ value: count() }).from(users)
+                        if (row?.value === 1) {
+                            await db
+                                .update(users)
+                                .set({ role: 'admin', updatedAt: new Date() })
+                                .where(eq(users.id, createdUser.id))
+                            logger.info('First user promoted to admin', {
+                                userId: createdUser.id,
+                                email: createdUser.email
+                            })
+                        }
+                    } catch (error) {
+                        logger.error(
+                            'First-signup-admin hook failed; promote manually via SQL',
+                            error,
+                            { metadata: { userId: createdUser.id, email: createdUser.email } }
+                        )
+                    }
+                }
+            }
+        }
+    },
+    plugins: [nextCookies()]
+})
+```
+
+Key shape notes:
+- `additionalFields.role` typed as a literal object — no `as any` cast, no `@ts-expect-error` needed. Better Auth's `DBFieldAttribute` accepts `{ type: 'string', defaultValue: 'user' }` directly.
+- `databaseHooks.user.create.after` receives `(user: User & Record<string, unknown>, context)` per `@better-auth/core/types/init-options.d.mts:1096`. The body returns `Promise<void>`. Wrapping in try/catch is required because a thrown after-hook would propagate as a 500 to the freshly-signed-up user even though the user row was already committed.
+- `trustedOrigins` is hoisted to a const so the betterAuth({...}) literal stays readable.
+
+### `src/lib/auth/client.ts` (20 lines)
+
+Browser SDK. Reads `env.NEXT_PUBLIC_BASE_URL` (T3 env exposes it to the client bundle) and re-exports the four named helpers:
+
+```typescript
+import { createAuthClient } from 'better-auth/react'
+import { env } from '@/env'
+
+export const authClient = createAuthClient({
+    baseURL: env.NEXT_PUBLIC_BASE_URL
+})
+
+export const { signIn, signUp, signOut, useSession } = authClient
+```
+
+No `server-only` guard — this file is intentionally client-safe. No imports from `./index` (server config) — that would poison the client bundle.
+
+### `src/lib/auth/get-session.ts` (22 lines)
+
+Server-only session helper:
+
+```typescript
+import 'server-only'
+
+import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
+
+export async function getSession() {
+    return auth.api.getSession({ headers: await headers() })
+}
+
+export type SessionData = Awaited<ReturnType<typeof getSession>>
+```
+
+The exported `SessionData` type spares downstream consumers from re-deriving the awaited return type. Better Auth's inferred shape includes the `role` additional field on `user`, so middleware (02-05) can branch on it directly.
+
+### `src/app/api/auth/[...all]/route.ts` (3 non-blank lines)
+
+The whole file:
+
+```typescript
+import { toNextJsHandler } from 'better-auth/next-js'
+import { auth } from '@/lib/auth'
+
+export const { GET, POST } = toNextJsHandler(auth)
+```
+
+No `withMutationGuards`. No CSRF wrapper. Better Auth handles its own CSRF via the trusted-origins check and the `nextCookies()` plugin.
+
+## Better Auth config object
+
+The first-signup-admin hook is the only piece of business logic in the entire auth config. Everything else is plumbing. The hook reads `count(*) FROM users` and updates the just-created user if the count is exactly 1. Race condition: explicitly out of scope per `02-CONTEXT.md` section 2 (single operator runs the first signup before announcing the URL; later admins are SQL UPDATEs).
+
+## Verification
+
+- `bun run lint` passes. Initial run flagged whitespace/format on the multi-line imports and the `.select().from()` chain inside the hook; `bun run lint:fix` collapsed those to single-line forms with zero behavioral change.
+- `bun run typecheck` passes with no errors and no `as any` or `@ts-expect-error` in the new files.
+- `bun run build` compiles successfully. The catch-all shows in the route table as `├ ƒ /api/auth/[...all]` (dynamic server-rendered). A `BetterAuthError: You are using the default secret` log line appears in build output because `BETTER_AUTH_SECRET` is unset in the local CI environment; this is expected (`env.ts` makes it optional outside Vercel production) and does not fail the build.
+- `git diff src/lib/auth/admin.ts` is empty. The existing Bearer-token guard is untouched.
+
+## Deviations from plan
+
+None. Plan executed exactly as written.
+
+## Self-Check: PASSED
+
+- src/lib/auth/index.ts: FOUND
+- src/lib/auth/client.ts: FOUND
+- src/lib/auth/get-session.ts: FOUND
+- src/app/api/auth/[...all]/route.ts: FOUND
+- src/lib/auth/admin.ts: UNCHANGED (git diff empty)
+- bun run lint: PASSED
+- bun run typecheck: PASSED
+- bun run build: PASSED (catch-all route registered as `ƒ /api/auth/[...all]`)

--- a/.planning/phases/02-auth-foundation/02-04-PLAN.md
+++ b/.planning/phases/02-auth-foundation/02-04-PLAN.md
@@ -1,0 +1,404 @@
+---
+phase: 02-auth-foundation
+plan: 04
+type: execute
+wave: 4
+depends_on: [02-03]
+files_modified:
+  - src/app/auth/layout.tsx
+  - src/app/auth/sign-in/page.tsx
+  - src/app/auth/sign-up/page.tsx
+  - src/app/admin/layout.tsx
+  - src/app/admin/page.tsx
+  - src/components/auth/SignInForm.tsx
+  - src/components/auth/SignUpForm.tsx
+  - src/components/auth/AccountMenu.tsx
+  - src/lib/schemas/auth-forms.ts
+autonomous: true
+requirements:
+  - AUTH-UI-LAYOUT
+  - AUTH-UI-SIGNIN-PAGE
+  - AUTH-UI-SIGNUP-PAGE
+  - AUTH-UI-SIGNIN-FORM
+  - AUTH-UI-SIGNUP-FORM
+  - AUTH-UI-ACCOUNT-MENU
+  - AUTH-ADMIN-LAYOUT-GUARD
+  - AUTH-ADMIN-PLACEHOLDER
+
+must_haves:
+  truths:
+    - "GET /auth/sign-in renders a server component with a SignInForm client child"
+    - "GET /auth/sign-up renders a server component with a SignUpForm client child"
+    - "SignInForm calls authClient.signIn.email(...) and on success the browser navigates to /admin"
+    - "SignUpForm calls authClient.signUp.email(...) and on success the browser navigates to /admin"
+    - "GET /admin with no session: server component returns redirect to /auth/sign-in"
+    - "GET /admin with session but role!='admin': server component returns a 403 page"
+    - "GET /admin with session and role='admin': renders the AccountMenu and 'Signed in as <email> (admin)'"
+    - "AccountMenu shows the user's email and a Sign out button that calls authClient.signOut() then navigates to /auth/sign-in"
+    - "All new user-facing copy is em/en-dash free"
+  artifacts:
+    - path: "src/app/auth/layout.tsx"
+      provides: "Centered, chrome-free layout for the auth pages"
+      contains: "children"
+    - path: "src/app/auth/sign-in/page.tsx"
+      provides: "Sign-in page (server component) exporting metadata"
+      contains: "export const metadata"
+    - path: "src/app/auth/sign-up/page.tsx"
+      provides: "Sign-up page (server component) exporting metadata"
+      contains: "export const metadata"
+    - path: "src/app/admin/layout.tsx"
+      provides: "Server-component guard: session check, role check, 403 fallback, AccountMenu chrome"
+      contains: "getSession"
+    - path: "src/app/admin/page.tsx"
+      provides: "Placeholder admin landing showing signed-in email + role"
+      contains: "Signed in as"
+    - path: "src/components/auth/SignInForm.tsx"
+      provides: "Client component calling authClient.signIn.email"
+      contains: "signIn.email"
+    - path: "src/components/auth/SignUpForm.tsx"
+      provides: "Client component calling authClient.signUp.email"
+      contains: "signUp.email"
+    - path: "src/components/auth/AccountMenu.tsx"
+      provides: "Client dropdown with email + Sign out button"
+      contains: "signOut"
+    - path: "src/lib/schemas/auth-forms.ts"
+      provides: "Zod schemas for sign-in and sign-up form inputs (used by both client forms)"
+      contains: "z.object"
+  key_links:
+    - from: "src/app/admin/layout.tsx"
+      to: "src/lib/auth/get-session.ts"
+      via: "getSession() server call, redirect or 403 based on result"
+      pattern: "getSession\\(\\)"
+    - from: "src/components/auth/SignInForm.tsx"
+      to: "src/lib/auth/client.ts"
+      via: "import { signIn } from '@/lib/auth/client'"
+      pattern: "from '@/lib/auth/client'"
+    - from: "src/components/auth/AccountMenu.tsx"
+      to: "src/lib/auth/client.ts"
+      via: "import { signOut } from '@/lib/auth/client'"
+      pattern: "signOut\\("
+    - from: "src/app/admin/layout.tsx"
+      to: "src/components/auth/AccountMenu.tsx"
+      via: "renders <AccountMenu email={session.user.email} /> in the top-right of the shell"
+      pattern: "<AccountMenu"
+---
+
+<objective>
+Build the user-facing surface for Better Auth: auth layout, sign-in/sign-up pages and their client forms, the `/admin` route group with its server-component guard, the placeholder admin landing, and the `AccountMenu` dropdown primitive.
+
+Purpose: This makes the loop visible. After this plan an operator can sign up, get bounced to `/admin`, see "Signed in as <email> (admin)", sign out, and bounce back to sign-in. The edge proxy guard (02-05) layers on top; this plan provides the source-of-truth server check.
+
+Output: 8 new files under `src/app/auth/*`, `src/app/admin/*`, `src/components/auth/*`, plus a single Zod schema file for the two forms.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/STATE.md
+@.planning/phases/02-auth-foundation/02-CONTEXT.md
+@CLAUDE.md
+@src/lib/auth/index.ts
+@src/lib/auth/client.ts
+@src/lib/auth/get-session.ts
+@src/components/ui/button.tsx
+@src/components/ui/input.tsx
+@src/components/ui/label.tsx
+@src/components/ui/card.tsx
+@src/lib/schemas/common.ts
+
+<interfaces>
+Confirmed primitives in `src/components/ui/`:
+- `Button` (variants: default, destructive, success, accent, outline, secondary, muted, ghost, link; sizes: default, sm, lg, xl, icon, icon-sm, icon-lg)
+- `Input` (text input with currency variant)
+- `Label`
+- `Card`
+
+NOT present: `dropdown-menu.tsx`. AccountMenu must be built without a shared dropdown primitive. Options:
+1. Native HTML `<details>` / `<summary>` — accessible by default, no JS.
+2. Plain React useState toggle with click-outside listener.
+
+Use option 1 (`<details>` + `<summary>`) — zero new deps, native a11y, matches the project's preference for native platform features. The form is small (email + Sign out button) so a full ARIA combobox is overkill.
+
+Existing toast pattern (`sonner`): `import { toast } from 'sonner'` then `toast.error(...)` / `toast.success(...)`. `<Toaster />` should already be mounted in the root layout — confirm with `grep -rn "Toaster" src/app/layout.tsx`; if it is not, mount it as part of this plan's auth layout instead (do not modify the root layout for this).
+
+Zod base validators in `src/lib/schemas/common.ts`: there is an existing `email` validator — reuse it.
+
+Better Auth client API (from src/lib/auth/client.ts):
+- `signIn.email({ email, password, callbackURL? })` returns `{ data, error }`
+- `signUp.email({ email, password, name?, callbackURL? })` returns `{ data, error }`
+- `signOut()` returns `{ data, error }`
+
+Use Next.js `useRouter` from `'next/navigation'` for client-side navigation after success: `router.push('/admin')` and `router.refresh()` (refresh forces RSC re-render so the new session cookie is honored).
+</interfaces>
+
+<copy_guard>
+ALL user-visible strings in this plan must be free of em-dash (U+2014) and en-dash (U+2013). Use comma, period, hyphen-minus (-), or "to" for ranges. Applies to JSX text, placeholders, aria-labels, button labels, page titles, metadata, error messages, the 403 message, and the AccountMenu items.
+
+Sweep with: `grep -nP "[\x{2014}\x{2013}]" <files modified by this plan>` must return zero matches.
+</copy_guard>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Write src/lib/schemas/auth-forms.ts (Zod schemas for sign-in / sign-up)</name>
+  <files>src/lib/schemas/auth-forms.ts</files>
+  <read_first>
+    - src/lib/schemas/common.ts (reuse the existing email validator; mirror the export style)
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (no specific password policy is mandated; use a sane default)
+  </read_first>
+  <action>
+Create `src/lib/schemas/auth-forms.ts`. Two Zod object schemas plus inferred types:
+
+1. `signInSchema = z.object({ email: <emailValidator>, password: z.string().min(8, 'Password must be at least 8 characters') })`
+2. `signUpSchema = z.object({ email: <emailValidator>, password: z.string().min(8, 'Password must be at least 8 characters'), name: z.string().min(1, 'Name is required').max(100).optional() })`
+
+If `src/lib/schemas/common.ts` already exports an `email` validator, import and use it. Otherwise inline `z.string().email('Enter a valid email')`. Inspect common.ts during the read_first step and pick the correct path.
+
+Export `type SignInInput = z.infer<typeof signInSchema>` and `type SignUpInput = z.infer<typeof signUpSchema>`.
+
+No 'server-only' directive (these schemas are shared between server and client form validation). No imports from `'@/lib/auth'`.
+  </action>
+  <verify>
+    <automated>bun run typecheck</automated>
+  </verify>
+  <acceptance_criteria>
+    - File exists
+    - `grep -c "export const signInSchema" src/lib/schemas/auth-forms.ts` returns 1
+    - `grep -c "export const signUpSchema" src/lib/schemas/auth-forms.ts` returns 1
+    - `grep -c "export type SignInInput" src/lib/schemas/auth-forms.ts` returns 1
+    - `grep -c "export type SignUpInput" src/lib/schemas/auth-forms.ts` returns 1
+    - `grep -c "'server-only'" src/lib/schemas/auth-forms.ts` returns 0
+    - `bun run typecheck` exits 0
+    - No em-dash or en-dash in user-visible error messages: `grep -nP "[\x{2014}\x{2013}]" src/lib/schemas/auth-forms.ts` returns 0 matches
+  </acceptance_criteria>
+  <done>Both client forms can import `signInSchema`, `signUpSchema`, `SignInInput`, `SignUpInput`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Write src/app/auth/layout.tsx + sign-in/page.tsx + sign-up/page.tsx (server pages)</name>
+  <files>src/app/auth/layout.tsx, src/app/auth/sign-in/page.tsx, src/app/auth/sign-up/page.tsx</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (sections 5 and 6 — auth pages described as server-rendered with embedded client form)
+    - src/app/layout.tsx (root layout — confirm Toaster is mounted; if not, mount in the auth layout)
+    - src/app/globals.css (look for centering utilities and `glass-card`, `card-padding-sm`, `section-spacing` to use)
+  </read_first>
+  <action>
+**`src/app/auth/layout.tsx`** (server component, no 'use client'):
+- Default-export `AuthLayout({ children }: { children: React.ReactNode })`.
+- Render a minimal centered container: full-viewport `<div className="min-h-screen flex items-center justify-center bg-surface-base p-6">` wrapping a `<main className="w-full max-w-md">` with `{children}`. (Verify `bg-surface-base` exists in globals.css; if not, fall back to `bg-background`.)
+- Do NOT render the site Navbar or Footer.
+- If the root layout does NOT mount `<Toaster />` from `sonner`, mount it here near the bottom. Verify by grep before deciding.
+
+**`src/app/auth/sign-in/page.tsx`** (server component):
+- `export const metadata = { title: 'Sign in', description: 'Sign in to the Hudson Digital Solutions admin.' }` (description 120-160 chars; expand to meet that if needed without using em/en-dashes).
+- Render: a `Card` wrapper with a heading "Sign in", a brief subhead "Use your admin credentials.", the `<SignInForm />` client component (imported from `@/components/auth/SignInForm`), and a small link to `/auth/sign-up` reading "Need an account? Sign up." (use Next.js `<Link>`).
+- No 'use client'.
+
+**`src/app/auth/sign-up/page.tsx`** (server component):
+- `export const metadata = { title: 'Sign up', description: 'Create an admin account for the Hudson Digital Solutions site.' }`.
+- Render: a `Card` wrapper with a heading "Create account", a subhead "The first signup becomes the admin.", the `<SignUpForm />` client component (imported from `@/components/auth/SignUpForm`), and a link to `/auth/sign-in` reading "Already have an account? Sign in." (use Next.js `<Link>`).
+- No 'use client'.
+
+Use existing `Card` from `@/components/ui/card`. Spacing classes: `card-padding-sm` or `card-padding` from globals.css. Headings use `text-2xl font-semibold`. Body copy default; if accent text on light needed, use `text-accent-text`, not raw `text-accent` (per CLAUDE.md/STATE.md WCAG note).
+
+All copy free of em/en-dash. Verify with grep before saving.
+  </action>
+  <verify>
+    <automated>bun run typecheck && grep -F "export const metadata" src/app/auth/sign-in/page.tsx && grep -F "export const metadata" src/app/auth/sign-up/page.tsx && ! grep -nlP "[\x{2014}\x{2013}]" src/app/auth/layout.tsx src/app/auth/sign-in/page.tsx src/app/auth/sign-up/page.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - All three files exist
+    - Neither sign-in/page.tsx nor sign-up/page.tsx begins with `'use client'`
+    - Each page file contains exactly one `export const metadata` block
+    - Each page file imports its client form via `@/components/auth/SignInForm` or `@/components/auth/SignUpForm`
+    - `auth/layout.tsx` default-exports a layout that wraps `children` in a centered container
+    - `grep -nP "[\x{2014}\x{2013}]"` over the three files returns zero matches
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>`/auth/sign-in` and `/auth/sign-up` render with the centered chrome and their respective forms. (Forms come from Task 3.)</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Write SignInForm + SignUpForm client components</name>
+  <files>src/components/auth/SignInForm.tsx, src/components/auth/SignUpForm.tsx</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 6 — the flow expectations)
+    - src/lib/auth/client.ts (the authClient API and exported helpers)
+    - src/lib/schemas/auth-forms.ts (just written)
+    - src/hooks/form-hook.tsx (the project's typed @tanstack/react-form factory; preferred form pattern per CLAUDE.md)
+    - src/components/forms/ContactForm.tsx (reference: existing form built on the project's pattern — mirror its structure)
+  </read_first>
+  <action>
+Both files start with `'use client'`. Imports: `useState`, `useRouter` from `'next/navigation'`, `toast` from `'sonner'`, the appropriate `signIn` or `signUp` from `'@/lib/auth/client'`, `signInSchema` / `signUpSchema` and inferred types from `'@/lib/schemas/auth-forms'`, primitives from `@/components/ui/*`, `logger` from `'@/lib/logger'`.
+
+**`SignInForm`** flow:
+1. State: `email`, `password`, `isSubmitting` (boolean).
+2. `onSubmit(e)`: prevent default, `signInSchema.safeParse({ email, password })`, on parse failure call `toast.error(<first issue message>)` and return.
+3. Set `isSubmitting=true`, call `await signIn.email({ email, password, callbackURL: '/admin' })`. If `result.error` truthy, `logger.error(...)`, `toast.error('Invalid email or password.')`, `setIsSubmitting(false)`, return.
+4. On success: `toast.success('Signed in.')`, `router.push('/admin')`, `router.refresh()`. Do NOT set `isSubmitting=false` after success — let the navigation tear down the component.
+
+**`SignUpForm`** flow:
+1. State: `email`, `password`, `name` (optional), `isSubmitting`.
+2. Same `safeParse` against `signUpSchema`.
+3. Call `await signUp.email({ email, password, name: name || undefined, callbackURL: '/admin' })`. On error, `logger.error`, `toast.error('Could not create account. <result.error?.message ?? "Please try again.">')` — but never expose internal Better Auth error codes; map to a friendly message.
+4. On success: `toast.success('Account created.')`, `router.push('/admin')`, `router.refresh()`.
+
+UI: each form uses `Label` + `Input` per field, a single submit `Button` (`type="submit"`, `disabled={isSubmitting}`, `aria-busy={isSubmitting}`, label "Sign in" / "Create account"). When `isSubmitting`, label can change to "Signing in..." / "Creating account..." (verify: use three periods, not ellipsis character U+2026? Hyphen-minus and periods are fine; U+2026 is not banned by CLAUDE.md but using `...` is more conventional in this codebase — check `git grep -nP "[\x{2026}]" src/` to confirm absence; if absent, use `...`).
+
+Field types: email input `type="email"` `autoComplete="email"`, password input `type="password"` `autoComplete="current-password"` for sign-in and `autoComplete="new-password"` for sign-up, name input `type="text"` `autoComplete="name"`.
+
+Accessibility: `aria-live="polite"` region not required (toast handles announcements). Each input has an associated `Label htmlFor=...`. Submit button is the only `Button` per form.
+
+No em-dash or en-dash anywhere in JSX text, placeholders, aria-labels, or error messages.
+
+Do NOT introduce `@tanstack/react-form` for this plan unless the read of ContactForm shows it is trivial to mirror. The forms are 2-3 fields each; useState is acceptable and matches `src/app/unsubscribe/UnsubscribeForm.tsx` precedent. If using useState, note in the SUMMARY that the project's preferred pattern is `@tanstack/react-form` and call out the deviation rationale (small surface, fewer abstractions for a 2-field form).
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && ! grep -nP "[\x{2014}\x{2013}]" src/components/auth/SignInForm.tsx src/components/auth/SignUpForm.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - Both files start with `'use client'`
+    - `grep -F "signIn.email" src/components/auth/SignInForm.tsx` matches once
+    - `grep -F "signUp.email" src/components/auth/SignUpForm.tsx` matches once
+    - Both files import `useRouter` from `'next/navigation'` and call `router.push('/admin')` then `router.refresh()` on success
+    - Both files use `safeParse` (not `parse`) against the appropriate schema
+    - Both files use `toast.error(...)` for user-visible errors
+    - Both files use `logger.error(...)` for internal logging (not `console.*`)
+    - Email inputs have `autoComplete="email"`; password inputs have `autoComplete="current-password"` (sign-in) or `autoComplete="new-password"` (sign-up)
+    - `grep -nP "[\x{2014}\x{2013}]"` over both files returns zero matches
+    - `bun run typecheck` and `bun run lint` both exit 0
+  </acceptance_criteria>
+  <done>Submitting either form against a running Better Auth backend will create / authenticate a user and bounce the browser to `/admin`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Write AccountMenu client component</name>
+  <files>src/components/auth/AccountMenu.tsx</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 5 — AccountMenu description)
+    - src/components/ui/button.tsx (Button variants; ghost or outline for the trigger)
+    - src/app/globals.css (look for any popover/menu styling utilities; do NOT invent new CSS)
+  </read_first>
+  <action>
+Create `src/components/auth/AccountMenu.tsx` starting with `'use client'`.
+
+Props: `{ email: string }`. (Role is not displayed in the menu itself; the placeholder admin page shows it.)
+
+Implementation: use the native `<details>` / `<summary>` pattern for a no-dependency dropdown:
+
+```
+<details className="relative">
+    <summary className="cursor-pointer ..." aria-haspopup="menu">
+        <span className="sr-only">Account menu</span>
+        {/* short trigger label: first 18 chars of email or "Account" */}
+    </summary>
+    <div role="menu" className="absolute right-0 mt-2 w-56 rounded-md border border-border bg-surface-base p-2 shadow-md">
+        <div className="px-2 py-1 text-sm text-muted-foreground" aria-label="Signed in email">{email}</div>
+        <button type="button" role="menuitem" onClick={handleSignOut} className="...">Sign out</button>
+    </div>
+</details>
+```
+
+`handleSignOut`:
+1. Call `await signOut()` (imported from `@/lib/auth/client`).
+2. On result.error: `logger.error(...)`, `toast.error('Could not sign out. Please try again.')`, return.
+3. On success: `toast.success('Signed out.')`, `router.push('/auth/sign-in')`, `router.refresh()`.
+
+No emoji. The trigger has an `aria-label="Account menu"`. Avoid em/en-dash in displayed text.
+
+If `<details>` styling is awkward (the default disclosure triangle), suppress it with `marker:hidden` or `[&::-webkit-details-marker]:hidden` Tailwind utilities — verify the exact class works under the project's Tailwind v4 setup by grepping for similar usage in `src/components/`. If neither is supported cleanly, a controlled useState + click-outside listener is an acceptable fallback; pick the option that produces less code and document the choice in the SUMMARY.
+
+Use existing `Button` for the Sign out action when feasible (variant="ghost" size="sm" works inside the panel). If `<button>` directly is simpler given the styling, that is fine — keyboard accessibility comes from `<button type="button">` natively.
+  </action>
+  <verify>
+    <automated>bun run typecheck && bun run lint && ! grep -nP "[\x{2014}\x{2013}]" src/components/auth/AccountMenu.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - File starts with `'use client'`
+    - `grep -F "signOut(" src/components/auth/AccountMenu.tsx` matches once
+    - `grep -F "router.push('/auth/sign-in')" src/components/auth/AccountMenu.tsx` matches once
+    - File exports a named `AccountMenu` component accepting `{ email: string }` (verify with `grep -F "export function AccountMenu" or "export const AccountMenu"`)
+    - `aria-label="Account menu"` appears on the trigger
+    - `grep -nP "[\x{2014}\x{2013}]" src/components/auth/AccountMenu.tsx` returns zero matches
+    - `grep -c "console\\." src/components/auth/AccountMenu.tsx` returns 0
+    - `bun run typecheck` and `bun run lint` both exit 0
+  </acceptance_criteria>
+  <done>`<AccountMenu email={...} />` renders a dropdown with email + Sign out; clicking Sign out logs the user out and navigates to `/auth/sign-in`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: Write src/app/admin/layout.tsx (guard) and src/app/admin/page.tsx (placeholder)</name>
+  <files>src/app/admin/layout.tsx, src/app/admin/page.tsx</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (sections 5, 6, 7 — server check is source of truth; 403 for role!=admin)
+    - src/lib/auth/get-session.ts (the SessionData type and getSession helper)
+    - src/components/auth/AccountMenu.tsx (just written; consumer in the layout)
+  </read_first>
+  <action>
+**`src/app/admin/layout.tsx`** (server component, no 'use client'):
+
+1. Import `getSession` from `'@/lib/auth/get-session'`, `redirect` from `'next/navigation'`, `AccountMenu` from `'@/components/auth/AccountMenu'`.
+2. Default-export `async function AdminLayout({ children }: { children: React.ReactNode })`.
+3. Call `const session = await getSession()`.
+4. If `!session` or `!session.user`: `redirect('/auth/sign-in')`.
+5. If `session.user.role !== 'admin'`: render a 403 panel (not just text — a minimal page with heading "403 - Not authorized", body "You are signed in but you do not have admin access. Contact the site owner if you need access.", and a small link "Sign out" that navigates to `/auth/sign-in` via a server-rendered Link — actual sign-out is via the AccountMenu in admin shell, so the 403 just gives a way back. A simple `<a href="/auth/sign-in">` is fine here because there is no client component context). Return this 403 panel WITHOUT rendering `children` — the role gate stops here.
+6. Otherwise render the admin shell: a thin top bar with `<AccountMenu email={session.user.email} />` in the top-right, then `<main>{children}</main>` below. Use semantic landmarks. No sidebar in this phase (Phase 03 ships the real shell).
+
+**`src/app/admin/page.tsx`** (server component):
+
+1. Import `getSession` from `'@/lib/auth/get-session'`.
+2. Default-export `async function AdminHome()`.
+3. Call `const session = await getSession()`. The layout already guaranteed a session+admin role, but call again for type narrowing (or use the layout's checked types — pick one and document; simpler is to re-call here and assert non-null after a `if (!session) return null`).
+4. Render: a heading "Admin", body "Signed in as {session.user.email} ({session.user.role})." Use period; no em/en-dash.
+
+No emoji. No `metadata.other`. No structured data on these pages.
+
+All visible copy free of em/en-dash. Sweep.
+  </action>
+  <verify>
+    <automated>bun run typecheck && grep -F "redirect('/auth/sign-in')" src/app/admin/layout.tsx && grep -F "Signed in as" src/app/admin/page.tsx && ! grep -nP "[\x{2014}\x{2013}]" src/app/admin/layout.tsx src/app/admin/page.tsx</automated>
+  </verify>
+  <acceptance_criteria>
+    - Both files exist, neither begins with `'use client'`
+    - `src/app/admin/layout.tsx`:
+      - imports `getSession` from `@/lib/auth/get-session`
+      - imports `redirect` from `'next/navigation'`
+      - imports `AccountMenu` from `@/components/auth/AccountMenu`
+      - contains `redirect('/auth/sign-in')` (no-session branch)
+      - contains a role check `session.user.role !== 'admin'` returning a 403 panel
+      - renders `<AccountMenu email={...} />` only in the admin-role branch
+    - `src/app/admin/page.tsx`:
+      - contains `Signed in as` substring inside JSX
+      - displays both `session.user.email` and `session.user.role`
+    - `grep -nP "[\x{2014}\x{2013}]"` over both files returns 0
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>Browser GET /admin redirects to /auth/sign-in when no cookie; shows the 403 panel for role=user; shows the AccountMenu + "Signed in as <email> (admin)" for role=admin.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `bun run typecheck && bun run lint` both pass
+- `grep -nP "[\x{2014}\x{2013}]" src/app/auth src/app/admin src/components/auth src/lib/schemas/auth-forms.ts` returns zero matches
+- All new pages render under `bun run dev` (smoke verification belongs to 02-05)
+- `src/lib/auth/admin.ts` is unchanged
+</verification>
+
+<success_criteria>
+- Sign-in / sign-up pages exist as server components with client form children
+- Forms call `signIn.email` / `signUp.email` and route to `/admin` on success
+- `/admin/layout.tsx` enforces session + role at the server level
+- `/admin/page.tsx` shows email + role
+- AccountMenu renders email + Sign out and bounces to `/auth/sign-in` on sign-out
+- Zero em/en-dash in any user-visible string
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-auth-foundation/02-04-SUMMARY.md` per the standard summary template. Note the AccountMenu implementation choice (native `<details>` vs useState fallback) and the form-state choice (useState vs @tanstack/react-form).
+</output>

--- a/.planning/phases/02-auth-foundation/02-04-SUMMARY.md
+++ b/.planning/phases/02-auth-foundation/02-04-SUMMARY.md
@@ -1,0 +1,139 @@
+---
+phase: 02-auth-foundation
+plan: 04
+subsystem: auth-ui
+tags: [better-auth, ui, admin-shell, sign-in, sign-up, role-guard]
+requires:
+  - 02-01 (better-auth installed + env vars wired)
+  - 02-02 (Neon auth tables: users, sessions, accounts, verifications)
+  - 02-03 (Better Auth server config + client SDK + getSession + /api/auth/[...all])
+provides:
+  - "/auth/sign-in route (static server page + client form)"
+  - "/auth/sign-up route (static server page + client form)"
+  - "/admin layout that gates on getSession() + session.user.role === 'admin'"
+  - "/admin placeholder page (replaced in Phase 03)"
+  - "<AccountMenu /> primitive for the admin shell top bar"
+  - "Zod schemas for sign-in / sign-up form input validation"
+affects:
+  - none (purely additive; root layout and existing routes untouched)
+tech-stack:
+  added: []
+  patterns:
+    - "Server page + client form component pair (because 'use client' files cannot export metadata)"
+    - "Native <details>/<summary> for dropdown menus (zero JS, native a11y, no new dependency)"
+    - "useState-driven forms for small surfaces (matches src/app/unsubscribe/UnsubscribeForm.tsx precedent)"
+    - "403 panel rendered inside the same layout that enforces the role check, so non-admins cannot bypass it by navigating to a deeper /admin/* URL"
+key-files:
+  created:
+    - src/lib/schemas/auth-forms.ts
+    - src/app/auth/layout.tsx
+    - src/app/auth/sign-in/page.tsx
+    - src/app/auth/sign-up/page.tsx
+    - src/components/auth/SignInForm.tsx
+    - src/components/auth/SignUpForm.tsx
+    - src/components/auth/AccountMenu.tsx
+    - src/app/admin/layout.tsx
+    - src/app/admin/page.tsx
+  modified: []
+decisions:
+  - "Used <details>/<summary> for AccountMenu (not useState toggle). Zero new deps, keyboard handling and screen-reader semantics come from the browser; the default disclosure triangle is suppressed via the `marker:hidden` Tailwind variant and the `::-webkit-details-marker` pseudo-element for cross-engine coverage."
+  - "Used useState for SignInForm and SignUpForm (not @tanstack/react-form). Two-to-three field forms with a single submit button do not benefit from the factory; the project already has the same call-out in src/app/unsubscribe/UnsubscribeForm.tsx."
+  - "403 panel is rendered by the admin layout itself (no separate route). A non-admin who navigates to /admin/anything triggers the layout, hits the role check, and gets the 403 before any deeper data fetch runs."
+  - "Sign-up form passes `name: parsed.data.name ?? parsed.data.email` because Better Auth's signUp.email contract requires a non-empty name; the UI field stays optional and falls back to the email."
+  - "Auth layout uses min-h-[calc(100vh-3.5rem)] (not min-h-screen) to account for the root layout's 56px Navbar so the centered form sits in the visible viewport instead of overflowing."
+metrics:
+  duration: ~15 minutes
+  completed: 2026-05-22
+---
+
+# Phase 02 Plan 04: Auth Pages, Admin Layout, AccountMenu
+
+JWT-cookie auth UI for Better Auth: sign-in and sign-up pages with their client forms, the /admin route group with a server-side session+role guard, the placeholder admin landing, and the AccountMenu dropdown primitive.
+
+## File-by-file
+
+| File | Purpose |
+|---|---|
+| `src/lib/schemas/auth-forms.ts` | Two Zod schemas (`signInSchema`, `signUpSchema`) + inferred input types. Reuses `emailSchema` from `common.ts`; password is `min(8).max(128)`; name is optional `min(1).max(100)`. |
+| `src/app/auth/layout.tsx` | Server component. Centers the auth form in the viewport (`bg-surface-base`, `min-h-[calc(100vh-3.5rem)]`). Does not render its own `<Toaster />` because the root layout already mounts one. |
+| `src/app/auth/sign-in/page.tsx` | Server component. Exports `metadata`. Wraps `<SignInForm />` inside a `<Card>` with heading "Sign in" and a link to `/auth/sign-up`. |
+| `src/app/auth/sign-up/page.tsx` | Server component. Exports `metadata`. Wraps `<SignUpForm />` inside a `<Card>` with heading "Create account" and a link to `/auth/sign-in`. |
+| `src/components/auth/SignInForm.tsx` | Client component. `safeParse(signInSchema)`, then `signIn.email({ email, password, callbackURL: '/admin' })`. On success: `toast.success(...)`, `router.push('/admin')`, `router.refresh()`. Errors go through `logger.error` (internal) and a generic `toast.error('Invalid email or password.')` (user). |
+| `src/components/auth/SignUpForm.tsx` | Client component. `safeParse(signUpSchema)`, then `signUp.email({ email, password, name: name ?? email, callbackURL: '/admin' })`. Same success/error path as SignInForm. |
+| `src/components/auth/AccountMenu.tsx` | Client component. Native `<details>`/`<summary>` dropdown. Trigger shows the truncated email + a chevron. Panel shows "Signed in as / {email}" and a "Sign out" button. Sign out calls `signOut()` then `router.push('/auth/sign-in')` + `router.refresh()`. |
+| `src/app/admin/layout.tsx` | Server component. `getSession()`. No session → `redirect('/auth/sign-in')`. Role mismatch → server-rendered 403 panel (does not render `children`). Admin → top bar with `<AccountMenu email={session.user.email} />` + `<main>{children}</main>`. |
+| `src/app/admin/page.tsx` | Server component placeholder. Re-calls `getSession()` for type narrowing and renders "Signed in as {email} ({role})." Phase 03 replaces it. |
+
+## Zod form schemas
+
+```ts
+const passwordSchema = z
+  .string()
+  .min(8, 'Password must be at least 8 characters')
+  .max(128, 'Password must be less than 128 characters')
+
+export const signInSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema
+})
+
+export const signUpSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+  name: z
+    .string()
+    .min(1, 'Name is required')
+    .max(100, 'Name must be less than 100 characters')
+    .optional()
+})
+
+export type SignInInput = z.infer<typeof signInSchema>
+export type SignUpInput = z.infer<typeof signUpSchema>
+```
+
+`emailSchema` is the shared validator from `src/lib/schemas/common.ts` (lowercased, trimmed, RFC-ish email check).
+
+## 403 approach
+
+The role guard lives in `src/app/admin/layout.tsx`, not a separate route. When `session.user.role !== 'admin'`:
+
+1. The layout `return`s a self-contained panel (heading "403 / Not authorized", body identifying the signed-in email + current role, a `mailto:` link for access requests, and a plain `<a href="/auth/sign-in">` for sign-out).
+2. `children` are NOT rendered, so no deeper `/admin/*` page executes its data fetches under a non-admin session.
+
+This is the source-of-truth check. The edge proxy (Plan 02-05) layers a fast cookie-presence short-circuit on top, but the layout's server check is what enforces role.
+
+## Build / lint / typecheck
+
+- `bun run typecheck` → exit 0
+- `bun run lint` (Biome) → exit 0 (one autofix applied to a manual `!session || !session.user` → `!session?.user` simplification)
+- `bun run build` → exit 0. Three new routes appear in the route table:
+  - `○ /auth/sign-in` (Static)
+  - `○ /auth/sign-up` (Static)
+  - `◐ /admin` (Partial Prerender)
+
+The `BetterAuthError: You are using the default secret` warning during prerender is environmental (no `BETTER_AUTH_SECRET` in the local build shell) and does not fail the build.
+
+## Em/en-dash sweep
+
+```
+$ git status --short | awk '{print $2}' | xargs rg -lF '—' ; echo EXIT=$?
+EXIT=1   (no matches)
+
+$ git status --short | awk '{print $2}' | xargs rg -lF '–' ; echo EXIT=$?
+EXIT=1   (no matches)
+```
+
+Zero em-dash or en-dash hits in any new file (JSX, comments, metadata, error strings, JSON, all clean).
+
+## Deviations from Plan
+
+None of substance. The plan flagged two implementation choices (AccountMenu primitive and form-state library) and the choices are documented in `decisions` above. One minor cleanup applied:
+
+- **[Rule 1] Removed em-dash from one JSDoc comment in `SignInForm.tsx`.** The user-supplied prompt's grep is path-scoped (not JSX-scoped), so even comments needed to be em/en-dash-free to pass.
+- **[Rule 1] Removed `'server-only'` literal from a comment in `auth-forms.ts`** so the acceptance check `grep -c "'server-only'"` returns 0 even though the file was never intended to be server-only.
+- **[Rule 1] Applied Biome's `!session?.user` suggestion** in `admin/layout.tsx` to clear a warning before commit.
+
+## Self-Check: PASSED
+
+- All 9 new files exist on disk: confirmed via `git status --short`.
+- All commits will be made by the executor in the closing commit (single atomic commit per the user's instructions).

--- a/.planning/phases/02-auth-foundation/02-05-PLAN.md
+++ b/.planning/phases/02-auth-foundation/02-05-PLAN.md
@@ -1,0 +1,253 @@
+---
+phase: 02-auth-foundation
+plan: 05
+type: execute
+wave: 5
+depends_on: [02-04]
+files_modified:
+  - proxy.ts
+autonomous: false
+
+requirements:
+  - AUTH-EDGE-COOKIE-GUARD
+  - AUTH-FULL-PHASE-VERIFICATION
+  - AUTH-EM-DASH-SWEEP
+  - AUTH-MANUAL-SMOKE
+
+must_haves:
+  truths:
+    - "proxy.ts redirects any /admin or /admin/* request without a Better Auth session cookie to /auth/sign-in"
+    - "The proxy redirect runs only when the cookie is absent; if the cookie is present, the request flows to the server-component guard (which is the source of truth)"
+    - "Existing proxy behavior (security headers, HTTPS redirect, UA blocklist, /api Cache-Control + CORS, Server-Timing) is preserved unchanged"
+    - "Full project verification passes: lint, typecheck, build"
+    - "Zero em-dash and zero en-dash across files touched in this phase (CONTEXT verification gate)"
+    - "Operator manual smoke checklist completed (sign up, sign in, sign out, role=user 403, incognito redirect)"
+  artifacts:
+    - path: "proxy.ts"
+      provides: "Edge proxy with /admin cookie pre-check"
+      contains: "/admin"
+  key_links:
+    - from: "proxy.ts"
+      to: "Better Auth session cookie"
+      via: "request.cookies.get('better-auth.session_token')"
+      pattern: "better-auth\\.session_token"
+---
+
+<objective>
+Layer an edge-level cookie pre-check onto the existing `proxy.ts` so anonymous traffic to `/admin/*` redirects at the edge instead of hitting the server-component guard. Then run the full verification sweep that closes the phase: lint, typecheck, build, em/en-dash grep on every file touched in phase 02, and the operator manual smoke checklist.
+
+Purpose: Defense in depth (CONTEXT section 7). The proxy check is a cheap fast-path for the common no-cookie case (and for bots probing /admin). The server-component check in `src/app/admin/layout.tsx` is the source of truth — the proxy never validates the cookie, only its presence.
+
+Output: One modified file (`proxy.ts`), one human checkpoint for manual smoke verification, all automated gates green.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/STATE.md
+@.planning/phases/02-auth-foundation/02-CONTEXT.md
+@CLAUDE.md
+@proxy.ts
+
+<interfaces>
+Better Auth's default session cookie name (with `nextCookies` plugin) is `better-auth.session_token`. In Next.js edge middleware (`proxy.ts`), access via `request.cookies.get('better-auth.session_token')`. The presence of the cookie is the signal; do NOT attempt to decode or validate it at the edge — that requires a DB round trip and Better Auth is not edge-runtime safe in all configs. The server component will validate; the proxy is only the fast bouncer.
+
+Existing proxy.ts structure (read it in full before editing):
+- Imports: `NextRequest, NextResponse`, `env`, `applySecurityHeaders`
+- `config.matcher`: already covers `/admin/*` (it excludes only static assets)
+- `proxy(request)` function: sets up `response = NextResponse.next()`, applies security headers, does HTTPS redirect, UA blocklist, then conditional Cache-Control / CORS based on pathname
+
+Insertion point for the /admin check: AFTER the UA blocklist (which would early-return for bots) and BEFORE the Cache-Control branches. The /admin check is its own early return (redirect to /auth/sign-in), so it does not need to interact with the response object.
+
+Redirect target: `/auth/sign-in`. Preserve the original URL as a `from` query param so the sign-in form (or a future enhancement) can bounce the user back: `${url.origin}/auth/sign-in?from=${encodeURIComponent(url.pathname + url.search)}`. Use status 307 (preserves method, though /admin/* is GET so it does not matter; 307 is the convention for auth redirects in Next).
+</interfaces>
+
+<verification_scope>
+Files changed in phase 02 (verify the em/en-dash sweep targets all of them):
+- package.json, bun.lock (Plan 01)
+- src/env.ts (Plan 01)
+- CLAUDE.md (Plan 01)
+- src/lib/schemas/auth.ts (Plan 02)
+- src/lib/schemas/schema.ts (Plan 02)
+- src/lib/auth/index.ts (Plan 03)
+- src/lib/auth/client.ts (Plan 03)
+- src/lib/auth/get-session.ts (Plan 03)
+- src/app/api/auth/[...all]/route.ts (Plan 03)
+- src/app/auth/layout.tsx (Plan 04)
+- src/app/auth/sign-in/page.tsx (Plan 04)
+- src/app/auth/sign-up/page.tsx (Plan 04)
+- src/app/admin/layout.tsx (Plan 04)
+- src/app/admin/page.tsx (Plan 04)
+- src/components/auth/SignInForm.tsx (Plan 04)
+- src/components/auth/SignUpForm.tsx (Plan 04)
+- src/components/auth/AccountMenu.tsx (Plan 04)
+- src/lib/schemas/auth-forms.ts (Plan 04)
+- proxy.ts (this plan)
+</verification_scope>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Extend proxy.ts with /admin cookie pre-check</name>
+  <files>proxy.ts</files>
+  <read_first>
+    - proxy.ts (full file — preserve every existing branch verbatim)
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (sections 5 and 7 — the edge check is presence-only, the layout is source of truth)
+  </read_first>
+  <action>
+Edit `proxy.ts`. Insert a single `if` block AFTER the UA blocklist early-return and BEFORE the Cache-Control branches:
+
+```typescript
+// /admin/* requires a session cookie. Presence-only check; the
+// admin layout (src/app/admin/layout.tsx) validates the session and
+// enforces the role. This branch keeps unauthenticated traffic out
+// of the React server-render path and gives bots a quick bounce.
+if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
+    const sessionCookie = request.cookies.get('better-auth.session_token')
+    if (!sessionCookie) {
+        const signInUrl = new URL('/auth/sign-in', request.url)
+        signInUrl.searchParams.set('from', url.pathname + url.search)
+        return NextResponse.redirect(signInUrl, { status: 307 })
+    }
+}
+```
+
+Do not modify the security headers, the HTTPS redirect, the UA blocklist, any Cache-Control branch, the CORS block, or the Server-Timing line. Do not modify `config.matcher`. Do not import anything new beyond what is already imported. (The cookie name is a string literal; no `env` lookup needed.)
+
+Add a one-line comment update at the top of the file's JSDoc summary: append `, plus /admin/* cookie presence check` to the existing "Owns:" list.
+  </action>
+  <verify>
+    <automated>bun run typecheck && grep -F "better-auth.session_token" proxy.ts && grep -F "/auth/sign-in" proxy.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep -c "better-auth.session_token" proxy.ts` returns 1
+    - `grep -c "/auth/sign-in" proxy.ts` returns 1
+    - `grep -c "/admin" proxy.ts` returns at least 2 (one in path match, one in startsWith)
+    - `grep -c "NextResponse.redirect" proxy.ts` returns 2 (HTTPS redirect already present + new one)
+    - All existing branches (HTTPS, UA blocklist, Cache-Control rules, CORS headers, Server-Timing) are preserved verbatim — verify with `git diff proxy.ts` showing only additions in the expected region
+    - `bun run typecheck` exits 0
+  </acceptance_criteria>
+  <done>Anonymous GET /admin returns 307 to /auth/sign-in?from=%2Fadmin at the edge; session-bearing requests pass through to the server-component guard.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Run full automated verification gates and em/en-dash sweep</name>
+  <files>(no source files; verification-only)</files>
+  <read_first>
+    - .planning/phases/02-auth-foundation/02-CONTEXT.md (section 9 — verification list)
+    - All files listed in <verification_scope> above
+  </read_first>
+  <action>
+Run, in order, from project root:
+
+1. `bun run lint` — must exit 0. If it fails, fix the offending file in-place (this is the verification plan; small lint fixes are scoped here), re-run.
+
+2. `bun run typecheck` — must exit 0. If it fails, this is a regression from an earlier plan; document the failure and stop the phase rather than papering over (no `as any`).
+
+3. `bun run build` — must exit 0. Build failures usually indicate Next.js App Router config issues (e.g., a `'use client'` page trying to export metadata). Fix in-place per CONVENTIONS (CLAUDE.md).
+
+4. Em/en-dash sweep across all phase 02 files:
+
+   ```
+   grep -nP '[\x{2014}\x{2013}]' \
+     src/env.ts \
+     CLAUDE.md \
+     src/lib/schemas/auth.ts \
+     src/lib/schemas/schema.ts \
+     src/lib/auth/index.ts \
+     src/lib/auth/client.ts \
+     src/lib/auth/get-session.ts \
+     'src/app/api/auth/[...all]/route.ts' \
+     src/app/auth/layout.tsx \
+     src/app/auth/sign-in/page.tsx \
+     src/app/auth/sign-up/page.tsx \
+     src/app/admin/layout.tsx \
+     src/app/admin/page.tsx \
+     src/components/auth/SignInForm.tsx \
+     src/components/auth/SignUpForm.tsx \
+     src/components/auth/AccountMenu.tsx \
+     src/lib/schemas/auth-forms.ts \
+     proxy.ts
+   ```
+
+   The sweep must return zero matches. CLAUDE.md's em/en-dash rule exempts code comments and developer-only strings; but in this phase, the policy is stricter (CONTEXT verification gate explicitly demands zero em/en-dash in all changed files — including comments — to make the sweep grep-clean). If a legitimate code comment uses em-dash, rewrite it to a hyphen-minus.
+
+5. Re-run `mcp__Neon__list_tables` (sanity confirm 02-02 tables are still present and nothing else has been added).
+
+Record the output of each command in the SUMMARY. If any gate fails, do NOT proceed to Task 3 (the human checkpoint); fix and re-run until green.
+  </action>
+  <verify>
+    <automated>bun run lint && bun run typecheck && bun run build && ! grep -rnP '[\x{2014}\x{2013}]' src/env.ts src/lib/schemas/auth.ts src/lib/schemas/schema.ts src/lib/auth/index.ts src/lib/auth/client.ts src/lib/auth/get-session.ts 'src/app/api/auth/[...all]/route.ts' src/app/auth src/app/admin src/components/auth src/lib/schemas/auth-forms.ts proxy.ts</automated>
+  </verify>
+  <acceptance_criteria>
+    - `bun run lint` exits 0
+    - `bun run typecheck` exits 0
+    - `bun run build` exits 0 with no warnings about missing pages, invalid metadata exports, or `'use client'` violations
+    - Em/en-dash grep across all phase-02 files returns zero matches
+    - `mcp__Neon__list_tables` still shows users, sessions, accounts, verifications (and the pre-existing tables)
+  </acceptance_criteria>
+  <done>All automated gates green; phase is mechanically complete.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Operator manual smoke verification</name>
+  <what-built>
+    Better Auth wired end-to-end: sign-up → admin loop, sign-in, sign-out, role-based 403, edge redirect for anonymous /admin traffic.
+  </what-built>
+  <how-to-verify>
+    1. Ensure `.env.local` has `BETTER_AUTH_SECRET` set (generate with `openssl rand -base64 32` if missing).
+    2. Start the dev server: `bun run dev`. Note the port (default 3000 unless changed).
+    3. **First signup → admin:**
+       - In a fresh browser profile (clear cookies for the dev host), visit `http://localhost:3000/auth/sign-up`.
+       - Fill in email + password (≥8 chars), submit.
+       - You should be redirected to `/admin` and see "Signed in as <your email> (admin)".
+       - Confirm in Neon (Neon MCP `run_sql` with `SELECT id, email, role FROM users`) that exactly one row exists and its role is `admin`.
+    4. **Edge redirect for anonymous:**
+       - Open an incognito window. Visit `http://localhost:3000/admin`.
+       - You should be 307-redirected to `/auth/sign-in?from=%2Fadmin`. (Verify in the network panel.)
+    5. **Second signup → user, role-based 403:**
+       - From the incognito window, click "Need an account? Sign up." (or visit `/auth/sign-up`).
+       - Sign up with a second email + password.
+       - You should be redirected to `/admin` and see the 403 panel ("You are signed in but you do not have admin access.").
+       - Confirm in Neon that the second row has role `user`.
+    6. **Sign in flow (returning admin):**
+       - Sign out of the original profile via the AccountMenu (top-right of the admin shell — click trigger, click "Sign out").
+       - You should land on `/auth/sign-in`.
+       - Sign back in with the admin email + password. You should land on `/admin` showing your admin row.
+    7. **Sign-out (non-admin):**
+       - From the incognito 403 page (or by visiting `/admin`), sign out is not in the 403 panel by default. Either click the inline "Sign out" link if you added one, or manually clear the cookie. Confirm visiting `/admin` afterwards bounces to `/auth/sign-in`.
+    8. **Sanity:** visit `/` (the marketing site) — it should render normally; the proxy did not break unrelated routes.
+
+    If any step fails, capture the network response / Neon row state and report it.
+  </how-to-verify>
+  <resume-signal>Type "smoke-pass" when all 8 steps succeed. Report failures inline with step number and observed behavior.</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+- Task 1: proxy.ts diff is additive only, contains the new /admin block
+- Task 2: lint, typecheck, build all green; em/en-dash sweep empty
+- Task 3: operator confirms 8-step manual smoke
+</verification>
+
+<success_criteria>
+- Phase 02 gate is closed: Better Auth signs users in, the first signup becomes admin, /admin enforces role, the AccountMenu signs out, and the edge proxy short-circuits anonymous traffic
+- All quality gates green
+- Operator has visually verified the loop
+- Phase summary written; STATE.md updated to mark phase 02 complete and phase 03 as next
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/02-auth-foundation/02-05-SUMMARY.md` per the standard summary template. Include:
+- The proxy.ts diff (or a code snippet of the new block)
+- The full output of `bun run lint`, `bun run typecheck`, `bun run build`
+- Confirmation that the em/en-dash sweep returned zero matches
+- The operator's smoke-test report (step-by-step pass/fail)
+- An update note for `.planning/STATE.md` flipping phase 02 to complete and phase 03 to in-progress
+</output>

--- a/.planning/phases/02-auth-foundation/02-05-VERIFICATION.md
+++ b/.planning/phases/02-auth-foundation/02-05-VERIFICATION.md
@@ -1,0 +1,135 @@
+---
+phase: 02-auth-foundation
+plan: 05
+type: verification
+status: passed
+date: 2026-05-22
+---
+
+# Phase 02 Plan 05 Verification
+
+All automated gates green. Manual operator smoke deferred to pre-PR.
+
+## Gate 1: `bun run lint`
+
+```
+$ bun run lint
+$ biome check src/
+Checked 289 files in 60ms. No fixes applied.
+EXIT=0
+```
+
+## Gate 2: `bun run typecheck`
+
+```
+$ bun run typecheck
+$ tsc --noEmit
+EXIT=0
+```
+
+## Gate 3: `bun run build`
+
+```
+$ bun run build
+... (full Next.js 16 route table) ...
+
+○  (Static)             prerendered as static content
+◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
+ƒ  (Dynamic)            server-rendered on demand
+
+EXIT=0
+```
+
+Auth/admin routes confirmed present in build output:
+
+```
+├ ◐ /admin
+├ ƒ /api/auth/[...all]
+├ ○ /auth/sign-in
+├ ○ /auth/sign-up
+```
+
+The two `[BetterAuthError]: You are using the default secret.` lines in the build log are the same environmental warning previously documented in `02-04-SUMMARY.md` (no `BETTER_AUTH_SECRET` in the local build shell). They are not build failures. Production sets the secret via Vercel env.
+
+## Gate 4: Em/en-dash sweep across phase-02 files
+
+Phase-02 changed file list (from `git diff main...HEAD --name-only -- src/ proxy.ts`):
+
+```
+proxy.ts
+src/app/admin/layout.tsx
+src/app/admin/page.tsx
+src/app/api/auth/[...all]/route.ts
+src/app/auth/layout.tsx
+src/app/auth/sign-in/page.tsx
+src/app/auth/sign-up/page.tsx
+src/components/auth/AccountMenu.tsx
+src/components/auth/SignInForm.tsx
+src/components/auth/SignUpForm.tsx
+src/env.ts
+src/lib/auth/client.ts
+src/lib/auth/get-session.ts
+src/lib/auth/index.ts
+src/lib/schemas/auth-forms.ts
+src/lib/schemas/auth.ts
+src/lib/schemas/schema.ts
+```
+
+Em-dash sweep:
+
+```
+$ git diff main...HEAD --name-only -- src/ proxy.ts | xargs rg -lF '—'
+(no output)
+EXIT=1   (= no matches)
+```
+
+En-dash sweep:
+
+```
+$ git diff main...HEAD --name-only -- src/ proxy.ts | xargs rg -lF '–'
+(no output)
+EXIT=1   (= no matches)
+```
+
+Plan-script grep recipe (Python regex, all 17 files explicit):
+
+```
+$ grep -nP '[\x{2014}\x{2013}]' src/env.ts src/lib/schemas/auth.ts ... proxy.ts
+(no output)
+EXIT=1   (= no matches)
+```
+
+All three sweeps return zero matches. Pre-existing em-dashes in two code comments (`src/lib/auth/index.ts:80`, `src/lib/auth/client.ts:9`) and two in `proxy.ts` (lines 13, 35) were rewritten to ASCII hyphen-minus during this plan, per the plan's strict-comment directive ("If a legitimate code comment uses em-dash, rewrite it to a hyphen-minus.").
+
+## Gate 5: `src/lib/auth/admin.ts` untouched
+
+```
+$ git diff main...HEAD -- src/lib/auth/admin.ts
+(no output)
+EXIT=0
+```
+
+The existing Bearer-token guard for cron/admin API endpoints (`ADMIN_SECRET` / `CRON_SECRET`) is unchanged. It runs parallel to the new session-based auth; this plan does not consolidate them.
+
+## Gate 6: Existing routes still build
+
+The build output (Gate 3) shows the full route table is intact: `/showcase`, `/contact`, `/blog`, `/api/contact`, `/api/blog/*`, etc. all still appear. The proxy change is additive (early-return only when path matches `/admin` or `/admin/*` and no session cookie), so non-admin routes flow through the existing branches unchanged.
+
+## Gate 7: Manual operator smoke (deferred)
+
+The 6-step smoke checklist in `02-CONTEXT.md` section 9 (fresh signup gets admin, edge redirect for anonymous, second signup gets user + 403, sign in, sign out from AccountMenu, sign out for non-admin) is deferred to the operator before opening the PR. See `02-SUMMARY.md` for the checklist.
+
+## Summary
+
+| Gate | Status | Evidence |
+|---|---|---|
+| lint | PASS | exit 0 |
+| typecheck | PASS | exit 0 |
+| build | PASS | exit 0; /admin + /api/auth/[...all] + /auth/sign-in + /auth/sign-up present |
+| em-dash sweep | PASS | 0 matches across 17 phase-02 files |
+| en-dash sweep | PASS | 0 matches across 17 phase-02 files |
+| admin.ts (Bearer guard) untouched | PASS | empty diff vs main |
+| existing routes intact | PASS | full route table preserved in build output |
+| manual smoke | DEFERRED | operator runs before PR |
+
+**Status: passed.** Phase 02 ready to close.

--- a/.planning/phases/02-auth-foundation/02-CONTEXT.md
+++ b/.planning/phases/02-auth-foundation/02-CONTEXT.md
@@ -1,0 +1,173 @@
+# Phase 02 — Auth Foundation
+
+**Date:** 2026-05-22
+**Branch:** `admin-panel-auth`
+**Milestone:** v4 — Admin Panel
+**Scope:** Wire Better Auth into the project. New users/sessions tables, sign-in/sign-up pages, `/admin/*` middleware guard, account menu primitive. No admin pages yet (those come in Phase 03+).
+
+## 1. Goal
+
+Stand up a production-grade auth foundation so subsequent v4 phases can assume "you have a session, you're an admin, you're inside `/admin`". This phase ships:
+
+- Better Auth library wired to the existing Neon Postgres database
+- 2 new Drizzle tables (`users`, `sessions`) generated from Better Auth's schema generator
+- 2 new server-rendered pages: `/auth/sign-in` and `/auth/sign-up`
+- An `/admin/*` route group + middleware that bounces unauthenticated requests to `/auth/sign-in`
+- Role-based access: first signup gets `role: 'admin'`; later signups default to `role: 'user'` and get a 403 at `/admin/*`
+- An `AccountMenu` client component (dropdown showing email + sign-out button); the only consumer in this phase is a placeholder `/admin/page.tsx` that proves the loop works
+
+After this phase, signing up creates a row in Neon, signing in sets a session cookie, hitting `/admin` while signed-out redirects to `/auth/sign-in`, and hitting it as a non-admin returns 403. Nothing more is required for downstream phases.
+
+## 2. Non-goals
+
+- No actual admin pages (Phase 03 builds the dashboard, 04/05 build CRUD).
+- No OAuth providers wired (architecture supports them; default to email/password only).
+- No password reset / email verification flows (Phase 06+ if ever).
+- No admin-promotion UI. The first sign-up wins; second-admin promotion is a manual SQL `UPDATE` (documented).
+- No changes to the existing ADMIN_SECRET bearer-token guard used by `/api/process-emails` and cron endpoints. Those stay as-is for non-UI access; the new session-based auth is parallel.
+- No migration of existing data (none exists — no users in Neon today).
+
+## 3. Library choice: Better Auth
+
+[Better Auth](https://www.better-auth.com/) is the pick because:
+- Drizzle adapter ships in the box (we already use Drizzle)
+- Server Component + Next.js App Router first-class support
+- No service to manage, no per-MAU billing, no vendor lock-in
+- Schema is owned by us (Neon tables, not someone else's hosted DB)
+- Active, MIT-licensed, modern
+
+Two strong alternatives considered and rejected:
+- **NextAuth / Auth.js** — older, more legacy patterns, weaker session model for Next 15+/16
+- **Clerk** — hosted, per-MAU billing, hard to escape later
+
+## 4. Schema additions
+
+Better Auth's CLI generates exact column shapes; this is the intended structure:
+
+**`users` table** (new, in `src/lib/schemas/`)
+- `id` text (UUID/CUID), primary key
+- `email` text, unique, not null
+- `emailVerified` boolean, default false
+- `name` text, nullable
+- `image` text, nullable
+- `role` text, default `'user'` — values: `'admin' | 'user'`. Enforced in middleware, not at DB level.
+- `createdAt` timestamp, not null
+- `updatedAt` timestamp, not null
+
+**`sessions` table** (new, in `src/lib/schemas/`)
+- `id` text, primary key
+- `userId` text, foreign key → `users.id` on delete cascade
+- `expiresAt` timestamp, not null
+- `token` text, unique, not null
+- `ipAddress` text, nullable
+- `userAgent` text, nullable
+- `createdAt` timestamp, not null
+- `updatedAt` timestamp, not null
+
+**`accounts` table** (new — Better Auth requires it even for email/password)
+- Standard Better Auth shape; covers credentials hash for password users + OAuth tokens for future providers.
+
+**`verifications` table** (new — Better Auth standard)
+- Holds short-lived tokens for email verification / password reset (unused initially, kept for future flows).
+
+These get added to `src/lib/schemas/schema.ts` (the barrel). All push via `mcp__Neon__run_sql` per project convention (drizzle-kit push is broken with pg_cron installed, per memory).
+
+## 5. File-level changes
+
+### New files
+
+- `src/lib/auth/index.ts` — `auth = betterAuth({ ... })` server-side config. Drizzle adapter, secret from env, base URL from env.
+- `src/lib/auth/client.ts` — `authClient = createAuthClient({ ... })` for use in client components (sign-in form, sign-out button).
+- `src/lib/auth/get-session.ts` — server-only helper, reads cookies, returns typed `{ user, session } | null`. Used by middleware and server components.
+- `src/lib/schemas/auth.ts` — Drizzle tables (users, sessions, accounts, verifications) exported and re-exported from `schema.ts`.
+- `src/app/api/auth/[...all]/route.ts` — single catch-all that proxies to Better Auth's request handler.
+- `src/app/auth/layout.tsx` — minimal centered layout (no nav, no footer) for sign-in/sign-up.
+- `src/app/auth/sign-in/page.tsx` — server-rendered page; embeds a small client form (`SignInForm`).
+- `src/app/auth/sign-up/page.tsx` — server-rendered page; embeds `SignUpForm`. Note: first signup gets admin role.
+- `src/app/admin/layout.tsx` — server component, calls `getSession()`, redirects to `/auth/sign-in` if no session, returns 403 if role !== 'admin'. Renders a thin shell with the AccountMenu in the top-right and `{children}` below. Real admin layout (sidebar, dashboard) lands in Phase 03.
+- `src/app/admin/page.tsx` — placeholder page so we can prove the loop works: shows `Signed in as {email} ({role})`. Phase 03 replaces this.
+- `src/components/auth/SignInForm.tsx` — client component, calls `authClient.signIn.email(...)`. Submits, handles error, on success redirects to `/admin`.
+- `src/components/auth/SignUpForm.tsx` — client component, calls `authClient.signUp.email(...)`. On success, server-side hook sets `role: 'admin'` if it's the first row, else `'user'`.
+- `src/components/auth/AccountMenu.tsx` — client component, dropdown with email + `Sign out` button; uses existing `DropdownMenu` from `src/components/ui/`.
+- `proxy.ts` — extend the existing edge proxy: bounce `/admin/*` to `/auth/sign-in` if no session cookie. (We already own `proxy.ts`; this is one extra check.)
+- `src/env.ts` — add 3 env vars: `BETTER_AUTH_SECRET` (required in production), `BETTER_AUTH_URL` (defaults to `BASE_URL`), `BETTER_AUTH_TRUSTED_ORIGINS` (comma-separated, optional).
+
+### Modified files
+
+- `src/lib/schemas/schema.ts` — re-export from new `auth.ts` schema file.
+- `proxy.ts` — see above.
+- `src/env.ts` — see above.
+- `package.json` — add `better-auth` dependency.
+- `CLAUDE.md` — single new line in the Auth section: "User auth: Better Auth, session cookies, see `src/lib/auth/`. Admin promotion is currently SQL-only — first signup gets it; later admins via `UPDATE users SET role='admin' WHERE email='...'`."
+
+### Deleted files
+
+None.
+
+## 6. Auth flow
+
+```
+GET /auth/sign-up → server-rendered page with SignUpForm
+SignUpForm POST → authClient.signUp.email({ email, password, name })
+                   → /api/auth/sign-up/email  (Better Auth handler)
+                   → inserts user row, hashed password into accounts row,
+                     session row + sets httpOnly session cookie
+                   → server-side hook: if (await db.select().from(users)).length === 1
+                     then UPDATE users SET role='admin' WHERE id=newUserId
+                   → client redirects to /admin
+
+GET /admin/* (no cookie)           → middleware redirects to /auth/sign-in
+GET /admin/* (cookie, role=user)   → admin/layout.tsx returns 403 page
+GET /admin/* (cookie, role=admin)  → admin/layout.tsx renders shell + children
+
+GET /auth/sign-in → server-rendered page with SignInForm
+SignInForm POST → authClient.signIn.email({ email, password })
+                   → /api/auth/sign-in/email (Better Auth handler)
+                   → validates, sets new session cookie
+                   → client redirects to /admin
+
+Sign-out (AccountMenu button) → authClient.signOut()
+                                 → /api/auth/sign-out (Better Auth handler)
+                                 → invalidates session, clears cookie
+                                 → client redirects to /auth/sign-in
+```
+
+## 7. Middleware vs server-component check
+
+Both. **Defense in depth:**
+- `proxy.ts` (edge middleware) does a cookie-presence check. Fast, runs before page render, catches the no-cookie case at the edge. Bounces to `/auth/sign-in`.
+- `src/app/admin/layout.tsx` (server component) does the real validation (`getSession()` against the DB) and the role check. Renders 403 for non-admin users.
+
+The edge check is cheap and stops bots; the server-component check is the source of truth.
+
+## 8. Security checklist (must hold)
+
+- Session cookie is `httpOnly`, `secure: true` in production, `sameSite: 'lax'`.
+- Password hashed via Better Auth's argon2id default. No homegrown hashing.
+- CSRF: Better Auth uses double-submit token automatically.
+- `BETTER_AUTH_SECRET` must be ≥32 chars; T3 env Zod validation enforces.
+- Production-required env vars (per existing `src/env.ts` pattern): `BETTER_AUTH_SECRET` becomes required when `VERCEL_ENV === 'production'`.
+- `/api/auth/[...all]/route.ts` does NOT go through `withMutationGuards` — Better Auth handles its own CSRF.
+
+## 9. Verification
+
+- `bun run lint && bun run typecheck && bun run build` all pass
+- New tables exist in Neon (`mcp__Neon__list_tables` returns users, sessions, accounts, verifications)
+- Manual smoke (deferred to operator):
+  1. `bun run dev`
+  2. Visit `/auth/sign-up`, sign up. First signup gets admin role; verify in Neon.
+  3. Hit `/admin` — see the placeholder page with email + role.
+  4. Open incognito, visit `/admin` — bounce to `/auth/sign-in`.
+  5. Sign in from incognito as a freshly created user — verify `role: 'user'` and 403 at `/admin`.
+  6. Sign out from the AccountMenu. Verify cookie cleared and `/admin` bounces again.
+- Em/en-dash sweep: zero `—` and zero `–` in any new copy (sign-in, sign-up, AccountMenu, 403 page).
+
+## 10. Out of scope
+
+- Admin pages (Phase 03+)
+- Sidebar nav / Dashboard 5 layout (Phase 03)
+- Password reset / email verification (deferred indefinitely)
+- OAuth providers (architecture supports; defer to a later phase)
+- User management UI (admin-promotion is SQL-only by design for now)
+- 2FA / passkeys (defer)
+- Mass migration of any existing accounts (there are none)

--- a/.planning/phases/02-auth-foundation/02-SUMMARY.md
+++ b/.planning/phases/02-auth-foundation/02-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: 02-auth-foundation
+milestone: v4
+status: complete
+plans: 5
+completed_plans: 5
+commits: 5
+date_started: 2026-05-22
+date_completed: 2026-05-22
+---
+
+# Phase 02 - Auth Foundation Summary
+
+Better Auth wired end to end against Neon: 4 new DB tables (users, sessions, accounts, verifications), email/password sign-up + sign-in pages, server-component `/admin` layout that enforces `role === 'admin'`, an AccountMenu primitive for sign-out, and an edge-level `proxy.ts` cookie short-circuit for anonymous `/admin/*` traffic. First signup is auto-promoted to admin; subsequent users default to `role: 'user'` and get a 403 panel on `/admin`.
+
+## What shipped
+
+| Plan | Title | Commit | What |
+|---|---|---|---|
+| 02-01 | Install better-auth and add auth env vars | `b9148a0` | `better-auth` npm dependency; `BETTER_AUTH_SECRET` / `BETTER_AUTH_URL` / `BETTER_AUTH_TRUSTED_ORIGINS` added to `src/env.ts` (secret required when `VERCEL_ENV === 'production'`); CLAUDE.md auth section updated. |
+| 02-02 | Add Drizzle tables and DDL for Better Auth | `c7f5615` | `src/lib/schemas/auth.ts` with `users`, `sessions`, `accounts`, `verifications` Drizzle tables; barrel re-export from `src/lib/schemas/schema.ts`; tables created in Neon via MCP `run_sql` (drizzle-kit push is broken with pg_cron installed). |
+| 02-03 | Wire Better Auth server, client, and API catch-all | `4212579` | `src/lib/auth/index.ts` (server config: Drizzle adapter, argon2id default, nextCookies plugin); `src/lib/auth/client.ts` (React SDK pinned to `NEXT_PUBLIC_BASE_URL`); `src/lib/auth/get-session.ts` (server-only typed helper); `src/app/api/auth/[...all]/route.ts` catch-all. First-signup admin promotion lives in the server config's after-hook. |
+| 02-04 | Auth pages, /admin layout, AccountMenu | `3c09d8a` | `/auth/sign-in` + `/auth/sign-up` server pages with their client forms; `src/app/admin/layout.tsx` server component that calls `getSession()`, redirects on no session, renders inline 403 panel when `role !== 'admin'`, mounts AccountMenu top-right; `src/app/admin/page.tsx` placeholder for proof-of-loop; `src/components/auth/AccountMenu.tsx` using native `<details>`/`<summary>`; Zod schemas in `src/lib/schemas/auth-forms.ts`. |
+| 02-05 | Edge cookie guard + full phase verification | (this commit) | `proxy.ts` extended with presence-only `better-auth.session_token` check for `/admin` + `/admin/*` (307 redirect to `/auth/sign-in?from={original}` when absent); existing security-headers / HTTPS-redirect / UA-blocklist / Cache-Control / CORS / Server-Timing branches preserved verbatim. Em-dash sweep scrubbed 4 pre-existing dashes in code comments (`proxy.ts:13,35`, `src/lib/auth/index.ts:80`, `src/lib/auth/client.ts:9`) to keep the per-file grep gate clean. |
+
+## Defense in depth: the two-layer admin guard
+
+The `/admin/*` access control is intentionally split across two layers:
+
+1. **Edge (`proxy.ts`).** Cheap presence check on the `better-auth.session_token` cookie. Runs before any React server-render, before any DB call. Catches the no-cookie case (anonymous users, scanner bots) and 307-redirects to `/auth/sign-in?from={pathname}`. Does not validate the cookie value; that would require an edge-runtime-safe DB call which Better Auth does not guarantee.
+2. **Server component (`src/app/admin/layout.tsx`).** Source of truth. Calls `getSession()` (which does the real DB lookup against the `sessions` table), then enforces `session.user.role === 'admin'`. Non-admins see a self-contained 403 panel; `children` are never rendered for them.
+
+The two layers cannot disagree about the no-cookie case (both redirect / refuse), and the role decision belongs entirely to the server component. `src/lib/auth/admin.ts` (the pre-existing Bearer-token guard for cron / `/api/process-emails`) is untouched by this phase and continues to gate non-UI API access in parallel.
+
+## Schema additions in Neon (`neondb.public`)
+
+Tables added by Plan 02-02 (DDL applied via Neon MCP `run_sql`):
+
+- `users` - id (text PK), email (text unique), emailVerified (bool), name (text), image (text), role (text default `'user'`), createdAt, updatedAt
+- `sessions` - id (text PK), userId (text FK -> users.id ON DELETE CASCADE), expiresAt, token (text unique), ipAddress, userAgent, createdAt, updatedAt
+- `accounts` - Better Auth standard shape (credentials hash for email/password, OAuth columns reserved for later providers)
+- `verifications` - short-lived token store for email verify / password reset (unused initially, kept for future flows)
+
+All four tables remain Drizzle-typed via `src/lib/schemas/auth.ts` and re-exported from the schema barrel.
+
+## Env vars added (`src/env.ts`)
+
+- `BETTER_AUTH_SECRET` - required when `VERCEL_ENV === 'production'` (T3 env `optional().refine(...)` pattern). Local dev gets a Better Auth warning if unset; the build still succeeds.
+- `BETTER_AUTH_URL` - optional; defaults to `BASE_URL`.
+- `BETTER_AUTH_TRUSTED_ORIGINS` - optional comma-separated list.
+
+## Operator manual smoke checklist (run before opening PR)
+
+Six steps. All deferred to the operator; the automated gates above cannot replace eyeball verification.
+
+1. Ensure `.env.local` has `BETTER_AUTH_SECRET` set (`openssl rand -base64 32` if missing). Start `bun run dev`.
+2. **First signup -> admin.** Fresh browser profile (or cleared cookies). Visit `http://localhost:3000/auth/sign-up`, submit email + password (>= 8 chars). Confirm redirect to `/admin` showing `Signed in as <email> (admin)`. Verify in Neon (`SELECT id, email, role FROM users`) that exactly one row exists, role = `admin`.
+3. **Edge redirect for anonymous.** Open an incognito window. Visit `http://localhost:3000/admin`. Network panel should show a 307 to `/auth/sign-in?from=%2Fadmin`. The edge proxy short-circuited before any React render.
+4. **Second signup -> user, role-based 403.** From the incognito window, sign up with a second email. After redirect to `/admin`, confirm the 403 panel appears ("You are signed in but you do not have admin access."). Verify in Neon that the second row has role = `user`.
+5. **Sign in + sign out (admin).** In the first browser profile, sign out via the AccountMenu (top-right of admin shell -> Sign out). Land on `/auth/sign-in`. Sign back in with the admin credentials, confirm `/admin` renders the admin shell.
+6. **Sanity check unrelated routes.** Visit `/`, `/showcase`, `/contact`. All should render normally; the proxy change must not regress non-admin paths.
+
+If any step fails, capture the network response + Neon row state and file the failure before opening the PR.
+
+## Recommended commit / PR shape
+
+Five atomic commits on `admin-panel-auth`:
+
+- `feat(auth): install better-auth and add auth env vars` (b9148a0)
+- `feat(auth): add Drizzle tables and DDL for Better Auth` (c7f5615)
+- `feat(auth): wire Better Auth server, client, and API catch-all` (4212579)
+- `feat(auth): sign-in/sign-up pages, /admin layout with role guard, AccountMenu` (3c09d8a)
+- `chore(02): phase verification passed` (this commit)
+
+PR recommendation: **squash on merge** to main with message `feat(auth): Better Auth foundation - users, sessions, /admin role guard, AccountMenu`. The 5-commit history stays on the feature branch for traceability.
+
+## Open follow-ups (not blocking the phase)
+
+- **No admin-promotion UI.** Promoting a second admin is a manual SQL `UPDATE users SET role='admin' WHERE email='...'`. Documented in CLAUDE.md. Phase 04/05 may add an admin user-management screen.
+- **No password reset / email verification flow.** The `verifications` table is provisioned but unused. Add when the product calls for it.
+- **No OAuth providers wired.** Architecture supports them via the `accounts` table; add when needed.
+- **Local dev `BETTER_AUTH_SECRET` warning is environmental.** The build still passes; production sets the secret via Vercel env. If a developer wants the warning gone locally, set the secret in `.env.local`.
+
+## Phase verdict
+
+All 5 plans shipped. All automated gates green (lint, typecheck, build, em/en-dash sweep, admin.ts untouched). Phase 02 ready for human manual smoke + PR. Phase 03 (admin-shell-and-dashboard) can begin immediately after merge.
+
+## Self-Check: PASSED
+
+- `proxy.ts` modified with the /admin block: confirmed via `git diff proxy.ts`.
+- `02-05-VERIFICATION.md` exists at `.planning/phases/02-auth-foundation/02-05-VERIFICATION.md`.
+- `02-SUMMARY.md` exists at `.planning/phases/02-auth-foundation/02-SUMMARY.md`.
+- `STATE.md` updated: phase 02 marked complete (5/5); next action set to operator smoke + Phase 03 kickoff.
+- `ROADMAP.md` updated: phase 02 row flipped to `complete (5/5)` with 5 plans.
+- All 5 commit hashes will be present in `git log` after the closing commit lands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@
 - pg_cron runs weekly VACUUM ANALYZE; see `.planning/` for details
 
 **Auth:**
-- No user-auth system in this app
+- User auth: Better Auth, session cookies, see src/lib/auth/. Admin promotion is currently SQL-only - first signup gets it; later admins via UPDATE users SET role='admin' WHERE email='...'.
 - Admin/cron endpoints guarded by Bearer token (`src/lib/auth/admin.ts`) using `ADMIN_SECRET` / `CRON_SECRET`
 
 **Resend (Email):**
@@ -178,7 +178,7 @@
 
 **Env vars:**
 - All env access goes through `src/env.ts` (T3 env). Never read `process.env.X` directly.
-- Schema-required when `VERCEL_ENV === 'production'` (enforced by a `.optional().refine(...)` pair; unset elsewhere): `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`
+- Schema-required when `VERCEL_ENV === 'production'` (enforced by a `.optional().refine(...)` pair; unset elsewhere): `POSTGRES_URL`, `CSRF_SECRET`, `ADMIN_SECRET`, `CRON_SECRET`, `BETTER_AUTH_SECRET`
 - Always defined (have defaults): `BASE_URL` (default `http://localhost:3000`), `NEXT_PUBLIC_BASE_URL` (default `http://localhost:3000`), `NODE_ENV` (default `development`)
 - Truly optional / feature-gated: `RESEND_API_KEY`, `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `STIRLING_PDF_URL`, `DISCORD_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, `GOOGLE_SITE_VERIFICATION`, `DATABASE_URL_UNPOOLED`, `NEXT_PUBLIC_SITE_URL`
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "@upstash/redis": "1.38.0",
         "@vercel/analytics": "2.0.1",
         "@vercel/speed-insights": "2.0.0",
+        "better-auth": "1.6.11",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "drizzle-orm": "0.45.2",
@@ -103,6 +104,24 @@
     "@babel/traverse": ["@babel/traverse@7.27.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "@babel/generator": "^7.27.0", "@babel/parser": "^7.27.0", "@babel/template": "^7.27.0", "@babel/types": "^7.27.0", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@better-auth/core": ["@better-auth/core@1.6.11", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ=="],
+
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw=="],
+
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "kysely": "^0.28.17" }, "optionalPeers": ["kysely"] }, "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg=="],
+
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0" } }, "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q=="],
+
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA=="],
+
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw=="],
+
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA=="],
+
+    "@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
+
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.4.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.15", "@biomejs/cli-darwin-x64": "2.4.15", "@biomejs/cli-linux-arm64": "2.4.15", "@biomejs/cli-linux-arm64-musl": "2.4.15", "@biomejs/cli-linux-x64": "2.4.15", "@biomejs/cli-linux-x64-musl": "2.4.15", "@biomejs/cli-win32-arm64": "2.4.15", "@biomejs/cli-win32-x64": "2.4.15" }, "bin": { "biome": "bin/biome" } }, "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw=="],
 
@@ -284,9 +303,9 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
-    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+    "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
-    "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+    "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -816,6 +835,10 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.24", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA=="],
 
+    "better-auth": ["better-auth@1.6.11", "", { "dependencies": { "@better-auth/core": "1.6.11", "@better-auth/drizzle-adapter": "1.6.11", "@better-auth/kysely-adapter": "1.6.11", "@better-auth/memory-adapter": "1.6.11", "@better-auth/mongo-adapter": "1.6.11", "@better-auth/prisma-adapter": "1.6.11", "@better-auth/telemetry": "1.6.11", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ=="],
+
+    "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -895,6 +918,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -1052,6 +1077,8 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
     "js-md5": ["js-md5@0.8.3", "", {}, "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
@@ -1067,6 +1094,8 @@
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
     "knip": ["knip@6.12.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-RcZpT1sVziKZgDk1F0hAcp+bq71VJAF8vg1Y9ZLXc1+UXQaMm1rjiUqpJQTIj+lqwmiBQT19/u7ikgazs23cvA=="],
+
+    "kysely": ["kysely@0.28.17", "", {}, "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q=="],
 
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
@@ -1222,6 +1251,8 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "nanostores": ["nanostores@1.3.0", "", {}, "sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA=="],
+
     "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
@@ -1358,6 +1389,8 @@
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
+    "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "sanitize-html": ["sanitize-html@2.17.3", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^10.1.0", "is-plain-object": "^5.0.0", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg=="],
@@ -1371,6 +1404,8 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "server-only": ["server-only@0.0.1", "", {}, "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@3.1.0", "", {}, "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
@@ -1560,6 +1595,8 @@
 
     "@babel/template/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
+    "@better-auth/core/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@esbuild-kit/esm-loader/get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
     "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
@@ -1579,6 +1616,10 @@
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@react-pdf/pdfkit/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
+    "@react-pdf/pdfkit/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@react-pdf/reconciler/scheduler": ["scheduler@0.25.0-rc-603e6108-20241029", "", {}, "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA=="],
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"@upstash/redis": "1.38.0",
 		"@vercel/analytics": "2.0.1",
 		"@vercel/speed-insights": "2.0.0",
+		"better-auth": "1.6.11",
 		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",
 		"drizzle-orm": "0.45.2",

--- a/proxy.ts
+++ b/proxy.ts
@@ -73,12 +73,19 @@ export function proxy(request: NextRequest) {
 	// admin layout (src/app/admin/layout.tsx) validates the session and
 	// enforces the role. This branch keeps unauthenticated traffic out
 	// of the React server-render path and gives bots a quick bounce.
+	//
+	// Better Auth prefixes the cookie with `__Secure-` when baseURL is
+	// https (production). Check both names so the edge guard is active
+	// in production too. 302 is intentional: this is a presence redirect
+	// for browser GET navigation; a 307 would preserve POST method on
+	// any future server-action POSTs under /admin and break them.
 	if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
-		const sessionCookie = request.cookies.get('better-auth.session_token')
+		const sessionCookie =
+			request.cookies.get('better-auth.session_token') ??
+			request.cookies.get('__Secure-better-auth.session_token')
 		if (!sessionCookie) {
 			const signInUrl = new URL('/auth/sign-in', request.url)
-			signInUrl.searchParams.set('from', url.pathname + url.search)
-			return NextResponse.redirect(signInUrl, { status: 307 })
+			return NextResponse.redirect(signInUrl, { status: 302 })
 		}
 	}
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -7,8 +7,10 @@
  *  - User-agent blocklist for known scanners
  *  - Cache-Control and CORS for /api/*
  *  - Performance timing header
+ *  - /admin/* cookie presence check (defense in depth; the
+ *    admin layout server component is the source of truth)
  *
- * Does NOT do CSRF / rate-limit / origin checks any more — those moved to
+ * Does NOT do CSRF / rate-limit / origin checks any more - those moved to
  * `src/lib/api/guards.ts::withMutationGuards` so they can be opted-in
  * per-route. Browser beacons (`/api/web-vitals`, `/api/csp-reports`)
  * legitimately can't carry a CSRF token, so a blanket proxy-level CSRF
@@ -30,7 +32,7 @@ export const config = {
 }
 
 // User-agent fragments associated with vulnerability scanners. Defense
-// in depth — sophisticated attackers spoof UAs trivially, but this
+// in depth - sophisticated attackers spoof UAs trivially, but this
 // catches the noisy crawl traffic.
 const SUSPICIOUS_UA = [
 	/sqlmap/i,
@@ -65,6 +67,19 @@ export function proxy(request: NextRequest) {
 	const userAgent = request.headers.get('user-agent') ?? ''
 	if (SUSPICIOUS_UA.some(pattern => pattern.test(userAgent))) {
 		return new NextResponse('Blocked', { status: 403 })
+	}
+
+	// /admin/* requires a session cookie. Presence-only check; the
+	// admin layout (src/app/admin/layout.tsx) validates the session and
+	// enforces the role. This branch keeps unauthenticated traffic out
+	// of the React server-render path and gives bots a quick bounce.
+	if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
+		const sessionCookie = request.cookies.get('better-auth.session_token')
+		if (!sessionCookie) {
+			const signInUrl = new URL('/auth/sign-in', request.url)
+			signInUrl.searchParams.set('from', url.pathname + url.search)
+			return NextResponse.redirect(signInUrl, { status: 307 })
+		}
 	}
 
 	// Cache-Control for top-level static-ish pages.

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -17,6 +17,7 @@
  * The 403 panel intentionally lives inside this layout (not a separate route)
  * so non-admins cannot bypass it by navigating to a deeper `/admin/...` URL.
  */
+import Link from 'next/link'
 import { redirect } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { AccountMenu } from '@/components/auth/AccountMenu'
@@ -64,12 +65,12 @@ export default async function AdminLayout({
 						</a>
 						.
 					</p>
-					<a
+					<Link
 						href="/auth/sign-in"
 						className="inline-block text-sm font-medium text-accent-text hover:underline"
 					>
 						Back to sign in
-					</a>
+					</Link>
 				</div>
 			</div>
 		)

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,89 @@
+/**
+ * Admin route-group layout (server component).
+ *
+ * Source-of-truth auth guard for everything under `/admin/*`. The edge proxy
+ * (Plan 02-05) layers a fast cookie-presence check on top, but THIS layout is
+ * the only place that calls `getSession()` and inspects the role; the proxy
+ * only short-circuits requests with no session cookie at all.
+ *
+ * Three branches:
+ *   1. No session  → redirect to `/auth/sign-in`
+ *   2. session.user.role !== 'admin' → render a server 403 panel and STOP
+ *      (children are not rendered, so deeper routes never execute their data
+ *      fetches under a non-admin session)
+ *   3. session.user.role === 'admin' → render the admin shell (top bar with
+ *      AccountMenu + main slot) and pass `children` through
+ *
+ * The 403 panel intentionally lives inside this layout (not a separate route)
+ * so non-admins cannot bypass it by navigating to a deeper `/admin/...` URL.
+ */
+import { redirect } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { AccountMenu } from '@/components/auth/AccountMenu'
+import { getSession } from '@/lib/auth/get-session'
+
+export default async function AdminLayout({
+	children
+}: {
+	children: ReactNode
+}) {
+	const session = await getSession()
+
+	if (!session?.user) {
+		redirect('/auth/sign-in')
+	}
+
+	if (session.user.role !== 'admin') {
+		return (
+			<div className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center bg-surface-base p-6">
+				<div className="w-full max-w-md rounded-xl border border-border bg-surface-raised p-8 shadow-sm">
+					<p className="text-xs font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+						403
+					</p>
+					<h1 className="text-2xl font-semibold text-foreground mb-3">
+						Not authorized
+					</h1>
+					<p className="text-sm text-muted-foreground mb-4">
+						You are signed in as{' '}
+						<span className="font-medium text-foreground">
+							{session.user.email}
+						</span>{' '}
+						with role{' '}
+						<span className="font-medium text-foreground">
+							{session.user.role}
+						</span>
+						. This area requires admin access.
+					</p>
+					<p className="text-sm text-muted-foreground mb-6">
+						If you should have admin access, contact the site owner at{' '}
+						<a
+							href="mailto:hello@hudsondigitalsolutions.com"
+							className="font-medium text-accent-text hover:underline"
+						>
+							hello@hudsondigitalsolutions.com
+						</a>
+						.
+					</p>
+					<a
+						href="/auth/sign-in"
+						className="inline-block text-sm font-medium text-accent-text hover:underline"
+					>
+						Back to sign in
+					</a>
+				</div>
+			</div>
+		)
+	}
+
+	return (
+		<div className="min-h-[calc(100vh-3.5rem)] bg-surface-base">
+			<header className="border-b border-border bg-surface-raised">
+				<div className="flex items-center justify-between px-6 py-3">
+					<p className="text-sm font-semibold text-foreground">Admin</p>
+					<AccountMenu email={session.user.email} />
+				</div>
+			</header>
+			<main className="p-6">{children}</main>
+		</div>
+	)
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,8 +6,10 @@
  * email and role, sign out.
  *
  * The parent layout (`src/app/admin/layout.tsx`) has already enforced session
- * + role, but we re-call `getSession()` here for type narrowing rather than
- * threading the session down. Both calls hit the same in-request cache.
+ * + role. We re-call `getSession()` here for type narrowing rather than
+ * threading the session down. `getSession()` is wrapped in `React.cache`, so
+ * both calls in the same render share one result without a second cookie
+ * parse or DB lookup.
  */
 import { getSession } from '@/lib/auth/get-session'
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * Placeholder admin landing.
+ *
+ * Phase 03 replaces this with the real dashboard. For now it exists only to
+ * prove the auth loop works end-to-end: sign up, get bounced here, see your
+ * email and role, sign out.
+ *
+ * The parent layout (`src/app/admin/layout.tsx`) has already enforced session
+ * + role, but we re-call `getSession()` here for type narrowing rather than
+ * threading the session down. Both calls hit the same in-request cache.
+ */
+import { getSession } from '@/lib/auth/get-session'
+
+export default async function AdminHomePage() {
+	const session = await getSession()
+	if (!session) {
+		return null
+	}
+
+	return (
+		<div className="max-w-2xl">
+			<h2 className="text-xl font-semibold text-foreground mb-2">
+				Welcome to the admin console.
+			</h2>
+			<p className="text-sm text-muted-foreground">
+				Signed in as{' '}
+				<span className="font-medium text-foreground">
+					{session.user.email}
+				</span>{' '}
+				({session.user.role}).
+			</p>
+			<p className="text-xs text-muted-foreground mt-6">
+				The full dashboard ships in Phase 03.
+			</p>
+		</div>
+	)
+}

--- a/src/app/api/auth/[...all]/route.ts
+++ b/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,4 @@
+import { toNextJsHandler } from 'better-auth/next-js'
+import { auth } from '@/lib/auth'
+
+export const { GET, POST } = toNextJsHandler(auth)

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,18 @@
+/**
+ * Auth route-group layout.
+ *
+ * Renders the sign-in and sign-up pages inside a centered, chrome-free
+ * container. The site Navbar and Footer (which live in the root layout)
+ * remain wrapped around this, but the page content here is centered into a
+ * narrow column so the form is the only focal point. The root layout already
+ * mounts a `<Toaster />` from sonner, so this layout does not duplicate it.
+ */
+import type { ReactNode } from 'react'
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+	return (
+		<div className="min-h-[calc(100vh-3.5rem)] flex items-center justify-center bg-surface-base p-6">
+			<div className="w-full max-w-md">{children}</div>
+		</div>
+	)
+}

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -12,8 +12,8 @@ import { Card } from '@/components/ui/card'
 
 export const metadata: Metadata = {
 	title: 'Sign in',
-	description:
-		'Sign in to the Hudson Digital Solutions admin console to manage site content, leads, and analytics.'
+	description: 'Sign in to your Hudson Digital Solutions account.',
+	robots: { index: false, follow: false }
 }
 
 export default function SignInPage() {

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,0 +1,40 @@
+/**
+ * Sign-in page (server component).
+ *
+ * Renders the Better Auth sign-in form inside the centered auth layout.
+ * The form itself is a client component that calls `authClient.signIn.email`
+ * and navigates to `/admin` on success.
+ */
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SignInForm } from '@/components/auth/SignInForm'
+import { Card } from '@/components/ui/card'
+
+export const metadata: Metadata = {
+	title: 'Sign in',
+	description:
+		'Sign in to the Hudson Digital Solutions admin console to manage site content, leads, and analytics.'
+}
+
+export default function SignInPage() {
+	return (
+		<Card variant="default" size="md">
+			<div className="space-y-1.5 mb-6">
+				<h1 className="text-2xl font-semibold text-foreground">Sign in</h1>
+				<p className="text-sm text-muted-foreground">
+					Use your admin credentials.
+				</p>
+			</div>
+			<SignInForm />
+			<p className="mt-6 text-sm text-muted-foreground text-center">
+				Need an account?{' '}
+				<Link
+					href="/auth/sign-up"
+					className="font-medium text-accent-text hover:underline"
+				>
+					Sign up.
+				</Link>
+			</p>
+		</Card>
+	)
+}

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -14,7 +14,7 @@ import { Card } from '@/components/ui/card'
 
 export const metadata: Metadata = {
 	title: 'Sign up',
-	description: 'Sign in to your Hudson Digital Solutions account.',
+	description: 'Create your Hudson Digital Solutions account.',
 	robots: { index: false, follow: false }
 }
 

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -14,8 +14,8 @@ import { Card } from '@/components/ui/card'
 
 export const metadata: Metadata = {
 	title: 'Sign up',
-	description:
-		'Create an admin account for the Hudson Digital Solutions site. The first signup is automatically granted admin access.'
+	description: 'Sign in to your Hudson Digital Solutions account.',
+	robots: { index: false, follow: false }
 }
 
 export default function SignUpPage() {

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,0 +1,44 @@
+/**
+ * Sign-up page (server component).
+ *
+ * Renders the Better Auth sign-up form inside the centered auth layout.
+ * The first user to sign up is auto-promoted to `role='admin'` by the
+ * `databaseHooks.user.create.after` hook in `src/lib/auth/index.ts`; later
+ * signups default to `role='user'` and are bounced to the 403 panel by
+ * `src/app/admin/layout.tsx` until promoted via SQL.
+ */
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { SignUpForm } from '@/components/auth/SignUpForm'
+import { Card } from '@/components/ui/card'
+
+export const metadata: Metadata = {
+	title: 'Sign up',
+	description:
+		'Create an admin account for the Hudson Digital Solutions site. The first signup is automatically granted admin access.'
+}
+
+export default function SignUpPage() {
+	return (
+		<Card variant="default" size="md">
+			<div className="space-y-1.5 mb-6">
+				<h1 className="text-2xl font-semibold text-foreground">
+					Create account
+				</h1>
+				<p className="text-sm text-muted-foreground">
+					The first signup becomes the admin.
+				</p>
+			</div>
+			<SignUpForm />
+			<p className="mt-6 text-sm text-muted-foreground text-center">
+				Already have an account?{' '}
+				<Link
+					href="/auth/sign-in"
+					className="font-medium text-accent-text hover:underline"
+				>
+					Sign in.
+				</Link>
+			</p>
+		</Card>
+	)
+}

--- a/src/components/auth/AccountMenu.tsx
+++ b/src/components/auth/AccountMenu.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+/**
+ * Account menu dropdown for the admin shell.
+ *
+ * Native `<details>` / `<summary>` powers the open/close behavior so the
+ * component ships zero extra JS for the toggle and gets keyboard handling
+ * (Enter, Space) plus screen-reader semantics for free. The default
+ * disclosure triangle is suppressed via the WebKit pseudo-element and the
+ * Tailwind `marker` variant (both are needed to cover Chromium, WebKit, and
+ * Firefox). Phase 03 may swap this for a richer popover if menu density
+ * grows; for now (email + Sign out) it is the smallest possible thing.
+ *
+ * Sign out calls `authClient.signOut()`, then navigates to `/auth/sign-in`
+ * and refreshes the route so the admin layout's `getSession()` call sees no
+ * session and the new sign-in page renders.
+ */
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { signOut } from '@/lib/auth/client'
+import { logger } from '@/lib/logger'
+
+interface AccountMenuProps {
+	email: string
+}
+
+export function AccountMenu({ email }: AccountMenuProps) {
+	const router = useRouter()
+	const [isSigningOut, setIsSigningOut] = useState(false)
+
+	async function handleSignOut() {
+		setIsSigningOut(true)
+		const result = await signOut()
+
+		if (result.error) {
+			logger.error('Sign-out failed', result.error)
+			toast.error('Could not sign out. Please try again.')
+			setIsSigningOut(false)
+			return
+		}
+
+		toast.success('Signed out.')
+		router.push('/auth/sign-in')
+		router.refresh()
+	}
+
+	return (
+		<details className="relative group">
+			<summary
+				aria-label="Account menu"
+				aria-haspopup="menu"
+				className="cursor-pointer list-none marker:hidden [&::-webkit-details-marker]:hidden inline-flex items-center gap-2 rounded-md border border-border bg-surface-raised px-3 py-1.5 text-sm font-medium text-foreground hover:bg-surface-sunken transition-smooth"
+			>
+				<span className="max-w-[12rem] truncate">{email}</span>
+				<svg
+					width="12"
+					height="12"
+					viewBox="0 0 12 12"
+					fill="none"
+					aria-hidden="true"
+					className="transition-transform group-open:rotate-180"
+				>
+					<title>Menu indicator</title>
+					<path
+						d="M2.5 4.5L6 8L9.5 4.5"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			</summary>
+			<div
+				role="menu"
+				className="absolute right-0 mt-2 w-64 rounded-md border border-border bg-surface-raised p-2 shadow-lg z-modal"
+			>
+				<div className="px-2 py-1.5 text-xs text-muted-foreground">
+					Signed in as
+				</div>
+				<div className="px-2 pb-2 text-sm font-medium text-foreground truncate">
+					{email}
+				</div>
+				<div className="border-t border-border my-1" />
+				<button
+					type="button"
+					role="menuitem"
+					onClick={handleSignOut}
+					disabled={isSigningOut}
+					aria-busy={isSigningOut}
+					className="w-full text-left px-2 py-1.5 text-sm rounded text-foreground hover:bg-surface-sunken focus-visible:bg-surface-sunken disabled:opacity-50 disabled:cursor-not-allowed transition-smooth"
+				>
+					{isSigningOut ? 'Signing out...' : 'Sign out'}
+				</button>
+			</div>
+		</details>
+	)
+}

--- a/src/components/auth/AccountMenu.tsx
+++ b/src/components/auth/AccountMenu.tsx
@@ -46,10 +46,13 @@ export function AccountMenu({ email }: AccountMenuProps) {
 	}
 
 	return (
+		// Native <details>/<summary> is a disclosure widget, not an ARIA
+		// menu. We deliberately don't add aria-haspopup="menu" / role="menu"
+		// here because that conflicts with the browser's disclosure semantics
+		// and confuses screen readers. The Sign out control is a plain button.
 		<details className="relative group">
 			<summary
 				aria-label="Account menu"
-				aria-haspopup="menu"
 				className="cursor-pointer list-none marker:hidden [&::-webkit-details-marker]:hidden inline-flex items-center gap-2 rounded-md border border-border bg-surface-raised px-3 py-1.5 text-sm font-medium text-foreground hover:bg-surface-sunken transition-smooth"
 			>
 				<span className="max-w-[12rem] truncate">{email}</span>
@@ -61,7 +64,6 @@ export function AccountMenu({ email }: AccountMenuProps) {
 					aria-hidden="true"
 					className="transition-transform group-open:rotate-180"
 				>
-					<title>Menu indicator</title>
 					<path
 						d="M2.5 4.5L6 8L9.5 4.5"
 						stroke="currentColor"
@@ -71,10 +73,7 @@ export function AccountMenu({ email }: AccountMenuProps) {
 					/>
 				</svg>
 			</summary>
-			<div
-				role="menu"
-				className="absolute right-0 mt-2 w-64 rounded-md border border-border bg-surface-raised p-2 shadow-lg z-modal"
-			>
+			<div className="absolute right-0 mt-2 w-64 rounded-md border border-border bg-surface-raised p-2 shadow-lg z-modal">
 				<div className="px-2 py-1.5 text-xs text-muted-foreground">
 					Signed in as
 				</div>
@@ -84,7 +83,6 @@ export function AccountMenu({ email }: AccountMenuProps) {
 				<div className="border-t border-border my-1" />
 				<button
 					type="button"
-					role="menuitem"
 					onClick={handleSignOut}
 					disabled={isSigningOut}
 					aria-busy={isSigningOut}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -42,10 +42,12 @@ export function SignInForm() {
 		}
 
 		setIsSubmitting(true)
+		// callbackURL is intentionally omitted: it sets a server header that
+		// our SPA-style flow does not act on. router.push() below does the
+		// actual navigation.
 		const result = await signIn.email({
 			email: parsed.data.email,
-			password: parsed.data.password,
-			callbackURL: '/admin'
+			password: parsed.data.password
 		})
 
 		if (result.error) {

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+/**
+ * Sign-in client form.
+ *
+ * Validates input with `signInSchema`, then calls Better Auth's
+ * `authClient.signIn.email(...)`. On success, the browser navigates to
+ * `/admin` and `router.refresh()` forces React Server Components to re-render
+ * with the freshly set session cookie. Errors are surfaced via sonner toasts;
+ * internal details go to the project logger, never to the user.
+ *
+ * Uses local `useState` rather than the project's @tanstack/react-form factory
+ * because the surface is two fields with a single submit button: the
+ * abstraction overhead outweighs the benefit. Mirrors the precedent in
+ * `src/app/unsubscribe/UnsubscribeForm.tsx`.
+ */
+import { useRouter } from 'next/navigation'
+import { type FormEvent, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { signIn } from '@/lib/auth/client'
+import { logger } from '@/lib/logger'
+import { signInSchema } from '@/lib/schemas/auth-forms'
+
+export function SignInForm() {
+	const router = useRouter()
+	const [email, setEmail] = useState('')
+	const [password, setPassword] = useState('')
+	const [isSubmitting, setIsSubmitting] = useState(false)
+
+	async function onSubmit(event: FormEvent<HTMLFormElement>) {
+		event.preventDefault()
+
+		const parsed = signInSchema.safeParse({ email, password })
+		if (!parsed.success) {
+			const message =
+				parsed.error.issues[0]?.message ?? 'Please check your input.'
+			toast.error(message)
+			return
+		}
+
+		setIsSubmitting(true)
+		const result = await signIn.email({
+			email: parsed.data.email,
+			password: parsed.data.password,
+			callbackURL: '/admin'
+		})
+
+		if (result.error) {
+			logger.error('Sign-in failed', result.error, {
+				metadata: { email: parsed.data.email }
+			})
+			toast.error('Invalid email or password.')
+			setIsSubmitting(false)
+			return
+		}
+
+		toast.success('Signed in.')
+		router.push('/admin')
+		router.refresh()
+	}
+
+	return (
+		<form onSubmit={onSubmit} className="space-y-4" noValidate>
+			<div className="space-y-1.5">
+				<Label htmlFor="sign-in-email">Email</Label>
+				<Input
+					id="sign-in-email"
+					name="email"
+					type="email"
+					autoComplete="email"
+					required
+					value={email}
+					onChange={event => setEmail(event.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+			<div className="space-y-1.5">
+				<Label htmlFor="sign-in-password">Password</Label>
+				<Input
+					id="sign-in-password"
+					name="password"
+					type="password"
+					autoComplete="current-password"
+					required
+					value={password}
+					onChange={event => setPassword(event.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+			<Button
+				type="submit"
+				disabled={isSubmitting}
+				aria-busy={isSubmitting}
+				className="w-full"
+			>
+				{isSubmitting ? 'Signing in...' : 'Sign in'}
+			</Button>
+		</form>
+	)
+}

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -46,11 +46,11 @@ export function SignUpForm() {
 		}
 
 		setIsSubmitting(true)
+		// callbackURL omitted: router.push() below handles navigation.
 		const result = await signUp.email({
 			email: parsed.data.email,
 			password: parsed.data.password,
-			name: parsed.data.name ?? parsed.data.email,
-			callbackURL: '/admin'
+			name: parsed.data.name ?? parsed.data.email
 		})
 
 		if (result.error) {

--- a/src/components/auth/SignUpForm.tsx
+++ b/src/components/auth/SignUpForm.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+/**
+ * Sign-up client form.
+ *
+ * Validates input with `signUpSchema`, then calls Better Auth's
+ * `authClient.signUp.email(...)`. On success, the browser navigates to
+ * `/admin` and `router.refresh()` forces React Server Components to re-render
+ * with the freshly set session cookie. Errors are mapped to friendly toasts;
+ * raw Better Auth error codes never leak to the user.
+ *
+ * Uses local `useState` rather than the project's @tanstack/react-form factory
+ * for the same reason as `SignInForm`: small surface (three fields), single
+ * submit button, mirrors the precedent in `src/app/unsubscribe/UnsubscribeForm.tsx`.
+ */
+import { useRouter } from 'next/navigation'
+import { type FormEvent, useState } from 'react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { signUp } from '@/lib/auth/client'
+import { logger } from '@/lib/logger'
+import { signUpSchema } from '@/lib/schemas/auth-forms'
+
+export function SignUpForm() {
+	const router = useRouter()
+	const [name, setName] = useState('')
+	const [email, setEmail] = useState('')
+	const [password, setPassword] = useState('')
+	const [isSubmitting, setIsSubmitting] = useState(false)
+
+	async function onSubmit(event: FormEvent<HTMLFormElement>) {
+		event.preventDefault()
+
+		const parsed = signUpSchema.safeParse({
+			email,
+			password,
+			name: name || undefined
+		})
+		if (!parsed.success) {
+			const message =
+				parsed.error.issues[0]?.message ?? 'Please check your input.'
+			toast.error(message)
+			return
+		}
+
+		setIsSubmitting(true)
+		const result = await signUp.email({
+			email: parsed.data.email,
+			password: parsed.data.password,
+			name: parsed.data.name ?? parsed.data.email,
+			callbackURL: '/admin'
+		})
+
+		if (result.error) {
+			logger.error('Sign-up failed', result.error, {
+				metadata: { email: parsed.data.email }
+			})
+			toast.error('Could not create account. Please try again.')
+			setIsSubmitting(false)
+			return
+		}
+
+		toast.success('Account created.')
+		router.push('/admin')
+		router.refresh()
+	}
+
+	return (
+		<form onSubmit={onSubmit} className="space-y-4" noValidate>
+			<div className="space-y-1.5">
+				<Label htmlFor="sign-up-name">Name (optional)</Label>
+				<Input
+					id="sign-up-name"
+					name="name"
+					type="text"
+					autoComplete="name"
+					value={name}
+					onChange={event => setName(event.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+			<div className="space-y-1.5">
+				<Label htmlFor="sign-up-email">Email</Label>
+				<Input
+					id="sign-up-email"
+					name="email"
+					type="email"
+					autoComplete="email"
+					required
+					value={email}
+					onChange={event => setEmail(event.target.value)}
+					disabled={isSubmitting}
+				/>
+			</div>
+			<div className="space-y-1.5">
+				<Label htmlFor="sign-up-password">Password</Label>
+				<Input
+					id="sign-up-password"
+					name="password"
+					type="password"
+					autoComplete="new-password"
+					required
+					minLength={8}
+					value={password}
+					onChange={event => setPassword(event.target.value)}
+					disabled={isSubmitting}
+				/>
+				<p className="text-xs text-muted-foreground">At least 8 characters.</p>
+			</div>
+			<Button
+				type="submit"
+				disabled={isSubmitting}
+				aria-busy={isSubmitting}
+				className="w-full"
+			>
+				{isSubmitting ? 'Creating account...' : 'Create account'}
+			</Button>
+		</form>
+	)
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -84,6 +84,22 @@ export const env = createEnv({
 				'CRON_SECRET is required in production'
 			),
 
+		// Better Auth - session-signing secret (required in Vercel production)
+		BETTER_AUTH_SECRET: z
+			.string()
+			.min(32, 'BETTER_AUTH_SECRET must be at least 32 characters')
+			.optional()
+			.refine(
+				val => process.env.VERCEL_ENV !== 'production' || !!val,
+				'BETTER_AUTH_SECRET is required in production'
+			),
+
+		// Better Auth - canonical app URL (optional; falls back to BASE_URL at call site)
+		BETTER_AUTH_URL: z.string().url().optional(),
+
+		// Better Auth - extra trusted origins (optional; comma-separated, parsed at call site)
+		BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
+
 		// Upstash Redis for distributed rate limiting (optional)
 		// Set automatically when an Upstash Redis integration is attached via Vercel Marketplace.
 		UPSTASH_REDIS_REST_URL: z.string().url().optional(),
@@ -130,6 +146,9 @@ export const env = createEnv({
 		npm_package_version: process.env.npm_package_version,
 		ADMIN_SECRET: process.env.ADMIN_SECRET,
 		CRON_SECRET: process.env.CRON_SECRET,
+		BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET,
+		BETTER_AUTH_URL: process.env.BETTER_AUTH_URL,
+		BETTER_AUTH_TRUSTED_ORIGINS: process.env.BETTER_AUTH_TRUSTED_ORIGINS,
 		DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
 		UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
 		UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -6,7 +6,7 @@
  * client-side base URL exposed by T3 env.
  *
  * Do NOT add a server-only guard here; this file is intentionally
- * client-safe. Do NOT import from `./index` (the server config) — that
+ * client-safe. Do NOT import from `./index` (the server config) - that
  * module is server-only and pulling it in would poison the client bundle.
  */
 import { createAuthClient } from 'better-auth/react'

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,0 +1,19 @@
+/**
+ * Better Auth browser SDK.
+ *
+ * Imported by client components (sign-in form, sign-up form, account menu,
+ * sign-out button). Points at the same origin the server is serving via the
+ * client-side base URL exposed by T3 env.
+ *
+ * Do NOT add a server-only guard here; this file is intentionally
+ * client-safe. Do NOT import from `./index` (the server config) — that
+ * module is server-only and pulling it in would poison the client bundle.
+ */
+import { createAuthClient } from 'better-auth/react'
+import { env } from '@/env'
+
+export const authClient = createAuthClient({
+	baseURL: env.NEXT_PUBLIC_BASE_URL
+})
+
+export const { signIn, signUp, signOut, useSession } = authClient

--- a/src/lib/auth/get-session.ts
+++ b/src/lib/auth/get-session.ts
@@ -13,10 +13,14 @@
 import 'server-only'
 
 import { headers } from 'next/headers'
+import { cache } from 'react'
 import { auth } from '@/lib/auth'
 
-export async function getSession() {
+// React's per-request cache: two calls inside the same render share one
+// result. Cheap protection against double-fetching when both the layout
+// and a child page call getSession() in the same request.
+export const getSession = cache(async () => {
 	return auth.api.getSession({ headers: await headers() })
-}
+})
 
 export type SessionData = Awaited<ReturnType<typeof getSession>>

--- a/src/lib/auth/get-session.ts
+++ b/src/lib/auth/get-session.ts
@@ -1,0 +1,22 @@
+/**
+ * Server-side session helper.
+ *
+ * Forwards the incoming request headers from `next/headers` to Better Auth
+ * and returns `{ user, session } | null`. Better Auth returns `null` for
+ * missing or invalid sessions; any thrown error is something the caller
+ * (admin layout, middleware, server components) should see, so this helper
+ * deliberately does not wrap the call in try/catch.
+ *
+ * Consumers in Plans 02-04 / 02-05 import `SessionData` to type their props
+ * without re-deriving the awaited return type.
+ */
+import 'server-only'
+
+import { headers } from 'next/headers'
+import { auth } from '@/lib/auth'
+
+export async function getSession() {
+	return auth.api.getSession({ headers: await headers() })
+}
+
+export type SessionData = Awaited<ReturnType<typeof getSession>>

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -77,7 +77,7 @@ export const auth = betterAuth({
 					} catch (error) {
 						// Never throw out of the hook: a thrown after-hook does not
 						// roll back the user create on Better Auth, but it does surface
-						// as a 500 to the client. The signup itself succeeded — log
+						// as a 500 to the client. The signup itself succeeded - log
 						// and move on so the operator can run the manual UPDATE.
 						logger.error(
 							'First-signup-admin hook failed; promote manually via SQL',

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Better Auth server configuration.
+ *
+ * Wires Better Auth to the existing Drizzle/Neon client and the auth tables
+ * defined in `src/lib/schemas/auth.ts`. Exposes a single `auth` export used by:
+ *   - `src/app/api/auth/[...all]/route.ts` (catch-all handler)
+ *   - `src/lib/auth/get-session.ts` (server-side session helper)
+ *
+ * Email + password is enabled; OAuth providers are intentionally not wired
+ * (see Phase 02 CONTEXT non-goals).
+ *
+ * The `databaseHooks.user.create.after` hook promotes the first signup to
+ * `role='admin'`. Race-condition tolerance: a single operator runs the first
+ * signup before announcing the URL, so a count-based check is sufficient.
+ * Later admins are promoted via SQL UPDATE (see CLAUDE.md > Auth).
+ *
+ * This module imports `server-only` to fail-fast if it is ever pulled into
+ * a client bundle (mirrors `src/lib/resend-client.ts` and the other
+ * server-only modules listed in CLAUDE.md > File Organization).
+ */
+import 'server-only'
+
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { nextCookies } from 'better-auth/next-js'
+import { count, eq } from 'drizzle-orm'
+import { env } from '@/env'
+import { db } from '@/lib/db'
+import { logger } from '@/lib/logger'
+import { accounts, sessions, users, verifications } from '@/lib/schemas/schema'
+
+const trustedOrigins =
+	env.BETTER_AUTH_TRUSTED_ORIGINS?.split(',')
+		.map(value => value.trim())
+		.filter(Boolean) ?? []
+
+export const auth = betterAuth({
+	database: drizzleAdapter(db, {
+		provider: 'pg',
+		schema: {
+			user: users,
+			session: sessions,
+			account: accounts,
+			verification: verifications
+		}
+	}),
+	emailAndPassword: {
+		enabled: true
+	},
+	secret: env.BETTER_AUTH_SECRET,
+	baseURL: env.BETTER_AUTH_URL ?? env.BASE_URL,
+	trustedOrigins,
+	user: {
+		additionalFields: {
+			role: {
+				type: 'string',
+				defaultValue: 'user'
+			}
+		}
+	},
+	databaseHooks: {
+		user: {
+			create: {
+				after: async createdUser => {
+					try {
+						const [row] = await db.select({ value: count() }).from(users)
+						if (row?.value === 1) {
+							await db
+								.update(users)
+								.set({ role: 'admin', updatedAt: new Date() })
+								.where(eq(users.id, createdUser.id))
+							logger.info('First user promoted to admin', {
+								userId: createdUser.id,
+								email: createdUser.email
+							})
+						}
+					} catch (error) {
+						// Never throw out of the hook: a thrown after-hook does not
+						// roll back the user create on Better Auth, but it does surface
+						// as a 500 to the client. The signup itself succeeded — log
+						// and move on so the operator can run the manual UPDATE.
+						logger.error(
+							'First-signup-admin hook failed; promote manually via SQL',
+							error,
+							{
+								metadata: {
+									userId: createdUser.id,
+									email: createdUser.email
+								}
+							}
+						)
+					}
+				}
+			}
+		}
+	},
+	plugins: [nextCookies()]
+})

--- a/src/lib/schemas/auth-forms.ts
+++ b/src/lib/schemas/auth-forms.ts
@@ -1,0 +1,37 @@
+/**
+ * Zod schemas for sign-in and sign-up form inputs.
+ *
+ * Shared by the client form components (`SignInForm`, `SignUpForm`) and any
+ * future server-side validation. Intentionally NOT marked as a server-only
+ * module so the same schema runs in the browser before the network call and
+ * on the server when Better Auth eventually validates the request.
+ *
+ * Email validation reuses the shared validator from `./common.ts` to stay
+ * consistent with the contact / newsletter forms (lowercased, trimmed,
+ * non-empty). Passwords are length-checked only; Better Auth handles hashing.
+ */
+import { z } from 'zod'
+import { emailSchema } from '@/lib/schemas/common'
+
+const passwordSchema = z
+	.string()
+	.min(8, 'Password must be at least 8 characters')
+	.max(128, 'Password must be less than 128 characters')
+
+export const signInSchema = z.object({
+	email: emailSchema,
+	password: passwordSchema
+})
+
+export const signUpSchema = z.object({
+	email: emailSchema,
+	password: passwordSchema,
+	name: z
+		.string()
+		.min(1, 'Name is required')
+		.max(100, 'Name must be less than 100 characters')
+		.optional()
+})
+
+export type SignInInput = z.infer<typeof signInSchema>
+export type SignUpInput = z.infer<typeof signUpSchema>

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -1,0 +1,94 @@
+/**
+ * Better Auth schemas
+ * Tables: users, sessions, accounts, verifications
+ *
+ * Better Auth supplies the id values (text), so no defaultRandom() on PKs.
+ * Role values ('admin' | 'user') are enforced by application code, not by a
+ * DB CHECK constraint. The first signup is promoted to 'admin' via the
+ * Better Auth databaseHook configured in src/lib/auth (see Plan 02-03).
+ *
+ * DDL was applied to Neon via mcp__Neon__run_sql (drizzle-kit push is broken
+ * on this project because pg_cron + hypopg are installed; see CLAUDE.md).
+ */
+import { boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core'
+
+export const users = pgTable('users', {
+	id: text('id').primaryKey(),
+	email: text('email').notNull().unique(),
+	emailVerified: boolean('email_verified').notNull().default(false),
+	name: text('name'),
+	image: text('image'),
+	role: text('role').notNull().default('user'),
+	createdAt: timestamp('created_at', { withTimezone: true })
+		.notNull()
+		.defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true })
+		.notNull()
+		.defaultNow()
+})
+
+export const sessions = pgTable('sessions', {
+	id: text('id').primaryKey(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => users.id, { onDelete: 'cascade' }),
+	expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+	token: text('token').notNull().unique(),
+	ipAddress: text('ip_address'),
+	userAgent: text('user_agent'),
+	createdAt: timestamp('created_at', { withTimezone: true })
+		.notNull()
+		.defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true })
+		.notNull()
+		.defaultNow()
+})
+
+export const accounts = pgTable('accounts', {
+	id: text('id').primaryKey(),
+	userId: text('user_id')
+		.notNull()
+		.references(() => users.id, { onDelete: 'cascade' }),
+	accountId: text('account_id').notNull(),
+	providerId: text('provider_id').notNull(),
+	accessToken: text('access_token'),
+	refreshToken: text('refresh_token'),
+	idToken: text('id_token'),
+	accessTokenExpiresAt: timestamp('access_token_expires_at', {
+		withTimezone: true
+	}),
+	refreshTokenExpiresAt: timestamp('refresh_token_expires_at', {
+		withTimezone: true
+	}),
+	scope: text('scope'),
+	password: text('password'),
+	createdAt: timestamp('created_at', { withTimezone: true })
+		.notNull()
+		.defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true })
+		.notNull()
+		.defaultNow()
+})
+
+export const verifications = pgTable('verifications', {
+	id: text('id').primaryKey(),
+	identifier: text('identifier').notNull(),
+	value: text('value').notNull(),
+	expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+	createdAt: timestamp('created_at', { withTimezone: true })
+		.notNull()
+		.defaultNow(),
+	updatedAt: timestamp('updated_at', { withTimezone: true })
+		.notNull()
+		.defaultNow()
+})
+
+// Type exports
+export type User = typeof users.$inferSelect
+export type NewUser = typeof users.$inferInsert
+export type Session = typeof sessions.$inferSelect
+export type NewSession = typeof sessions.$inferInsert
+export type Account = typeof accounts.$inferSelect
+export type NewAccount = typeof accounts.$inferInsert
+export type Verification = typeof verifications.$inferSelect
+export type NewVerification = typeof verifications.$inferInsert

--- a/src/lib/schemas/schema.ts
+++ b/src/lib/schemas/schema.ts
@@ -3,6 +3,7 @@
  * Re-exports all Drizzle table definitions for use with drizzle-orm
  */
 export * from './analytics'
+export * from './auth'
 export * from './blog'
 export * from './content'
 export * from './emails'


### PR DESCRIPTION
## Summary

Phase 02 of v4 (Admin Panel). Wires Better Auth into the project so subsequent v4 phases can assume "you have a session, you're an admin, you're inside `/admin`."

Built via GSD: design spec at `.planning/phases/02-auth-foundation/02-CONTEXT.md`, 5 plans across 5 sequential waves, atomic commits per plan.

## What ships

**Database (Neon)**
- 4 new tables: `users`, `sessions`, `accounts`, `verifications` (Better Auth standard shape with our `role` column on users)
- DDL run via `psql` against `neondb` (drizzle-kit push is broken on this project due to pg_cron + hypopg; documented)
- First signup auto-promoted to `role='admin'` via Better Auth `databaseHooks.user.create.after`

**Library + config**
- `better-auth@1.6.11` installed
- 3 new env vars: `BETTER_AUTH_SECRET` (production-required, min 32 chars), `BETTER_AUTH_URL` (defaults to BASE_URL), `BETTER_AUTH_TRUSTED_ORIGINS` (optional)
- Server config: `src/lib/auth/index.ts` (`server-only`)
- Client SDK: `src/lib/auth/client.ts`
- Session helper: `src/lib/auth/get-session.ts` (`server-only`)
- Catch-all API route: `src/app/api/auth/[...all]/route.ts`

**UI**
- `/auth/sign-in` and `/auth/sign-up` (server pages + client form components)
- Zod form schemas at `src/lib/schemas/auth-forms.ts`
- `/admin/layout.tsx` server component: redirects to `/auth/sign-in` if no session, returns 403 if `role !== 'admin'`
- `/admin/page.tsx` placeholder confirms the loop works (Phase 03 replaces it)
- `AccountMenu` uses native `<details>/<summary>` (zero new dependencies, native a11y)

**Edge guard**
- `proxy.ts` extended with `/admin/*` cookie-presence check (defense in depth; the server-component layout is the source of truth for DB-backed validation + role enforcement)

## Verification

- `bun run lint`: PASS (Biome, 289 files)
- `bun run typecheck`: PASS (`tsc --noEmit`)
- `bun run build`: PASS — new routes `/auth/sign-in`, `/auth/sign-up`, `/admin`, `/api/auth/[...all]` all in route table
- Em-dash / en-dash sweep across all phase-02 files: zero matches
- `src/lib/auth/admin.ts` (Bearer guard for cron) diff vs main: empty (untouched, runs in parallel)

## Out of scope (Phase 03+)

- Admin dashboard page itself (Phase 03 builds the Efferd Dashboard 5 layout + real-data wiring)
- Admin CRUD for showcase/blog/testimonials (Phase 04)
- Admin ops pages for leads/newsletter/emails (Phase 05)
- Password reset, email verification, OAuth providers, 2FA — deferred indefinitely
- Admin promotion UI; second-admin via manual SQL `UPDATE users SET role='admin' WHERE email='...'` (documented in CLAUDE.md)

## Plan trail

| Commit | Plan | What |
|---|---|---|
| \`b9148a0\` | 02-01 | better-auth + env vars |
| \`c7f5615\` | 02-02 | Drizzle tables + Neon DDL |
| \`4212579\` | 02-03 | Better Auth server, client, catch-all, first-signup-admin hook |
| \`3c09d8a\` | 02-04 | Auth pages + /admin layout + AccountMenu |
| \`25cf5ee\` | 02-05 | proxy.ts edge guard + verification |

[hudsor01]