### PR TITLE
fix: post-smoke audit findings + close Phase 05 Gate 14

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,19 +1,22 @@
 # STATE — Current GSD Position
 
-**Last updated:** 2026-05-23
-**Branch:** `admin-ops`
-**Current milestone:** v4 (Admin Panel)
-**Current phase:** `05-admin-ops` (complete 7/7, PR not yet open)
-**Current plan:** none — phase complete, awaiting operator smoke + PR
+**Last updated:** 2026-05-25
+**Branch:** `fix/smoke-audit-findings`
+**Current milestone:** v4 (Admin Panel) — **shipped to production**
+**Current phase:** none (v4 complete, post-ship audit polish in flight)
+**Current plan:** none
 
 ## What just happened
 
-- Phase 05 (`admin-ops`) closed. 7 plans across 4 waves, 14 implementation commits on `admin-ops` (bootstrap + Wave 1 + 12 Wave-2 commits + Wave-3 cleanup; 4 of the Wave-2 commits are SUMMARY-only docs). Operator-facing ops surfaces shipped for all 4 surfaces: `/admin/leads` (list with status filter + detail with attribution, notes, status mutations, delete), `/admin/leads/calculator` (list with quality filter + detail with inputs / results / conversion / mark-contacted / mark-converted), `/admin/newsletter` (list + detail with unsubscribe / re-subscribe state machine + GDPR hard delete), `/admin/emails` (list with 4 queue-health stat cards + status filter + detail with retry guard / cancel / delete). Every mutation is a single-button `<form action={...}>` posting to a Server Action that calls `requireAdminSession()` first then validates with Zod then mutates via Drizzle then `revalidatePath` for both list AND detail paths. 2 new shared admin primitives reused across all 4 surfaces: `StatusFilterBar` (server-side `<form method="get">` chip row) + `StatusBadge` (OKLCH token color map). Detail page IS the edit surface (no `/[id]/edit` split). No useAppForm — every form is `<form action={...}>` + hidden id + submit button. No new shared helpers needed; reuse rate from Phase 04 = 100%. Phase 02 / 03 / 04 files plus all public-route, public-API, n8n Bearer, and cron endpoint surfaces are byte-equal to `main` (53/53 protected paths verified). All 13 automated gates + Gate 10b green: lint (353 files, 0 diagnostics) + typecheck + 563 unit tests (unchanged baseline; Phase 05 added no new tests by design) + build (19 admin routes, all `◐` partial prerender, zero `(coming-soon)`) + em/en-dash sweep = 0 + protected-files diff = 53/53 OK + defense-in-depth auth verified (leads=5, calculator=4, newsletter=4, emails=4 `requireAdminSession()` calls) + every mutation calls `revalidatePath` (counts: leads=7, calculator=7, newsletter=7, emails=7) + no `console.*` / `process.env.X` / `any` in any added file + no non-async value exports in any `'use server'` file. 35-step operator manual smoke deferred to operator pre-PR (see `.planning/phases/05-admin-ops/05-07-VERIFICATION.md` for the checklist). Wave 2 ran 4 parallel agents in a single working tree; commit-message attribution got crossed with file contents on one commit (`2445bc1` named "leads Server Actions" actually contains newsletter Task 1 files too) — end state on disk is correct, future readers should verify via `git show <hash> --stat`. Latent `flattenZod` + `ActionResult` non-async runtime export in `leads/actions.ts` was invisible until `next build` could run end-to-end; Wave 3's stub-deletion commit (`cf59c45`) caught and fixed it inline.
-- Phase 04 (`admin-content-crud`) closed earlier; PR not yet opened, deferred to operator. End state: branch `admin-content-crud` complete, awaiting operator smoke and PR.
-- Phase 03 (`admin-shell-and-dashboard`) closed earlier and merged to `main` via PR #213.
-- Phase 02 (`auth-foundation`) closed earlier. Merged into the base for `admin-shell-dashboard`.
-- Milestone v4 (Admin Panel) complete: 4 / 4 phases done. After Phase 04 + Phase 05 PRs merge, v4 ships.
-- Milestone v3 closed: Phase 01 (`showcase-ui-redesign`) shipped to main as `59e5e70` via PR #208.
+- **Phase 05 operator smoke closed at 35/35.** Prod read-only sweep 2026-05-24 (19/19 verifiable on `https://www.hudsondigitalsolutions.com`) + local destructive + fixture-blocked sweep 2026-05-25 (16/16 against `http://localhost:3001`, driven via Claude-in-Chrome MCP). Zero failures. Chrome-bleed check PASS. Console-error gate PASS (only pre-fix "Failed to fetch" entries from before the local env-var fix, none during the smoke). 8 `smoke-*@example.com` fixtures seeded + cleaned via `psql`. Gate 14 closed; the result appended to `.planning/phases/05-admin-ops/05-07-VERIFICATION.md`.
+- **Smoke surfaced 3 post-ship findings** addressed by this branch (`fix/smoke-audit-findings`): (1) Next.js 16 `data-scroll-behavior="smooth"` attribute now set on `<html>` (silences the per-route scroll-restoration warning); (2) WebVitals dev-console logger now picks `info | warn | error` based on the metric's CWV rating instead of always logging at `warn`; (3) Better Auth's internal logger is now piped through the project logger (CLAUDE.md compliance) with a `redactEmails` walker that masks any `email` / `recipientEmail` field before it reaches the log sink.
+- **v4 (Admin Panel) is shipped end-to-end.** 4/4 phases complete on `main`:
+  - Phase 02 (`auth-foundation`) via PR #210 (`54603c1`) — Better Auth + sessions + admin role guard + AccountMenu.
+  - Phase 03 (`admin-shell-and-dashboard`) via PR #213 (`d88d049`) — Sidebar + Topbar + Forbidden + 5 dashboard widgets.
+  - Phase 04 (`admin-content-crud`) via PR #215 (`cf37d1c`) — showcase / blog / testimonials CRUD with Server Actions + TanStack Form.
+  - Phase 05 (`admin-ops`) via PR #217 (`5221269`) — leads / calculator-leads / newsletter / emails ops surfaces with `<form action>` Server Actions, 4 queue-health stat cards on /admin/emails.
+- **PR #218 (`4114d37`) closed the cross-phase chrome bleed + project-wide em/en-dash sweep** that the per-phase review pipeline had missed (NavbarLight + Footer now self-suppress on `/admin/*` and `/auth/*` via `usePathname`; ~80 em/en-dash CLAUDE.md violations fixed across 30 files). Smoke was what surfaced the gap; future review prompts should include a project-wide CLAUDE.md compliance sweep as a separate concern from per-phase scope.
+- Milestone v3 closed: Phase 01 (`showcase-ui-redesign`) shipped via PR #208.
 
 ## Active decisions (still in force from v3)
 
