### PR TITLE
fix(admin): unstick edit pages by skipping placeholder render

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/edit/page.tsx
@@ -6,11 +6,11 @@
  * options come from the same public read helpers as the create page so
  * the dropdowns stay in sync with what the public site sees.
  *
- * Wrapped in <Suspense> + `await connection()` so the DB read stays out
- * of any partial-prerender step in `next build`. Next.js 16 `params` is
- * async AND counts as uncached request data; we pass the Promise through
- * to the EditLoader subtree and await inside Suspense so the page shell
- * still prerenders.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -18,6 +18,7 @@ import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { getBlogPostForAdmin } from '@/lib/admin/blog-queries'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getAuthors, getTags } from '@/lib/blog'
 import { EditBlogForm } from './EditBlogForm'
 
@@ -26,22 +27,24 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
+export function generateStaticParams() {
+	return [{ id: BUILD_PLACEHOLDER_ID }]
+}
+
 interface EditBlogPostPageProps {
 	params: Promise<{ id: string }>
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real post (getBlogPostForAdmin returns null which
-// triggers notFound()), so the only thing that ships from this prerender
-// is the 404 path -- real ids render on first request via ISR.
-export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
-}
-
 async function EditLoader({ params }: EditBlogPostPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const [row, authors, tags] = await Promise.all([
 		getBlogPostForAdmin(id),
 		getAuthors(),

--- a/src/app/(admin)/admin/emails/[id]/page.tsx
+++ b/src/app/(admin)/admin/emails/[id]/page.tsx
@@ -12,10 +12,11 @@
  * mirrors the server-side guard in `retryScheduledEmail()`. The backend
  * gate is still authoritative -- this is a visual hint, not the check.
  *
- * Wrapped in <Suspense> + `await connection()` so the DB read stays out
- * of any partial-prerender step at build time. `generateStaticParams`
- * returns a placeholder id so Next.js 16 `cacheComponents` has at least
- * one prerender sample to validate against.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -24,6 +25,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getScheduledEmailById } from '@/lib/admin/emails-queries'
 import {
 	cancelScheduledEmailAction,
@@ -36,12 +38,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can validate
-// dynamic accesses against a real prerender. The placeholder never resolves to
-// a real row (getScheduledEmailById returns null which triggers notFound());
-// real ids render on first request via ISR.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface EmailDetailPageProps {
@@ -65,8 +67,11 @@ async function cancelAction(formData: FormData): Promise<void> {
 }
 
 async function EmailDetailLoader({ params }: EmailDetailPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const row = await getScheduledEmailById(id)
 	if (!row) {
 		notFound()

--- a/src/app/(admin)/admin/leads/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/[id]/page.tsx
@@ -13,11 +13,11 @@
  *                       each note with a delete button
  *   5. Danger        -- `DeleteButton` (cascades to attribution + notes)
  *
- * Wrapped in <Suspense> + `await connection()` so the DB read stays out of
- * any partial-prerender step in `next build`. `generateStaticParams`
- * returns a placeholder id so `cacheComponents` has a sample prerender to
- * validate against; the placeholder resolves to `null` and triggers
- * `notFound()`, real ids render via ISR on first request.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -26,6 +26,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getLeadById } from '@/lib/admin/leads-queries'
 import { LEAD_STATUSES } from '@/lib/schemas/admin-leads'
 import {
@@ -40,13 +41,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real row (getLeadById returns null which triggers
-// notFound()), so the only thing that ships from this prerender is the
-// 404 path -- real ids render on first request via ISR.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface AdminLeadDetailPageProps {
@@ -60,8 +60,11 @@ const STATUS_BTN_INACTIVE =
 const STATUS_BTN_ACTIVE = 'text-foreground bg-surface-base'
 
 async function LeadDetailLoader({ params }: AdminLeadDetailPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const detail = await getLeadById(id)
 	if (!detail) {
 		notFound()

--- a/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
@@ -7,9 +7,11 @@
  * type, so they are dumped via `<pre>{JSON.stringify(..., null, 2)}</pre>`
  * with no client-side reshape; admin-only display.
  *
- * Wrapped in <Suspense> + `await connection()` per the Next.js 16
- * `cacheComponents` requirement; `generateStaticParams` returns a
- * placeholder so the build can validate the dynamic route's shell.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -18,6 +20,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getCalculatorLeadById } from '@/lib/admin/calculator-leads-queries'
 import {
 	deleteCalculatorLeadAction,
@@ -52,13 +55,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real row (getCalculatorLeadById returns null which
-// triggers notFound()), so the only thing that ships from this prerender
-// is the 404 path; real ids render on first request.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface AdminCalculatorLeadDetailPageProps {
@@ -85,8 +87,11 @@ function DefinitionRow({
 async function CalculatorLeadDetail({
 	params
 }: AdminCalculatorLeadDetailPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const row = await getCalculatorLeadById(id)
 	if (!row) {
 		notFound()

--- a/src/app/(admin)/admin/newsletter/[id]/page.tsx
+++ b/src/app/(admin)/admin/newsletter/[id]/page.tsx
@@ -9,14 +9,11 @@
  *    the status is `bounced` or anything unrecognized)
  *  - Danger: GDPR hard-delete via the shared `<DeleteButton>` primitive
  *
- * Wrapped in <Suspense> + `await connection()` so the DB read stays out of
- * any partial-prerender step at build time (same pattern as the showcase
- * edit page).
- *
- * Next.js 16 `params` is async AND is uncached request data. Awaiting it
- * outside a Suspense boundary blocks the entire route's prerender shell,
- * which `cacheComponents` flags as an error. We pass the `params` Promise
- * straight through to the SubscriberLoader subtree and await inside Suspense.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -25,6 +22,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getSubscriberById } from '@/lib/admin/newsletter-queries'
 import {
 	deleteSubscriberAction,
@@ -55,13 +53,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real row (getSubscriberById returns null which
-// triggers notFound()), so the only thing that ships from this prerender
-// is the 404 path; real ids render on first request via ISR.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface SubscriberDetailPageProps {
@@ -72,8 +69,11 @@ const ACTION_BTN_CLASS =
 	'inline-flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium text-accent-text border border-border bg-surface-raised hover:bg-surface-base transition-smooth'
 
 async function SubscriberLoader({ params }: SubscriberDetailPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const row = await getSubscriberById(id)
 	if (!row) {
 		notFound()

--- a/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
@@ -2,20 +2,20 @@
  * Admin Edit Showcase page (server component).
  *
  * Loads the row by id via the admin query layer, 404s when missing, and
- * hands the row to the client form island. Wrapped in <Suspense> + `await
- * connection()` so the DB read stays out of any partial-prerender step at
- * build time (same pattern as the dashboard page).
+ * hands the row to the client form island.
  *
- * Next.js 16 `params` is async AND is uncached request data. Awaiting it
- * outside a Suspense boundary blocks the entire route's prerender shell,
- * which `cacheComponents` flags as an error. We pass the `params` Promise
- * straight through to the EditLoader subtree and await inside Suspense.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getShowcaseById } from '@/lib/admin/showcase-queries'
 import { EditShowcaseForm } from './EditShowcaseForm'
 
@@ -24,13 +24,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real row (getShowcaseById returns null which
-// triggers notFound()), so the only thing that ships from this prerender
-// is the 404 path -- real ids render on first request via ISR.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface EditShowcasePageProps {
@@ -38,8 +37,11 @@ interface EditShowcasePageProps {
 }
 
 async function EditLoader({ params }: EditShowcasePageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const row = await getShowcaseById(id)
 	if (!row) {
 		notFound()

--- a/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
@@ -5,17 +5,18 @@
  * gets the standard 404 instead of an empty form. The pre-filled form +
  * delete button live in the client island.
  *
- * Wrapped in <Suspense> + `await connection()` so the DB read stays out
- * of any partial-prerender step in `next build`. Next.js 16 `params` is
- * async AND counts as uncached request data; we pass the Promise through
- * to the EditLoader subtree and await inside Suspense so the page shell
- * still prerenders.
+ * Wrapped in <Suspense> + `await connection()` so the DB read happens
+ * inside a streaming boundary. `generateStaticParams` returns a
+ * placeholder id (required by `cacheComponents`) which the loader
+ * short-circuits to 404 before `connection()`; see
+ * `@/lib/admin/build-placeholder` for the full root-cause analysis.
  */
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getTestimonialById } from '@/lib/admin/testimonials-queries'
 import { EditTestimonialForm } from './EditTestimonialForm'
 
@@ -24,13 +25,12 @@ export const metadata: Metadata = {
 	robots: { index: false, follow: false }
 }
 
-// `cacheComponents` requires at least one sample id so the build can
-// validate dynamic accesses against a real prerender. The placeholder
-// never resolves to a real row (getTestimonialById returns null which
-// triggers notFound()), so the only thing that ships from this prerender
-// is the 404 path -- real ids render on first request via ISR.
+// `cacheComponents` rejects an empty static-params list; the loader
+// short-circuits the placeholder to `notFound()` before `connection()`
+// to avoid a PPR postponed-boundary marker the client can't reveal. See
+// `@/lib/admin/build-placeholder` for the full root-cause analysis.
 export function generateStaticParams() {
-	return [{ id: '__build_placeholder__' }]
+	return [{ id: BUILD_PLACEHOLDER_ID }]
 }
 
 interface EditTestimonialPageProps {
@@ -38,8 +38,11 @@ interface EditTestimonialPageProps {
 }
 
 async function EditLoader({ params }: EditTestimonialPageProps) {
-	await connection()
 	const { id } = await params
+	if (id === BUILD_PLACEHOLDER_ID) {
+		notFound()
+	}
+	await connection()
 	const row = await getTestimonialById(id)
 	if (!row) {
 		notFound()

--- a/src/lib/admin/build-placeholder.ts
+++ b/src/lib/admin/build-placeholder.ts
@@ -1,0 +1,36 @@
+/**
+ * Build-time placeholder id for admin dynamic routes.
+ *
+ * Every admin `[id]` page exports `generateStaticParams` that returns
+ * `[{ id: BUILD_PLACEHOLDER_ID }]`. This is required because Next.js 16
+ * with `cacheComponents: true` rejects an empty static-params list for
+ * dynamic routes (`EmptyGenerateStaticParamsError`).
+ *
+ * Each loader MUST short-circuit to `notFound()` when it sees this id
+ * BEFORE calling `await connection()` or any DB read. If `connection()`
+ * runs during the build-time prerender of the placeholder, Next.js emits
+ * a PPR postponed-boundary marker (`<!--$~-->`) in the prerendered shell.
+ * That marker is not handled by React's `$RC` inline reveal script
+ * (`$RC` only handles `<!--$?-->` pending-suspense markers), so on
+ * production the edge-cached shell ships with the resolved content
+ * buffered inside `<div id="S:N" hidden>` but never revealed - operators
+ * see an indefinite "Loading..." spinner.
+ *
+ * Calling `notFound()` synchronously short-circuits the placeholder
+ * render to the 404 path with no Suspense streaming boundary, so the
+ * prerendered shell contains no `$~` marker. Real ids skip the check
+ * and render fully dynamic at runtime as regular `$?` boundaries that
+ * `$RC` reveals correctly.
+ *
+ * Canonical usage in a loader:
+ *
+ *   async function Loader({ params }: Props) {
+ *     const { id } = await params
+ *     if (id === BUILD_PLACEHOLDER_ID) {
+ *       notFound()
+ *     }
+ *     await connection()
+ *     // ...db read, render
+ *   }
+ */
+export const BUILD_PLACEHOLDER_ID = '__build_placeholder__'

--- a/tests/unit/admin/build-placeholder.test.ts
+++ b/tests/unit/admin/build-placeholder.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression tests for the admin `BUILD_PLACEHOLDER_ID` contract.
+ *
+ * The placeholder string MUST stay byte-equal across the shared constant
+ * AND every admin `[id]` page that returns it from `generateStaticParams`.
+ * A drift between the two would silently break the placeholder
+ * short-circuit in the loader (the `id === BUILD_PLACEHOLDER_ID` check)
+ * and re-introduce the original PPR postponed-boundary "Loading..." bug.
+ *
+ * These tests are file-source regressions: they read each admin page as
+ * text and assert (a) it imports the shared constant, (b) it does not
+ * hard-code the literal string anywhere. Coupled with TypeScript, this
+ * is enough to prevent the silent typo failure mode.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+
+const ADMIN_ROOT = join(process.cwd(), 'src/app/(admin)/admin')
+
+// Files that need the BUILD_PLACEHOLDER_ID contract. Each must:
+//   1. Import BUILD_PLACEHOLDER_ID from '@/lib/admin/build-placeholder'
+//   2. Reference it from generateStaticParams() (not a hard-coded string)
+//   3. Reference it from the loader's short-circuit check
+const ADMIN_DYNAMIC_PAGES: string[] = [
+	'blog/[id]/edit/page.tsx',
+	'showcase/[id]/edit/page.tsx',
+	'testimonials/[id]/edit/page.tsx',
+	'leads/[id]/page.tsx',
+	'leads/calculator/[id]/page.tsx',
+	'emails/[id]/page.tsx',
+	'newsletter/[id]/page.tsx'
+]
+
+describe('BUILD_PLACEHOLDER_ID', () => {
+	it('exports the expected literal value', () => {
+		expect(BUILD_PLACEHOLDER_ID).toBe('__build_placeholder__')
+	})
+
+	it.each(
+		ADMIN_DYNAMIC_PAGES
+	)('%s imports BUILD_PLACEHOLDER_ID from the shared module', relPath => {
+		const source = readFileSync(join(ADMIN_ROOT, relPath), 'utf8')
+		expect(source).toContain(
+			"import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'"
+		)
+	})
+
+	it.each(
+		ADMIN_DYNAMIC_PAGES
+	)('%s does not hard-code the placeholder string literal', relPath => {
+		const source = readFileSync(join(ADMIN_ROOT, relPath), 'utf8')
+		// The literal MUST only appear in the shared constant module.
+		// Any direct occurrence in a page file means the import was
+		// bypassed and the short-circuit could drift silently.
+		expect(source).not.toContain("'__build_placeholder__'")
+		expect(source).not.toContain('"__build_placeholder__"')
+	})
+
+	it.each(
+		ADMIN_DYNAMIC_PAGES
+	)('%s short-circuits to notFound() before connection() in its loader', relPath => {
+		// Strip JSDoc + line comments so we only check actual code.
+		// Without this, an `await connection()` mention in the file
+		// header docstring would match first and the test would
+		// spuriously fail.
+		const source = readFileSync(join(ADMIN_ROOT, relPath), 'utf8')
+			.replace(/\/\*[\s\S]*?\*\//g, '')
+			.replace(/^\s*\/\/.*$/gm, '')
+		const notFoundIdx = source.indexOf('if (id === BUILD_PLACEHOLDER_ID) {')
+		const connectionIdx = source.indexOf('await connection()')
+		expect(notFoundIdx).toBeGreaterThan(-1)
+		expect(connectionIdx).toBeGreaterThan(-1)
+		expect(notFoundIdx).toBeLessThan(connectionIdx)
+	})
+
+	it('covers every admin [id] page (no new dynamic route slipped through)', () => {
+		// Walk the admin tree; collect every leaf `page.tsx` that lives
+		// inside a [param] segment. Compare to ADMIN_DYNAMIC_PAGES so a
+		// future new dynamic route forces the author to update this test.
+		function walk(dir: string, rel = ''): string[] {
+			const out: string[] = []
+			for (const entry of readdirSync(dir, { withFileTypes: true })) {
+				const relChild = rel ? `${rel}/${entry.name}` : entry.name
+				if (entry.isDirectory()) {
+					out.push(...walk(join(dir, entry.name), relChild))
+				} else if (entry.name === 'page.tsx' && rel.includes('[')) {
+					out.push(relChild)
+				}
+			}
+			return out
+		}
+		const found = walk(ADMIN_ROOT).sort()
+		const expected = ADMIN_DYNAMIC_PAGES.slice().sort()
+		expect(found).toEqual(expected)
+	})
+})


### PR DESCRIPTION
## Summary

All 7 admin dynamic edit pages were stuck on the Suspense \`Loading...\` fallback in production. Form HTML was present in the DOM inside a hidden \`<div id="S:N" hidden>\` but React's \`\$RC\` inline reveal script never unhid it.

**Root cause:** Each page exported \`generateStaticParams\` returning \`[{ id: '__build_placeholder__' }]\` to satisfy \`cacheComponents\` (which rejects an empty static-params list with \`EmptyGenerateStaticParamsError\`). At build time the loader ran \`await connection()\` BEFORE checking the placeholder id, so the prerendered shell was a Suspense-streamed dynamic boundary marked \`<!--\$~-->\` (PPR postponed). That marker is not handled by React's \`\$RC\` -- \`\$RC\` only handles \`<!--\$?-->\` (regular pending suspense). On production the edge cache served the postponed shell with the resolved form buffered inside \`<div id="S:N" hidden>\`, \`\$RC\` ran without effect, and operators got an indefinite spinner.

**Fix:** Each loader checks the placeholder id BEFORE calling \`connection()\` / the DB read and short-circuits to \`notFound()\`. The prerender renders the 404 path instead of a dynamic Suspense shell, so no \`\$~\` marker is emitted. Real ids skip the short-circuit and render fully dynamic at runtime as regular \`\$?\` boundaries that \`\$RC\` reveals correctly.

## Changes

- **\`src/lib/admin/build-placeholder.ts\`** (new) — canonical \`BUILD_PLACEHOLDER_ID\` constant + full root-cause docblock. Single source of truth so a typo can't silently break the short-circuit across 7 files.
- **\`tests/unit/admin/build-placeholder.test.ts\`** (new, 23 cases) — regression suite asserting every admin \`[id]\` page (a) imports the constant, (b) never hard-codes the literal, (c) short-circuits before \`connection()\`. Also enumerates the admin tree so a new dynamic route forces the author to extend coverage.
- 7 admin pages updated to import the constant and short-circuit before \`connection()\` / DB call. Stale module JSDocs that incorrectly claimed "Fully dynamic (no \`generateStaticParams\`)" are corrected.

Affected: \`blog/[id]/edit\`, \`showcase/[id]/edit\`, \`testimonials/[id]/edit\`, \`leads/[id]\`, \`leads/calculator/[id]\`, \`emails/[id]\`, \`newsletter/[id]\`.

Public dynamic routes (\`blog/[slug]\`, \`showcase/[slug]\`, etc.) are unaffected — they use \`'use cache'\` data layers, never call \`connection()\` inside Suspense, so they emit \`\$?\` boundaries that \`\$RC\` reveals correctly. No fix needed.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean
- [x] \`bun run build\` succeeds — all 7 routes classified \`(Partial Prerender)\` with the placeholder rendering 404 (no \`\$~\` in shell)
- [x] \`bun run test:unit\` 605/605 pass (was 582, +23 new regression cases)
- [ ] Live verify on Vercel preview: \`/admin/showcase/[id]/edit\` and \`/admin/blog/[id]/edit\` render form (not "Loading...") for a real id

[hudsor01]