### PR TITLE
fix(admin): unbreak admin list pages — buttonVariants off client boundary

### DIFF
--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,70 @@
+/**
+ * Button style variants + props type, extracted into a server-safe
+ * module so server components can import `buttonVariants` without
+ * crossing the client boundary.
+ *
+ * Background: `src/components/ui/button.tsx` is `'use client'` (Button
+ * uses `@radix-ui/react-slot` via `asChild`, which requires the client
+ * runtime). When `buttonVariants` lived in that same file, importing
+ * it from a server component (e.g. shadcn `<PaginationLink>` from
+ * `@/components/ui/pagination`, which is itself server-renderable)
+ * tripped Next.js's "Attempted to call buttonVariants() from server
+ * in a Server Component" error -- the function was tagged client-only
+ * by being exported from a `'use client'` module, even though the
+ * function body is pure (no client APIs).
+ *
+ * The `cva()` config + `ButtonProps` type live here (no `'use client'`).
+ * `button.tsx` re-exports both so existing imports keep working;
+ * shadcn primitives that need only the variants (e.g. `pagination.tsx`)
+ * should import from here directly to avoid pulling the client Button
+ * into a server render path.
+ */
+import { cva, type VariantProps } from 'class-variance-authority'
+import type * as React from 'react'
+
+export const buttonVariants = cva(
+	"inline-flex items-center justify-center gap-tight whitespace-nowrap rounded-md text-sm font-medium transition-smooth disabled:pointer-events-none disabled:opacity-50 will-change-transform [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	{
+		variants: {
+			variant: {
+				default:
+					'bg-primary text-primary-foreground shadow-sm hover:bg-primary/80 active:bg-primary/70 focus-visible:ring-primary/30',
+				destructive:
+					'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80 active:bg-destructive/75 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+				success:
+					'bg-success text-success-foreground shadow-sm hover:bg-success/90 active:bg-success/80',
+				accent:
+					'bg-accent text-accent-foreground shadow-sm hover:bg-accent/85 active:bg-accent/75',
+				outline:
+					'border border-border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/15 dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+				secondary:
+					'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80 active:bg-secondary/70',
+				muted:
+					'bg-muted text-muted-foreground hover:bg-muted/80 active:bg-muted/70',
+				ghost: 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+				link: 'text-primary underline-offset-4 hover:underline'
+			},
+			size: {
+				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+				sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+				xl: 'h-12 rounded-xl px-10 py-5 text-lg font-bold has-[>svg]:px-8',
+				icon: 'size-9',
+				'icon-sm': 'size-8',
+				'icon-lg': 'size-10'
+			}
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default'
+		}
+	}
+)
+
+export interface ButtonProps
+	extends React.ComponentProps<'button'>,
+		VariantProps<typeof buttonVariants> {
+	asChild?: boolean
+	/** Track this button click as a conversion event (handled by Vercel Analytics) */
+	trackConversion?: boolean
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,57 +1,12 @@
 'use client'
 
 import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
-import type * as React from 'react'
 
+import {
+	type ButtonProps,
+	buttonVariants
+} from '@/components/ui/button-variants'
 import { cn } from '@/lib/utils'
-
-const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-tight whitespace-nowrap rounded-md text-sm font-medium transition-smooth disabled:pointer-events-none disabled:opacity-50 will-change-transform [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-hidden focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-	{
-		variants: {
-			variant: {
-				default:
-					'bg-primary text-primary-foreground shadow-sm hover:bg-primary/80 active:bg-primary/70 focus-visible:ring-primary/30',
-				destructive:
-					'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/80 active:bg-destructive/75 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
-				success:
-					'bg-success text-success-foreground shadow-sm hover:bg-success/90 active:bg-success/80',
-				accent:
-					'bg-accent text-accent-foreground shadow-sm hover:bg-accent/85 active:bg-accent/75',
-				outline:
-					'border border-border bg-background text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground active:bg-accent/15 dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
-				secondary:
-					'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80 active:bg-secondary/70',
-				muted:
-					'bg-muted text-muted-foreground hover:bg-muted/80 active:bg-muted/70',
-				ghost: 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-				link: 'text-primary underline-offset-4 hover:underline'
-			},
-			size: {
-				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
-				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-				xl: 'h-12 rounded-xl px-10 py-5 text-lg font-bold has-[>svg]:px-8',
-				icon: 'size-9',
-				'icon-sm': 'size-8',
-				'icon-lg': 'size-10'
-			}
-		},
-		defaultVariants: {
-			variant: 'default',
-			size: 'default'
-		}
-	}
-)
-
-interface ButtonProps
-	extends React.ComponentProps<'button'>,
-		VariantProps<typeof buttonVariants> {
-	asChild?: boolean
-	/** Track this button click as a conversion event (handled by Vercel Analytics) */
-	trackConversion?: boolean
-}
 
 function Button({
 	className,
@@ -75,5 +30,11 @@ function Button({
 	)
 }
 
+// Re-export from button-variants so existing imports like
+// `import { buttonVariants } from '@/components/ui/button'` keep working
+// AND server components can `import { buttonVariants } from
+// '@/components/ui/button-variants'` to avoid pulling the client Button
+// module into a server render path. See button-variants.ts for the
+// background.
 export type { ButtonProps }
 export { Button, buttonVariants }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,7 +1,10 @@
 import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
 import * as React from 'react'
 
-import { type ButtonProps, buttonVariants } from '@/components/ui/button'
+import {
+	type ButtonProps,
+	buttonVariants
+} from '@/components/ui/button-variants'
 import { cn } from '@/lib/utils'
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (

--- a/tests/unit/admin/server-client-boundary.test.ts
+++ b/tests/unit/admin/server-client-boundary.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Server / client boundary regression tests for the shadcn ui/ primitives
+ * that Phase 10 admin pages render in server components.
+ *
+ * Background (PR #228 post-merge hotfix): `buttonVariants` was originally
+ * exported from `src/components/ui/button.tsx`, which begins with
+ * `'use client'` (Button uses `@radix-ui/react-slot` via `asChild`,
+ * which requires the client runtime). When `buttonVariants` lived in
+ * that file, importing it from a server component -- e.g. shadcn
+ * `<PaginationLink>` from `@/components/ui/pagination`, itself rendered
+ * inside server-component admin list pages -- crashed prod with
+ * "Attempted to call buttonVariants() from server in a Server
+ * Component". Fix: move `buttonVariants` + `ButtonProps` into a
+ * non-client module (`src/components/ui/button-variants.ts`) and import
+ * from there everywhere a server render path may touch them. Button
+ * re-exports for backward compatibility.
+ *
+ * These tests are file-source regressions: they read each ui/ primitive
+ * as text and assert (a) `button-variants.ts` does NOT carry a
+ * `'use client'` directive, (b) `pagination.tsx` imports `buttonVariants`
+ * from `button-variants` (not from the client `button` module). Coupled
+ * with the existing prod build + tsc, this catches a future drift where
+ * someone moves `buttonVariants` back into the client Button file.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const UI_ROOT = join(process.cwd(), 'src/components/ui')
+
+describe('shadcn ui server/client boundary', () => {
+	it('button-variants.ts is server-safe (no `use client` directive)', () => {
+		const source = readFileSync(join(UI_ROOT, 'button-variants.ts'), 'utf8')
+		// The directive must be the first non-comment statement in the file
+		// to take effect. We strip the leading JSDoc block (which is allowed
+		// to MENTION `'use client'` for explanatory purposes) and check that
+		// no directive form starts the remaining code.
+		const stripped = source.replace(/^\/\*[\s\S]*?\*\//, '').trimStart()
+		expect(/^['"]use client['"];?/.test(stripped)).toBe(false)
+	})
+
+	it('button-variants.ts exports buttonVariants + ButtonProps', () => {
+		const source = readFileSync(join(UI_ROOT, 'button-variants.ts'), 'utf8')
+		expect(source.includes('export const buttonVariants')).toBe(true)
+		expect(source.includes('export interface ButtonProps')).toBe(true)
+	})
+
+	it('button.tsx re-exports buttonVariants + ButtonProps from button-variants', () => {
+		// Backward compatibility: existing imports of the form
+		// `import { buttonVariants } from '@/components/ui/button'` keep working.
+		const source = readFileSync(join(UI_ROOT, 'button.tsx'), 'utf8')
+		expect(source.includes("from '@/components/ui/button-variants'")).toBe(true)
+		expect(source.includes('buttonVariants')).toBe(true)
+		expect(source.includes('ButtonProps')).toBe(true)
+	})
+
+	it('pagination.tsx imports buttonVariants from button-variants, NOT from button', () => {
+		// This is the load-bearing assertion: if someone re-routes the import
+		// back to the client Button file, server rendering of <PaginationLink>
+		// crashes again. Match the closing quote so we don't get a false
+		// positive from `button-variants` (which has `button` as a prefix).
+		const source = readFileSync(join(UI_ROOT, 'pagination.tsx'), 'utf8')
+		expect(source.includes("from '@/components/ui/button-variants'")).toBe(true)
+		expect(/from ['"]@\/components\/ui\/button['"]/.test(source)).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary

Hotfix for a Phase 10 production regression. After PR #228 + #230 shipped, every admin list page that rendered shadcn \`<Pagination>\` crashed in production with:

\`\`\`
Error: Attempted to call buttonVariants() from server in a Server Component
\`\`\`

The user-visible symptom was an "Oops! Something went wrong" boundary at \`/admin/showcase\` and the other 6 list pages.

## Root cause

- \`src/components/ui/button.tsx\` carries \`'use client'\` (Button uses \`@radix-ui/react-slot\` via \`asChild\`, which needs the client runtime).
- Phase 10's \`src/components/ui/pagination.tsx\` (pulled from the shadcn registry, server-renderable) imported \`buttonVariants\` from \`@/components/ui/button\` to compose its link classes.
- When a SERVER component (each of the 7 admin list pages) rendered shadcn \`<PaginationLink>\`, Next.js refused to call the client-tagged \`buttonVariants\` from the server render path. The page-level error boundary swallowed it in production.

This wasn't caught by the Phase 10 pre-merge gates because \`bun run build\` succeeded (the static shell renders fine) and the helper tests don't exercise the page-render path.

## Fix (canonical shadcn pattern, used by newer shadcn-ui releases)

1. New \`src/components/ui/button-variants.ts\` — NO \`'use client'\` directive. Contains the \`cva()\` config + \`ButtonProps\` type. Pure, no client deps.
2. \`src/components/ui/button.tsx\` now imports from button-variants and re-exports \`buttonVariants\` + \`ButtonProps\` so existing call sites keep working without churn.
3. \`src/components/ui/pagination.tsx\` now imports \`buttonVariants\` directly from \`@/components/ui/button-variants\`. **This is the load-bearing change.** Pagination no longer pulls the client Button module into a server render path.

## Regression test

New \`tests/unit/admin/server-client-boundary.test.ts\` (4 cases) asserts:
- \`button-variants.ts\` has no \`'use client'\` directive at the top (strips the JSDoc first so the docblock can MENTION the term for explanation).
- \`button-variants.ts\` exports \`buttonVariants\` + \`ButtonProps\`.
- \`button.tsx\` re-exports from button-variants for back-compat.
- \`pagination.tsx\` imports \`buttonVariants\` from \`button-variants\` and NOT from the client Button module.

If a future edit re-routes the import or adds \`'use client'\` to button-variants, the test fails before the bug ships.

## Gates

- \`bun run lint\` exit 0
- \`bun run typecheck\` exit 0
- \`bun run test:unit\`: **727 / 727 pass** (was 723, +4 new regression cases)
- \`bun run build\` exit 0

## Test plan

- [x] All gates green
- [x] Regression test added
- [ ] Live verify after merge: \`/admin/showcase\`, \`/admin/blog\`, \`/admin/testimonials\`, \`/admin/leads\`, \`/admin/leads/calculator\`, \`/admin/newsletter\`, \`/admin/emails\` all render visibly (no error boundary)

[hudsor01]