@@ -48,12 +51,10 @@
 
 ## Next action
 
-Operator manual smoke checklist (35 steps in `.planning/phases/05-admin-ops/05-07-VERIFICATION.md`) on local dev, then ship PR for `admin-ops` -> `main`. After merge, v4 milestone (Admin Panel) complete; choose v5 direction.
+Ship this branch (`fix/smoke-audit-findings`) as the smoke-closeout PR, merge, and v4 closes for real. After merge, choose v5 direction. Candidates surfaced during v4:
 
-Recommended PR squash message:
-
-```
-feat(admin): ops - leads, calculator-leads, newsletter, emails with Server Actions
-```
-
-(Phase 04 PR for `admin-content-crud` is also pending — both should ship before v4 closes.)
+- Admin chrome route-group refactor (move `src/app` into `(public)/` + `(admin)/` + `(auth)/` route groups so chrome lives in the group layout instead of via `usePathname` self-suppression).
+- Image-upload UI for showcase / blog / testimonials (admin currently pastes URLs).
+- Rich-text / markdown editor for blog content (admin currently uses a plain `<textarea>`).
+- Pagination + search for any list growing past ~200 rows.
+- Better Auth logger compliance sweep (Phase 05 smoke found Better Auth was logging raw emails; this branch installs a redacting logger adapter, but a future audit could also check for emails leaking through other 3rd-party libraries).

