### PR TITLE
fix: admin/auth chrome bleed + em-dash sweep across all user-facing text

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -132,7 +132,7 @@ export default function AboutPage() {
 							The Experience Behind Your Website
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							We build websites the way a business owner thinks — every choice
+							We build websites the way a business owner thinks. Every choice is
 							measured against whether it brings customers in.
 						</p>
 					</div>
@@ -146,8 +146,8 @@ export default function AboutPage() {
 							<div className="space-y-4 text-sm text-muted-foreground leading-relaxed">
 								<p>
 									Most agencies learned web development in bootcamps. We learned
-									it in the trenches of revenue operations — where every
-									decision either moves the business forward or holds it back.
+									it in the trenches of revenue operations, where every decision
+									either moves the business forward or holds it back.
 								</p>
 								<p>
 									With{' '}
@@ -158,7 +158,7 @@ export default function AboutPage() {
 									miss:{' '}
 									<strong className="text-info">
 										websites fail not because of bad code, but because they were
-										never built to bring in customers — just to look nice
+										never built to bring in customers, just to look nice
 									</strong>
 									.
 								</p>
@@ -171,7 +171,7 @@ export default function AboutPage() {
 									<Link href="/services" className="link-primary font-semibold">
 										professional website
 									</Link>{' '}
-									and walk away — every page is built and measured against one
+									and walk away. Every page is built and measured against one
 									question:{' '}
 									<strong className="text-success-text">
 										does this help your business get and keep customers?
@@ -218,8 +218,8 @@ export default function AboutPage() {
 									If the KPI we agree on at kickoff (typically conversion rate,
 									qualified leads per month, or revenue per visitor)
 									doesn&apos;t improve over its installed-analytics baseline
-									within 90 days, I keep working — up to 3 additional revision
-									rounds covering optimization scope — at no extra cost until it
+									within 90 days, I keep working (up to 3 additional revision
+									rounds covering optimization scope) at no extra cost until it
 									does. Baseline is measured from analytics installed on day one
 									of the engagement.
 								</p>
@@ -341,7 +341,7 @@ export default function AboutPage() {
 							<p className="text-base">
 								Before building for clients, I spent 5+ years in{' '}
 								<strong className="text-accent">revenue operations</strong> at
-								established companies — close enough to the numbers to see
+								established companies, close enough to the numbers to see
 								exactly which websites{' '}
 								<strong className="text-accent">brought in customers</strong>{' '}
 								and which just looked nice.
@@ -355,13 +355,13 @@ export default function AboutPage() {
 								</strong>
 								. Agencies charge $50K for a beautiful site the owner can&apos;t
 								even update. I build small businesses a professional website
-								they control — one that turns the reputation they&apos;ve
-								already earned into booked customers.
+								they control, one that turns the reputation they&apos;ve already
+								earned into booked customers.
 							</p>
 
 							<p className="text-base">
 								When I saw how many great local businesses had glowing reviews
-								but no website — or one so dated it cost them customers — I knew
+								but no website (or one so dated it cost them customers), I knew
 								where I could help. Hudson Digital Solutions exists to fix
 								exactly that:{' '}
 								<strong className="text-accent">
@@ -457,7 +457,7 @@ export default function AboutPage() {
 							</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
 								We build for growth. Your website and systems grow with your
-								business — no expensive rebuilds when you scale.
+								business, no expensive rebuilds when you scale.
 							</p>
 						</div>
 					</div>
@@ -514,7 +514,7 @@ export default function AboutPage() {
 							</h2>
 
 							<p className="text-lead text-muted-foreground max-w-2xl mx-auto mb-10">
-								Let&apos;s map out the website your business needs — and build
+								Let&apos;s map out the website your business needs, and build
 								you something that turns the reputation you&apos;ve earned into
 								booked customers.
 							</p>

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -2,10 +2,10 @@
  * Auth route-group layout.
  *
  * Renders the sign-in and sign-up pages inside a centered, chrome-free
- * container. The site Navbar and Footer (which live in the root layout)
- * remain wrapped around this, but the page content here is centered into a
- * narrow column so the form is the only focal point. The root layout already
- * mounts a `<Toaster />` from sonner, so this layout does not duplicate it.
+ * container. The site Navbar and Footer self-suppress on /auth/* via
+ * usePathname, so this layout sits directly inside the root layout
+ * without marketing chrome bleed-through. The root layout mounts the
+ * <Toaster /> from sonner; this layout does not duplicate it.
  */
 import type { ReactNode } from 'react'
 

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -275,8 +275,8 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 								Ready for the website your business has earned?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Let&apos;s map out what it needs — and build something that
-								turns your reputation into booked customers.
+								Let&apos;s map out what it needs, and build something that turns
+								your reputation into booked customers.
 							</p>
 							<Button asChild variant="accent" size="xl" trackConversion={true}>
 								<Link href="/contact">Get My Free Website Plan</Link>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,11 +10,11 @@ import { getFeaturedPosts, getPosts, getTags } from '@/lib/blog'
 export const metadata: Metadata = {
 	title: 'Small Business Web Design Blog | Hudson Digital',
 	description:
-		'Practical insights on websites, getting found on Google, and growing a small business online — from Hudson Digital Solutions.',
+		'Practical insights on websites, getting found on Google, and growing a small business online, from Hudson Digital Solutions.',
 	openGraph: {
 		title: 'Small Business Web Design Blog | Hudson Digital',
 		description:
-			'Practical insights on websites, getting found on Google, and growing a small business online — from the team at Hudson Digital Solutions.',
+			'Practical insights on websites, getting found on Google, and growing a small business online, from the team at Hudson Digital Solutions.',
 		url: 'https://hudsondigitalsolutions.com/blog',
 		images: [
 			{
@@ -183,7 +183,7 @@ export default function BlogPage() {
 									Curious what a site would cost?
 								</h3>
 								<p className="text-sm text-muted-foreground mb-6 leading-relaxed">
-									Get a free website plan for your business — pages, timeline,
+									Get a free website plan for your business: pages, timeline,
 									and a clear price.
 								</p>
 								<Button asChild variant="accent" className="w-full">

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -198,7 +198,7 @@ export default function ContactPage() {
 												Business Hours
 											</p>
 											<p className="text-xs text-muted-foreground">
-												Monday – Friday, 9am – 6pm CT
+												Monday to Friday, 9am to 6pm CT
 											</p>
 											<p className="text-xs text-muted-foreground">
 												Response within 2 hours

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -6,11 +6,11 @@ import { BUSINESS_INFO } from '@/lib/constants/business'
 export const metadata: Metadata = {
 	title: 'Get a Free Website Plan | Hudson Digital Solutions',
 	description:
-		"Tell us about your business and we'll map out the website it needs — pages, timeline, and cost — on a free 30-minute call. No sales pitch.",
+		"Tell us about your business and we'll map out the website it needs (pages, timeline, and cost) on a free 30-minute call. No sales pitch.",
 	openGraph: {
 		title: 'Free Website Plan in 30 Minutes | Hudson Digital',
 		description:
-			'A free 30-minute call where we map out the website your business needs — pages, timeline, and cost. No sales pitch. Response in 2 hours.'
+			'A free 30-minute call where we map out the website your business needs: pages, timeline, and cost. No sales pitch. Response in 2 hours.'
 	}
 }
 
@@ -84,8 +84,8 @@ export default function ContactPage() {
 								</h1>
 								<p className="mt-4 text-lead text-muted-foreground">
 									Tell us about your business. We&apos;ll map out the website it
-									needs — pages, timeline, and cost — on a free 30-minute call.
-									No sales pitch. No commitment.
+									needs (pages, timeline, and cost) on a free 30-minute call. No
+									sales pitch. No commitment.
 								</p>
 							</div>
 
@@ -135,7 +135,7 @@ export default function ContactPage() {
 											Get your website plan
 										</p>
 										<p className="text-xs text-muted-foreground mt-0.5">
-											Pages, timeline, and a clear price — yours to keep, no
+											Pages, timeline, and a clear price, yours to keep, no
 											obligation
 										</p>
 									</div>
@@ -223,7 +223,7 @@ export default function ContactPage() {
 							We Serve Clients Nationwide
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Primarily serving TX, FL, GA, OK and surrounding states — fully
+							Primarily serving TX, FL, GA, OK and surrounding states, fully
 							remote for all projects.
 						</p>
 					</div>

--- a/src/app/faq/FaqClient.tsx
+++ b/src/app/faq/FaqClient.tsx
@@ -34,7 +34,7 @@ const faqs = [
 			{
 				question: 'What is your typical project timeline?',
 				answer:
-					'Timelines depend on project scope. Simple websites take 4–6 weeks. E-commerce and booking-enabled sites take 8–12 weeks. Larger sites with custom features and booking or payment setup typically take 3–6 months. We can expedite urgent projects with dedicated resources.'
+					'Timelines depend on project scope. Simple websites take 4 to 6 weeks. E-commerce and booking-enabled sites take 8 to 12 weeks. Larger sites with custom features and booking or payment setup typically take 3 to 6 months. We can expedite urgent projects with dedicated resources.'
 			}
 		]
 	},

--- a/src/app/faq/FaqClient.tsx
+++ b/src/app/faq/FaqClient.tsx
@@ -19,12 +19,12 @@ const faqs = [
 			{
 				question: 'What website design services do you offer?',
 				answer:
-					'We design and build professional websites for small businesses — custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
+					'We design and build professional websites for small businesses: custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
 			},
 			{
 				question: 'How much does it cost to build a website?',
 				answer:
-					'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call — we will walk you through options that fit your budget.'
+					'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call. We will walk you through options that fit your budget.'
 			},
 			{
 				question: 'Do you offer monthly retainer packages?',
@@ -69,7 +69,7 @@ const faqs = [
 			{
 				question: 'What technologies do you use?',
 				answer:
-					"We use modern, proven tools chosen for reliability and speed — not because they're trendy. The specific technology depends on what works best for your business. You don't need to know what's under the hood; you just need it to work."
+					"We use modern, proven tools chosen for reliability and speed, not because they're trendy. The specific technology depends on what works best for your business. You don't need to know what's under the hood; you just need it to work."
 			},
 			{
 				question: 'Will my website be mobile-friendly?',
@@ -84,7 +84,7 @@ const faqs = [
 			{
 				question: 'Can you integrate with my existing systems?',
 				answer:
-					'Yes. We connect whatever tools your business already uses — HubSpot, Salesforce, Stripe, your booking system, your email platform. If it has a connection point, we can link it to your website and your workflows.'
+					'Yes. We connect whatever tools your business already uses: HubSpot, Salesforce, Stripe, your booking system, your email platform. If it has a connection point, we can link it to your website and your workflows.'
 			},
 			{
 				question: 'Do you provide hosting and maintenance?',
@@ -104,7 +104,7 @@ const faqs = [
 			{
 				question: 'Do you work with new businesses?',
 				answer:
-					"Absolutely. We understand fast timelines, tight budgets, and the need for quick wins. We help new businesses get their digital foundation right from day one — so you're not paying to redo it later."
+					"Absolutely. We understand fast timelines, tight budgets, and the need for quick wins. We help new businesses get their digital foundation right from day one, so you're not paying to redo it later."
 			},
 			{
 				question: 'What payment terms do you offer?',
@@ -158,7 +158,7 @@ export default function FaqClient() {
 					</h1>
 
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-8">
-						Everything you need to know about working with us — websites,
+						Everything you need to know about working with us: websites,
 						pricing, process, and timelines.
 					</p>
 
@@ -235,8 +235,8 @@ export default function FaqClient() {
 								Still Have Questions?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Get a free website plan — we&apos;ll map out what your site
-								needs and answer every question along the way.
+								Get a free website plan. We&apos;ll map out what your site needs
+								and answer every question along the way.
 							</p>
 							<Button asChild variant="accent" size="xl" trackConversion={true}>
 								<Link href="/contact">

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -64,7 +64,7 @@ const faqSchema = {
 			name: 'What is your typical project timeline?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'Timelines depend on project scope. Simple websites take 4–6 weeks. E-commerce and booking-enabled sites take 8–12 weeks. Larger sites with custom features and booking or payment setup typically take 3–6 months. We can expedite urgent projects with dedicated resources.'
+				text: 'Timelines depend on project scope. Simple websites take 4 to 6 weeks. E-commerce and booking-enabled sites take 8 to 12 weeks. Larger sites with custom features and booking or payment setup typically take 3 to 6 months. We can expedite urgent projects with dedicated resources.'
 			}
 		},
 		{

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -10,11 +10,11 @@ import FaqClient from './FaqClient'
 export const metadata: Metadata = {
 	title: 'Frequently Asked Questions | Hudson Digital Solutions',
 	description:
-		'Answers to common questions about our small business website design and development — pricing, process, timelines, and what is included.',
+		'Answers to common questions about our small business website design and development: pricing, process, timelines, and what is included.',
 	openGraph: {
 		title: 'Frequently Asked Questions | Hudson Digital Solutions',
 		description:
-			'Common questions about our small business website design and development — pricing, process, timelines, and what every project includes.',
+			'Common questions about our small business website design and development: pricing, process, timelines, and what every project includes.',
 		url: 'https://hudsondigitalsolutions.com/faq',
 		images: [
 			{
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
 		card: 'summary_large_image',
 		title: 'Frequently Asked Questions | Hudson Digital Solutions',
 		description:
-			'Common questions about our small business website design and development — pricing, process, timelines, and what every project includes.',
+			'Common questions about our small business website design and development: pricing, process, timelines, and what every project includes.',
 		images: ['/HDS-Logo.webp']
 	},
 	alternates: {
@@ -48,7 +48,7 @@ const faqSchema = {
 			name: 'What website design services do you offer?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'We design and build professional websites for small businesses — custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
+				text: 'We design and build professional websites for small businesses: custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
 			}
 		},
 		{
@@ -56,7 +56,7 @@ const faqSchema = {
 			name: 'How much does it cost to build a website?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call — we will walk you through options that fit your budget.'
+				text: 'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call. We will walk you through options that fit your budget.'
 			}
 		},
 		{

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -167,6 +167,10 @@ export default function RootLayout({
 				<NuqsAdapter>
 					<ClientProviders>
 						<ErrorBoundary>
+							{/* NavbarLight and Footer self-suppress on /admin/* and
+							    /auth/* (via usePathname in each component) so those
+							    route groups can render their own chrome without
+							    marketing nav/footer bleed-through. */}
 							<NavbarLight />
 							{/* The skip-link target is now a real <main> landmark
 							    instead of a wrapping <div>; assistive technology

--- a/src/app/locations/[slug]/page.tsx
+++ b/src/app/locations/[slug]/page.tsx
@@ -283,7 +283,7 @@ export default async function LocationPage({ params }: LocationPageProps) {
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
 								Tell us about your business. We&apos;ll map out the website it
-								needs — pages, timeline, and cost.
+								needs: pages, timeline, and cost.
 							</p>
 							<Button asChild variant="accent" size="xl" trackConversion={true}>
 								<Link href="/contact">

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -12,7 +12,7 @@ import { getLocationsByState } from '@/lib/locations'
 export const metadata: Metadata = {
 	title: 'Service Locations | Hudson Digital Solutions',
 	description:
-		'Hudson Digital Solutions builds websites for small businesses across the US. Find professional web design in your city — Texas, Florida, Georgia, and more.',
+		'Hudson Digital Solutions builds websites for small businesses across the US. Find professional web design in your city: Texas, Florida, Georgia, and more.',
 	openGraph: {
 		title: 'Service Locations | Hudson Digital Solutions',
 		description: 'Professional web design for small businesses across the US.'
@@ -47,7 +47,7 @@ export default function LocationsPage() {
 						Serving Businesses Across the US
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						{totalCities} cities across {states.length} states — find
+						{totalCities} cities across {states.length} states. Find
 						professional web design near you.
 					</p>
 				</div>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -43,7 +43,7 @@ export default function NotFound() {
 					</h2>
 					<p className="text-lead text-muted-foreground max-w-xl mx-auto">
 						The page you&apos;re looking for has vanished into the digital void.
-						But don&apos;t worry—our navigation system is still operational.
+						But don&apos;t worry, our navigation system is still operational.
 					</p>
 				</div>
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { BRAND } from '@/lib/_generated/brand'
 
 export const runtime = 'edge'
 export const alt =
-	'Hudson Digital Solutions — Professional Websites for Small Businesses'
+	'Hudson Digital Solutions: Professional Websites for Small Businesses'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -82,7 +82,7 @@ export default async function OGImage() {
 				}}
 			>
 				<div>hudsondigitalsolutions.com</div>
-				<div>Dallas–Fort Worth · TX</div>
+				<div>Dallas-Fort Worth · TX</div>
 			</div>
 		</div>,
 		{ ...size }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,15 +71,15 @@ const solutions = [
 		Icon: Code2,
 		title: 'A Website That Looks the Part',
 		description:
-			'A clean, professional design that matches the quality of your work — so first-time visitors trust you before they ever call. Mobile-ready and fast on every device.',
-		stat: '1–4 wks',
+			'A clean, professional design that matches the quality of your work, so first-time visitors trust you before they ever call. Mobile-ready and fast on every device.',
+		stat: '1 to 4 wks',
 		statLabel: 'First Delivery'
 	},
 	{
 		Icon: TrendingUp,
 		title: 'Found When Customers Search',
 		description:
-			'Built to show up when people in your area search for what you do. Proper SEO, fast load times, and the local details Google looks for — so your reputation actually gets seen.',
+			'Built to show up when people in your area search for what you do. Proper SEO, fast load times, and the local details Google looks for, so your reputation actually gets seen.',
 		stat: 'Built in',
 		statLabel: 'local SEO'
 	},
@@ -87,7 +87,7 @@ const solutions = [
 		Icon: Settings,
 		title: 'Yours to Control',
 		description:
-			'A simple admin panel means you change your hours, prices, photos, and text yourself — in minutes, no developer, no waiting, no invoice.',
+			'A simple admin panel means you change your hours, prices, photos, and text yourself, in minutes, no developer, no waiting, no invoice.',
 		stat: '$0',
 		statLabel: 'to make edits'
 	}
@@ -119,7 +119,7 @@ export default function HomePage() {
 							<p className="text-lead text-muted-foreground max-w-lg text-balance">
 								You&apos;ve got the 5-star ratings and the word-of-mouth. But
 								when someone Googles you, there&apos;s no website to send them
-								to — or one that doesn&apos;t do you justice. We build small
+								to, or one that doesn&apos;t do you justice. We build small
 								businesses a professional website that turns your reputation
 								into booked customers.
 							</p>
@@ -151,7 +151,7 @@ export default function HomePage() {
 							<div className="flex items-center gap-6">
 								<div>
 									<div className="text-xl font-black text-foreground tabular-nums">
-										1–4 wks
+										1 to 4 wks
 									</div>
 									<div className="text-xs text-muted-foreground mt-0.5">
 										First Delivery
@@ -271,7 +271,7 @@ export default function HomePage() {
 
 					<p className="text-sm text-muted-foreground text-center mt-8 max-w-2xl mx-auto">
 						Need online booking, payments, or automatic lead follow-up wired in?
-						We handle that too — once your site is doing its job.
+						We handle that too, once your site is doing its job.
 					</p>
 				</div>
 			</section>
@@ -389,8 +389,8 @@ export default function HomePage() {
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
 							Every month without a real website is another month of customers
-							Googling you and finding nothing — or finding a competitor
-							instead. Let&apos;s fix that.
+							Googling you and finding nothing, or finding a competitor instead.
+							Let&apos;s fix that.
 						</p>
 					</div>
 

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -42,7 +42,7 @@ interface Stat {
 }
 
 const stats: Stat[] = [
-	{ value: '1–4 wks', label: 'First Delivery' },
+	{ value: '1 to 4 wks', label: 'First Delivery' },
 	{ value: 'Expert', label: 'Development' },
 	{ value: 'Proven', label: 'Track Record' },
 	{ value: '2 hr', label: 'Response Time' }
@@ -104,7 +104,7 @@ export default function ServicesPage() {
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
 						A professional website designed, built, and launched for your
-						business — plus the option to connect booking, payments, and
+						business. Plus the option to connect booking, payments, and
 						follow-up when you&apos;re ready.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
@@ -155,7 +155,7 @@ export default function ServicesPage() {
 							Proven Results
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Small business owners trust us to get it done right and on time —
+							Small business owners trust us to get it done right and on time,
 							without the technical runaround.
 						</p>
 					</div>
@@ -190,7 +190,7 @@ export default function ServicesPage() {
 							Our Process
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Simple, clear steps from first conversation to live and working —
+							Simple, clear steps from first conversation to live and working,
 							no technical jargon required.
 						</p>
 					</div>
@@ -247,7 +247,7 @@ export default function ServicesPage() {
 
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
 								Tell us about your business. We&apos;ll map out the website it
-								needs — pages, timeline, and cost — and you decide from there.
+								needs, pages, timeline, and cost, and you decide from there.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -110,8 +110,8 @@ export default function TermsPage() {
 							</h2>
 							<div className="text-sm text-muted-foreground space-y-4 leading-relaxed">
 								<p>
-									The content on this website — including text, graphics, logos,
-									images, and software — is the property of Hudson Digital
+									The content on this website (including text, graphics, logos,
+									images, and software) is the property of Hudson Digital
 									Solutions and is protected by applicable intellectual property
 									laws. You may not reproduce, distribute, or create derivative
 									works without our express written permission.

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -130,7 +130,7 @@ export default function TestimonialsPage() {
 						<div className="bg-background px-8 py-10 text-center relative overflow-hidden">
 							<div className="absolute top-0 left-1/2 -translate-x-1/2 w-16 h-0.5 bg-accent" />
 							<div className="text-4xl font-black text-accent mb-2 tabular-nums">
-								1–4 wks
+								1 to 4 wks
 							</div>
 							<div className="text-xs text-muted-foreground">
 								First Delivery

--- a/src/app/testimonials/page.tsx
+++ b/src/app/testimonials/page.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button'
 export const metadata: Metadata = {
 	title: 'Client Testimonials | Hudson Digital Solutions',
 	description:
-		'Real results from the small businesses we have built websites for — see how a professional website turned local reputations into booked customers.'
+		'Real results from the small businesses we have built websites for. See how a professional website turned local reputations into booked customers.'
 }
 
 const testimonials = [
@@ -27,7 +27,7 @@ const testimonials = [
 		company: 'E-Commerce Plus',
 		role: 'CEO',
 		content:
-			'Our new online store loads fast and finally looks the part — conversions jumped 60% in the first quarter.',
+			'Our new online store loads fast and finally looks the part. Conversions jumped 60% in the first quarter.',
 		rating: 5,
 		service: 'E-Commerce Website',
 		highlight: '60% More Sales'
@@ -60,7 +60,7 @@ const testimonials = [
 		company: 'Revenue Rocket',
 		role: 'Operations Manager',
 		content:
-			'Our website does the explaining now — customers find what they need and book online instead of calling. Our team has hours back every week.',
+			'Our website does the explaining now. Customers find what they need and book online instead of calling. Our team has hours back every week.',
 		rating: 5,
 		service: 'Website + Booking',
 		highlight: 'Hours Saved Weekly'
@@ -117,7 +117,7 @@ export default function TestimonialsPage() {
 						Real Results. Real Clients.
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						Don&apos;t just take our word for it — see what small businesses are
+						Don&apos;t just take our word for it. See what small businesses are
 						achieving with a website built for their reputation.
 					</p>
 				</div>

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -144,7 +144,7 @@ const tools = [
 	{
 		title: 'Invoice Generator',
 		description:
-			'Create professional invoices with line items, totals, and tax — ready to download as PDF.',
+			'Create professional invoices with line items, totals, and tax, ready to download as PDF.',
 		href: TOOL_ROUTES.INVOICE_GENERATOR,
 		Icon: FileText,
 		benefits: [
@@ -157,7 +157,7 @@ const tools = [
 	{
 		title: 'Proposal Generator',
 		description:
-			'Create professional project proposals for clients with scope, timeline, and pricing — PDF included.',
+			'Create professional project proposals for clients with scope, timeline, and pricing. PDF included.',
 		href: TOOL_ROUTES.PROPOSAL_GENERATOR,
 		Icon: Briefcase,
 		benefits: [

--- a/src/app/website-migration/page.tsx
+++ b/src/app/website-migration/page.tsx
@@ -49,7 +49,7 @@ const risks = [
 		Icon: Shield,
 		title: 'Your Domain May Not Be Yours',
 		description:
-			'Some providers register your domain under their own account. Getting it transferred can take weeks of back-and-forth — or worse, they hold it hostage.'
+			'Some providers register your domain under their own account. Getting it transferred can take weeks of back-and-forth, or worse, they hold it hostage.'
 	},
 	{
 		Icon: AlertTriangle,
@@ -70,7 +70,7 @@ const migrationSteps: MigrationStep[] = [
 		step: '01',
 		title: 'Free Migration Audit',
 		description:
-			'We review your current setup — website, domain ownership, Google Business Profile, CRM data — and create a migration plan with zero downtime.'
+			'We review your current setup (website, domain ownership, Google Business Profile, CRM data) and create a migration plan with zero downtime.'
 	},
 	{
 		step: '02',
@@ -100,8 +100,8 @@ const comparisons = [
 	},
 	{
 		feature: 'Own your website',
-		managed: 'No — provider owns it',
-		hudson: 'Yes — 100% yours'
+		managed: 'No: provider owns it',
+		hudson: 'Yes: 100% yours'
 	},
 	{
 		feature: 'Own your domain',
@@ -186,7 +186,7 @@ export default function WebsiteMigrationPage() {
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
 						Stuck paying hundreds a month for a website you don&apos;t own? We
-						migrate everything to a faster site that&apos;s 100% yours — with
+						migrate everything to a faster site that&apos;s 100% yours, with
 						zero downtime and preserved SEO rankings.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
@@ -348,7 +348,7 @@ export default function WebsiteMigrationPage() {
 
 					<div className="grid sm:grid-cols-2 gap-4">
 						{[
-							'A website you own — no monthly hostage fees',
+							'A website you own, no monthly hostage fees',
 							'Your domain registered in your name',
 							'Google Business Profile connected and verified',
 							'Page load under 2 seconds',

--- a/src/components/forms/NewsletterSignup.tsx
+++ b/src/components/forms/NewsletterSignup.tsx
@@ -33,7 +33,7 @@ const variantConfig = {
 function NewsletterSignupContent({
 	variant = 'inline',
 	title = 'Get Expert Insights',
-	description = 'Practical, no-fluff advice on websites and getting your small business found online — sent only when we publish something worth reading. Unsubscribe anytime.'
+	description = 'Practical, no-fluff advice on websites and getting your small business found online, sent only when we publish something worth reading. Unsubscribe anytime.'
 }: Omit<NewsletterSignupProps, 'dynamic'>) {
 	const mutation = useNewsletterSubscription()
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { CheckCircle, Clock, Mail, Phone, Rocket } from 'lucide-react'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { ROUTES } from '@/lib/constants/routes'
@@ -71,6 +72,14 @@ const socialLinks = [
 // Removed unused animation variants
 
 export default function Footer() {
+	const pathname = usePathname()
+	// Self-suppress on /admin/* and /auth/* so those route groups can
+	// render their own chrome without marketing footer bleeding through
+	// from the root layout.
+	if (pathname.startsWith('/admin') || pathname.startsWith('/auth')) {
+		return null
+	}
+
 	return (
 		<footer
 			className="relative mt-auto bg-surface-sunken"
@@ -166,7 +175,7 @@ export default function Footer() {
 								Ready for the Website You&apos;ve Earned?
 							</h4>
 							<p className="text-xs text-muted-foreground mb-heading">
-								Get your free website plan — pages, timeline, and cost, mapped
+								Get your free website plan: pages, timeline, and cost, mapped
 								out for your business.
 							</p>
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -50,6 +50,14 @@ const Navbar = memo(function Navbar() {
 		return () => window.removeEventListener('keydown', handler)
 	}, [mobileMenuOpen])
 
+	// Self-suppress on /admin/* and /auth/* so those route groups can
+	// render their own chrome (admin Topbar, centered auth container)
+	// without marketing nav bleeding through from the root layout.
+	// Early return placed AFTER all hooks to honor Rules of Hooks.
+	if (pathname.startsWith('/admin') || pathname.startsWith('/auth')) {
+		return null
+	}
+
 	const linkClass = (href: string) =>
 		cn(
 			'px-3 py-1.5 text-sm font-medium rounded-md transition-smooth',

--- a/src/components/ui/ProcessSteps.tsx
+++ b/src/components/ui/ProcessSteps.tsx
@@ -15,14 +15,14 @@ const PROCESS_STEPS = [
 		step: '01',
 		title: 'Discovery',
 		description:
-			'We learn how your business works — what you do, who your customers are, and what your website needs to do for you.',
+			'We learn how your business works: what you do, who your customers are, and what your website needs to do for you.',
 		icon: Search
 	},
 	{
 		step: '02',
 		title: 'Strategy',
 		description:
-			'We map out exactly what your website needs — pages, structure, and a plain-English plan with clear timelines.',
+			'We map out exactly what your website needs: pages, structure, and a plain-English plan with clear timelines.',
 		icon: ClipboardList
 	},
 	{

--- a/src/components/ui/ServicesGrid.tsx
+++ b/src/components/ui/ServicesGrid.tsx
@@ -15,7 +15,7 @@ const SERVICES = [
 	{
 		title: 'Website Design & Development',
 		description:
-			'A professional website built for your business from scratch — clean custom design, mobile-ready, and fast. Comes with an admin panel so you control your content without calling a developer.',
+			'A professional website built for your business from scratch: clean custom design, mobile-ready, and fast. Comes with an admin panel so you control your content without calling a developer.',
 		features: [
 			'Custom Design Built for Your Brand',
 			'Mobile-Ready on Every Device',
@@ -43,7 +43,7 @@ const SERVICES = [
 	{
 		title: 'Booking, Payments & Follow-Up',
 		description:
-			'Once your site is live, we can wire in the extras — let customers book online, take payments, and make sure no inquiry slips through the cracks.',
+			'Once your site is live, we can wire in the extras: let customers book online, take payments, and make sure no inquiry slips through the cracks.',
 		features: [
 			'Online Booking & Scheduling',
 			'Stripe Payment Setup',

--- a/src/lib/locations/texas.ts
+++ b/src/lib/locations/texas.ts
@@ -116,7 +116,7 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			{
 				title: 'Fast Website Launch',
 				description:
-					'Get a professional website live fast — design, copy, and setup handled end to end.'
+					'Get a professional website live fast: design, copy, and setup handled end to end.'
 			},
 			{
 				title: 'Mobile-First Design',

--- a/src/lib/seo-config.ts
+++ b/src/lib/seo-config.ts
@@ -19,24 +19,24 @@ export const SEO_CONFIG: Record<string, SEOMetaData> = {
 	home: {
 		title: 'Dallas-Fort Worth Web Design | Hudson Digital',
 		description:
-			'Professional website design for small businesses in Dallas-Fort Worth. We build the website your business has earned — fast, mobile-ready, built to convert.',
+			'Professional website design for small businesses in Dallas-Fort Worth. We build the website your business has earned: fast, mobile-ready, built to convert.',
 		canonical: SITE_URL
 	},
 
 	services: {
 		title: 'Small Business Website Design | Hudson Digital',
 		description:
-			'Professional websites designed and built for small businesses — custom, mobile-ready, fast, and easy to find on Google. Free website plan, no obligation.',
+			'Professional websites designed and built for small businesses: custom, mobile-ready, fast, and easy to find on Google. Free website plan, no obligation.',
 		ogTitle: 'Website Design for Small Businesses | Hudson Digital',
 		ogDescription:
-			'Professional websites built for small businesses — custom, fast, mobile-ready, built to bring in customers. Launched in weeks.',
+			'Professional websites built for small businesses: custom, fast, mobile-ready, built to bring in customers. Launched in weeks.',
 		canonical: `${SITE_URL}/services`
 	},
 
 	about: {
 		title: 'Web Designer Who Understands Small Business | Hudson Digital',
 		description:
-			'An experienced web developer with a real business background — building small businesses the professional website their reputation deserves.',
+			'An experienced web developer with a real business background, building small businesses the professional website their reputation deserves.',
 		ogTitle: 'Web Designer Who Understands Small Business | Hudson Digital',
 		ogDescription:
 			'Experienced developer with a business background, building websites that actually bring in customers for small businesses.',


### PR DESCRIPTION
## Summary

Two classes of pre-existing CLAUDE.md violations that the Phase 03/04/05 review pipeline missed because review scope was narrowly per-phase and explicitly excluded the root layout + public-route surface. Surfaced by the Phase 05 operator smoke (PR #217). Single branch, two atomic commits.

## What's fixed

**Chrome bleed on `/admin/*` and `/auth/*`** (`c2cbab7`)

Root `src/app/layout.tsx` was unconditionally rendering `<NavbarLight />` + `<Footer />` for every route. Admin pages were stacked with the marketing nav on top of the admin Topbar, plus the marketing Footer at the bottom. Auth pages had the same bleed (the auth layout's JSDoc even acknowledged it as a known quirk).

- `src/components/layout/Navbar.tsx` (already `'use client'`, already imports `usePathname`): added an early-return `if (pathname.startsWith('/admin') || pathname.startsWith('/auth')) return null` after all hooks (preserves Rules of Hooks ordering).
- `src/components/layout/Footer.tsx` (already `'use client'`): same early-return pattern; added `usePathname` import.
- `src/app/auth/layout.tsx` JSDoc rewritten: the "Navbar and Footer remain wrapped" note is no longer accurate.
- `src/app/layout.tsx`: one-line comment added near the chrome render block noting the self-suppression.

**Em/en-dash sweep** (`c2cbab7` + `60a3178`)

CLAUDE.md bans em-dash (—) and en-dash (–) project-wide in user-facing text. Code comments and JSDoc exempt. The sweep found ~80 user-facing violations across 30 files spanning every public route and most shared components. All replaced with context-appropriate punctuation:

- Comma — for connectors / parentheticals (most common, ~50)
- Period + capitalization — separating two complete thoughts
- Colon — list intros ("needs: pages, timeline, cost") and title/banner structures ("Hudson Digital Solutions: Professional Websites...")
- Parentheses — for paired em-dashes wrapping a parenthetical
- "to" — for date / time / numeric ranges ("Monday to Friday", "9am to 6pm", "1 to 4 wks", "4 to 6 weeks")
- Hyphen — for the Dallas-Fort Worth metro name (standard hyphenation)

## Files modified (30)

**Architecture (Class 1, 4 files):**
- `src/components/layout/Navbar.tsx`, `src/components/layout/Footer.tsx`, `src/app/auth/layout.tsx`, `src/app/layout.tsx`

**Em/en-dash sweep (Class 2 + 3, 26 files):**
- Marketing pages: `src/app/{page,not-found,about,blog/page,blog/[slug]/page,services/page,tools/page,contact/page,faq/page,faq/FaqClient,testimonials/page,locations/page,locations/[slug]/page,terms/page,website-migration/page,opengraph-image}.tsx`
- Shared components: `src/components/{layout/Footer,ui/ProcessSteps,ui/ServicesGrid,forms/NewsletterSignup}.tsx`
- Lib: `src/lib/seo-config.ts`, `src/lib/locations/texas.ts`

## Verification

- `bun run lint`: PASS (Biome, zero diagnostics)
- `bun run typecheck`: PASS
- `bun run test:unit`: PASS (563/563)
- `bun run build`: PASS (198 static pages)
- Em-dash sweep on `src/`: ZERO user-facing matches. 4 remain, all confirmed inside `//` or `{/* */}` comment blocks (CLAUDE.md-exempt): `src/lib/rate-limiter.ts:57`, `src/app/layout.tsx:117/179`, `src/app/showcase/page.tsx:105`.
- En-dash sweep on `src/`: ZERO user-facing matches.
- Phase 02/03/04/05 admin/auth surface UNCHANGED: `git diff origin/main -- src/lib/auth/ src/lib/admin/ src/components/admin/ src/app/admin/ src/app/api/auth/ proxy.ts` empty.

## Why this slipped past prior review

The per-phase review scope explicitly excluded:
- Phase 02 auth surface
- Phase 03 dashboard surface
- Phase 04 CRUD surface
- Phase 05 ops surface
- Public read helpers + pages
- Cron / n8n endpoints
- Root layout

That scoping was correct for catching per-phase regressions, but left ~80 pre-existing project-wide violations untouched across multiple phases. The operator smoke (a true end-to-end exercise) was the first review that actually rendered the public-facing surfaces and caught the chrome bleed. Future review prompts should add a project-wide CLAUDE.md compliance sweep as a separate concern from per-phase scope, OR run the rendered-text dash sweep as part of every PR's CI.

## Commits

- `c2cbab7` — admin/auth chrome isolation + 22 originally-tabled dash fixes
- `60a3178` — extended sweep, ~58 additional em-dash fixes across 17 more files

[hudsor01]