### PR TITLE
chore(planning): sync STATE after PR #213 + dependabot triage

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,14 +1,16 @@
 # STATE — Current GSD Position
 
 **Last updated:** 2026-05-23
-**Branch:** `admin-shell-dashboard`
+**Branch:** `main`
 **Current milestone:** v4 (Admin Panel)
-**Current phase:** `03-admin-shell-and-dashboard` (complete 6/6)
+**Current phase:** `03-admin-shell-and-dashboard` (complete 6/6, **merged to main as `d88d049` via PR #213**)
 **Current plan:** none (phase closed)
 
 ## What just happened
 
-- Phase 03 (`admin-shell-and-dashboard`) closed. 6 plans across 4 waves, 5 implementation commits + 1 verification commit on `admin-shell-dashboard`. Real admin shell shipped: `Sidebar` (client, `usePathname` active state) + `Topbar` (server, site name + page label + AccountMenu) + `Forbidden` (server, 403 panel) composed in `src/app/admin/layout.tsx`; `/admin` 307-redirects to `/admin/dashboard`; the dashboard page renders 5 widgets (VisitorsChart, WebVitalsCards, TopPagesTable, TrafficSourcesPie, RecentLeadsPanel) all backed by `src/lib/admin/dashboard-queries.ts` via `Promise.all`; 6 coming-soon stubs under `(coming-soon)/{showcase,blog,testimonials,leads,newsletter,emails}` for Phase 04/05. `recharts@3.8.1` added. All automated gates green: lint + typecheck + build exit 0 with the full `/admin/*` + `/auth/*` route table present, em/en-dash count = 0 across 19 changed files, every Phase-02 file + `src/lib/auth/admin.ts` (Bearer guard for cron) byte-equal to `main`, no hardcoded sample arrays in any widget. Manual 12-step operator smoke deferred to operator pre-PR (see `.planning/phases/03-admin-shell-and-dashboard/03-SUMMARY.md`).
+- Dependabot triage swept clean. PR #207 (sanitize-html 2.17.4 standalone) closed in favor of `#211`, which bundled the same security patch. `#212` (dev tooling: types/bun, types/node, types/react, knip, lefthook) merged as `c36a8f2`. `#211` (sanitize-html 2.17.4 xmp tag bypass fix + @tanstack/react-query 5.100.13) merged as `3a5ab55`. `#205` (lucide-react 1.14.0 -> 1.16.0; was red on a 5-day-stale base inheriting the admin-auth test flake) recreated via `@dependabot recreate`, locally verified on fresh main (516/516 tests), merged as `f15d7a6`. All three merges admin-flagged past the recurring Create Neon Branch transient failure; build/code-quality/test/setup all green.
+- PR #213 (Phase 03) merged to `main` as `d88d049`. Review loop ran 2 iterations: iter-1 flagged 6 findings (W1-W4 + N1-N2, addressed in commit `5fcfc8e`), iter-2 verified zero findings and approved. CI: build/code-quality/test/setup all green; Create Neon Branch failed (recurring transient flake, admin-merged per established pattern). Branch deleted.
+- Phase 03 (`admin-shell-and-dashboard`) closed. 6 plans across 4 waves, 5 implementation commits + 1 verification commit + 1 review-fix commit on `admin-shell-dashboard`. Real admin shell shipped: `Sidebar` (client, `usePathname` active state, brand is `<Link>` to `/admin/dashboard`) + `Topbar` (server, site name + page label + AccountMenu) + `Forbidden` (server, 403 panel) composed in `src/app/admin/layout.tsx`; `/admin` 307-redirects to `/admin/dashboard`; the dashboard page renders 5 widgets (VisitorsChart, WebVitalsCards, TopPagesTable, TrafficSourcesPie, RecentLeadsPanel) all backed by `src/lib/admin/dashboard-queries.ts` via `Promise.all`; 6 coming-soon stubs under `(coming-soon)/{showcase,blog,testimonials,leads,newsletter,emails}` for Phase 04/05. `recharts@3.8.1` added. All automated gates green: lint + typecheck + build exit 0 with the full `/admin/*` + `/auth/*` route table present, em/en-dash count = 0 across 19 changed files, every Phase-02 file + `src/lib/auth/admin.ts` (Bearer guard for cron) byte-equal to `main`, no hardcoded sample arrays in any widget. Manual 12-step operator smoke deferred to operator pre-PR (see `.planning/phases/03-admin-shell-and-dashboard/03-SUMMARY.md`).
 - Phase 02 (`auth-foundation`) closed earlier. 5 plans, 5 commits on `admin-panel-auth`. Better Auth wired end to end (users/sessions/accounts/verifications + sign-in / sign-up + role-guarded `/admin` layout + AccountMenu + `proxy.ts` edge cookie short-circuit). Merged into the base for `admin-shell-dashboard`.
 - Milestone v4 (Admin Panel) on track: 2/4 phases complete, 2 pending (`04-admin-content-crud`, `05-admin-ops`).
 - Milestone v3 closed: Phase 01 (`showcase-ui-redesign`) shipped to main as `59e5e70` via PR #208; planning sync as `60175b3` via PR #209.
@@ -39,8 +41,8 @@
 - 4 location pages (75 cities) shipped in PR #206; no follow-up planned.
 - 4 pre-existing em-dashes in `src/components/ui/card.tsx` JSX block comments — out of scope per v3.0/01 verification.
 - `industry` prop on `ProjectCardProps` is dead surface (pre-existing); candidate for cleanup if v4 phase 04 touches Card again.
-- Biome `lint/style/useTemplate` info diagnostic on `src/components/admin/Sidebar.tsx:61` (`item.href + '/'`) — info-only, exit 0; auto-fix available if Phase 04 touches the file.
+- The Biome `lint/style/useTemplate` info diagnostic in Sidebar.tsx was fixed during PR #213 iter-1 (W1).
 
 ## Next action
 
-Ship Phase 03 PR. Operator runs the 12-step manual smoke checklist from `.planning/phases/03-admin-shell-and-dashboard/03-SUMMARY.md` against `bun run dev`, then opens the PR for `admin-shell-dashboard` (squash recommended: `feat(admin): shell + dashboard - sidebar, topbar, 5 real-data widgets, 6 coming-soon stubs`). After merge, kick off Phase 04 (`admin-content-crud`) on a fresh branch off `main`: write `04-CONTEXT.md` (resource list, CRUD pattern, list/create/edit/delete page shapes for `/admin/showcase`, `/admin/blog`, `/admin/testimonials`) and run `gsd-plan-phase 04-admin-content-crud`.
+Operator runs the 12-step manual smoke from `.planning/phases/03-admin-shell-and-dashboard/03-SUMMARY.md` against the live `/admin/dashboard` deploy. After that, kick off Phase 04 (`admin-content-crud`) on a fresh branch off `main`: write `04-CONTEXT.md` (resource list, CRUD pattern, list/create/edit/delete page shapes for `/admin/showcase`, `/admin/blog`, `/admin/testimonials`) and run `gsd-plan-phase 04-admin-content-crud`.


### PR DESCRIPTION
Planning STATE.md sync after Phase 03 (PR #213) merged and 4 dependabot PRs were processed:

- #207 closed (superseded by #211)
- #212 merged: dev tooling patch bumps (`c36a8f2`)
- #211 merged: sanitize-html 2.17.4 xmp tag bypass security patch + react-query 5.100.13 (`3a5ab55`)
- #205 merged: lucide-react 1.14 -> 1.16 (`f15d7a6`)

All three dependabot merges locally re-verified (516/516 tests) on the recreated branches before flagging through.

Next action: operator manual smoke on /admin/dashboard, then Phase 04 (admin-content-crud) kickoff.

[hudsor01]