--- a/.planning/phases/05-admin-ops/05-07-VERIFICATION.md
+++ b/.planning/phases/05-admin-ops/05-07-VERIFICATION.md
@@ -382,6 +382,21 @@ If all 35 steps pass: write "Operator smoke: PASS (35 / 35)" into this
 file and proceed to PR. If any step fails: write the failure into the
 Operator Smoke section of this file and STOP for triage.
 
+### Operator smoke run — 2026-05-24 + 2026-05-25
+
+**Operator smoke: PASS (35/35), env: prod-read-only + local-destructive**
+
+- Prod read-only sweep (2026-05-24): 19/19 verifiable steps PASS against `https://www.hudsondigitalsolutions.com` on deployed commit `cf37d1c -> 5221269`. 4 read-only steps SKIPPED for missing fixtures (14 no calc rows; 28/29/30 no failed/sent/cancelled emails).
+- Local destructive + fixture-blocked sweep (2026-05-25): 12 destructive + 4 fixture-blocked = 16/16 PASS against `http://localhost:3001` on commit `19bb7d1` (= `4114d37` + local empty redeploy commit). Browser smoke driven via Claude-in-Chrome.
+- Chrome-bleed check: PASS. NavbarLight + Footer correctly suppressed on `/auth/*` and `/admin/*` (validated by PR #218 `4114d37` self-suppression via `usePathname`).
+- Console-error gate (Step 35): PASS. Only pre-smoke "Sign-in failed" entries (from before the local env-var fix) appeared in the buffer. Zero new errors during the smoke run.
+- Pre-existing issues surfaced during the smoke and resolved:
+  - PR #218 (`4114d37`): ~80 em/en-dash CLAUDE.md violations swept from user-facing text; marketing chrome bleed on /admin and /auth.
+  - This PR: Next.js 16 `data-scroll-behavior="smooth"` attribute on `<html>`, WebVitals log level mapped to CWV rating, Better Auth logger piped through project logger with email-field redaction.
+- Cleanup: all 8 `smoke-*@example.com` fixtures deleted post-smoke (4 deleted by the destructive steps themselves, 4 cleaned via DELETE on the four LIKE-pattern queries; final counts = 0 in leads / calculator_leads / newsletter_subscribers / scheduled_emails).
+
+Phase 05 is closed. Milestone v4 (Admin Panel) is complete (4/4 phases shipped).
+
 ## Conclusion
 
 All 13 automated gates + Gate 10b green. Phase 05 is ready for operator

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -98,7 +98,7 @@ export default function RootLayout({
 	children: React.ReactNode
 }>) {
 	return (
-		<html lang="en" className="scroll-smooth">
+		<html lang="en" className="scroll-smooth" data-scroll-behavior="smooth">
 			<head>
 				{/* Critical mobile-first meta tags */}
 				<meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/utilities/WebVitalsReporting.tsx
+++ b/src/components/utilities/WebVitalsReporting.tsx
@@ -13,16 +13,23 @@ export function WebVitalsReporting() {
 		// Store in database for admin dashboard
 		storeWebVital(metric)
 
-		// Log performance issues in development
+		// Log in development at a level that matches the CWV rating so good
+		// metrics show as info and bad metrics surface in warn/error filters.
+		// The Phase 03 dashboard widget uses the same rating thresholds for
+		// its KPI cards (text-success-text / warning / destructive); align
+		// the log level here so dev-console filtering matches.
 		if (process.env.NODE_ENV === 'development') {
-			logger.warn(
-				`[WebVitals] ${metric.name}: ${metric.value} (${metric.rating})`,
-				{
-					name: metric.name,
-					value: metric.value,
-					rating: metric.rating
-				}
-			)
+			const log =
+				metric.rating === 'poor'
+					? logger.error
+					: metric.rating === 'needs-improvement'
+						? logger.warn
+						: logger.info
+			log(`[WebVitals] ${metric.name}: ${metric.value} (${metric.rating})`, {
+				name: metric.name,
+				value: metric.value,
+				rating: metric.rating
+			})
 		}
 	})
 

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -34,6 +34,38 @@ const trustedOrigins =
 		.map(value => value.trim())
 		.filter(Boolean) ?? []
 
+/**
+ * Redact `email` (and `recipientEmail`) fields anywhere in a structured log
+ * argument so Better Auth's internal logs (e.g. "User not found" on failed
+ * sign-in) don't write raw addresses into our log sink. Replaces the value
+ * with the literal `[redacted-email]` so the call site is still debuggable
+ * (the field still exists in the object, you just can't read the user).
+ *
+ * Pure, non-recursive on arrays of primitives (no expansion of strings into
+ * char arrays). Recursion is bounded by object depth; we don't need cycle
+ * detection because Better Auth's log args are flat JSON-serializable blobs.
+ */
+function redactEmails(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(redactEmails)
+	}
+	if (value && typeof value === 'object') {
+		const out: Record<string, unknown> = {}
+		for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+			if (
+				(key === 'email' || key === 'recipientEmail') &&
+				typeof val === 'string'
+			) {
+				out[key] = '[redacted-email]'
+			} else {
+				out[key] = redactEmails(val)
+			}
+		}
+		return out
+	}
+	return value
+}
+
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: 'pg',
@@ -94,5 +126,29 @@ export const auth = betterAuth({
 			}
 		}
 	},
-	plugins: [nextCookies()]
+	plugins: [nextCookies()],
+	logger: {
+		// Pipe Better Auth's internal log lines through the project logger
+		// (matches CLAUDE.md > Logging: no direct console.* anywhere) and
+		// redact email fields before they hit any log sink. Better Auth's
+		// `log` signature is `(level, message, ...args)` per the upstream
+		// reference docs; `level` is one of debug | info | warn | error.
+		log: (level, message, ...args) => {
+			const redactedArgs = args.map(redactEmails)
+			const metadata =
+				redactedArgs.length === 1 && typeof redactedArgs[0] === 'object'
+					? (redactedArgs[0] as Record<string, unknown>)
+					: { args: redactedArgs }
+			const tag = `[Better Auth] ${message}`
+			if (level === 'error') {
+				logger.error(tag, undefined, { metadata })
+			} else if (level === 'warn') {
+				logger.warn(tag, { metadata })
+			} else if (level === 'info') {
+				logger.info(tag, { metadata })
+			} else {
+				logger.debug(tag, { metadata })
+			}
+		}
+	}
 })


### PR DESCRIPTION
## Summary

Phase 05 operator smoke ran 2026-05-24 (prod read-only, 19/19) + 2026-05-25 (local destructive + fixture-blocked, 16/16) for a final 35/35 PASS. Smoke surfaced 3 post-ship findings against the live deploy. All 3 fixed canonically here in one branch; verification doc updated with the smoke result; STATE synced to v4 fully shipped.

## What's fixed

### Finding 1 — Next.js 16 `data-scroll-behavior` warning

- **File:** `src/app/layout.tsx`
- **Symptom:** Browser console emitted on every redirect after a Server Action mutation (seen 5× during the smoke):
  > `Detected scroll-behavior: smooth on the <html> element. To disable smooth scrolling during route transitions, add data-scroll-behavior="smooth" to your <html> element.`
- **Fix:** Add the explicit `data-scroll-behavior="smooth"` attribute alongside the existing `scroll-smooth` class. Anchor-link smooth scrolling stays; App Router scroll restoration on route changes no longer fights it.

### Finding 2 — WebVitals dev-console log level matches CWV rating

- **File:** `src/components/utilities/WebVitalsReporting.tsx`
- **Symptom:** Every WebVitals beacon in dev was logged at `WARN` regardless of `rating`. 30+ false-positive `[browser] [WARN] [WebVitals]` entries during the smoke for metrics rated `good`. Pollutes dev console + makes warn-filtering useless.
- **Fix:** Pick the logger method per rating: `good → logger.info`, `needs-improvement → logger.warn`, `poor → logger.error`. Matches the Phase 03 dashboard widget's color coding (text-success-text / warning / destructive) for consistent semantics across the codebase.

### Finding 3 — Better Auth logger piped through project logger with email redaction

- **File:** `src/lib/auth/index.ts`
- **Symptom:** Better Auth wrote raw user emails to the server log on every failed sign-in:
  > `ERROR [Better Auth]: User not found { email: 'rhudson42@yahoo.com' }`
  > `ERROR [Better Auth]: Invalid password { email: '...' }`
  
  PII in logs. Project-wide CLAUDE.md says `@/lib/logger` not `console.*`; the 3rd-party library bypasses that.
- **Fix:** Install a custom logger on the `betterAuth({ logger: { log: ... } })` config (per the Better Auth docs canonical signature `(level, message, ...args) => void`) that:
  1. Maps Better Auth's level to the project logger's method (`debug | info | warn | error`).
  2. Runs every log arg through a `redactEmails` walker that masks any `email` or `recipientEmail` field with the literal `[redacted-email]`.
  3. Tags every line with `[Better Auth]` prefix so they're grep-able in any log sink.
- The redaction helper is pure, bounded recursion on objects (no array-of-char expansion on strings), no cycle detection needed since Better Auth's log args are flat JSON blobs.

## Gate 14 closed

`.planning/phases/05-admin-ops/05-07-VERIFICATION.md` — appended under Gate 14:

```
**Operator smoke: PASS (35/35), env: prod-read-only + local-destructive**
```

with per-step evidence pointers + fixture-cleanup note (8 `smoke-*@example.com` rows seeded via `psql`, 4 deleted by the destructive steps themselves, 4 cleaned via `DELETE ... WHERE email LIKE 'smoke-%@example.com'` queries; final counts = 0 in leads / calculator_leads / newsletter_subscribers / scheduled_emails).

## STATE / ROADMAP sync

`.planning/STATE.md` — v4 (Admin Panel) marked **shipped end-to-end**: PRs #210, #213, #215, #217 merged; #218 closed the cross-phase chrome bleed + project-wide em-dash sweep; this PR closes the post-ship audit findings. Next-action repointed at v5 candidates surfaced during v4 (route-group chrome refactor, image uploads, rich-text editor, pagination, 3rd-party logger compliance sweep).

`.planning/ROADMAP.md` — no change needed (Phase 05 already marked complete after the operator smoke + PR #217 closed).

## Verification

- `bun run lint`: PASS (Biome, 353 files, zero diagnostics)
- `bun run typecheck`: PASS (`tsc --noEmit`)
- `bun run test:unit`: PASS (563/563, 2335 expect() calls)
- `bun run build`: PASS
- Em-dash sweep (project-wide): 4 remaining, ALL confirmed comment exemptions: `src/lib/rate-limiter.ts:57`, `src/app/layout.tsx:117`, `src/app/layout.tsx:179`, `src/app/showcase/page.tsx:105`. Zero user-facing matches.
- En-dash sweep: ZERO user-facing matches.
- Protected paths untouched: `git diff origin/main -- src/lib/admin/ src/components/admin/ src/app/admin/ src/app/api/auth/ src/lib/auth/admin.ts proxy.ts` is empty (Phase 02/03/04/05 admin + cron + n8n surfaces all preserved).

## Why these slipped past prior review

Per-phase scope deliberately excluded the root layout, public-route surface, and 3rd-party library behavior (each was deemed pre-existing not regression-introduced). The smoke — true end-to-end browser exercise + server log inspection — is the only review path that catches:

1. Browser console warnings emitted only at runtime (Finding 1)
2. Log level mismatches only visible when you actually tail the logs (Finding 2)
3. Log content leakage from upstream libraries that don't go through our logger (Finding 3)

Lesson: keep the operator smoke as a real gate before merging any future phase that touches the rendered surface or auth/data flows.

[hudsor01]