### PR TITLE
chore: prune dead code surfaced by knip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,9 @@ temp/
 
 # IDE and editor files
 .claude/
+.codex/
+.cursor/
+.gemini/
 .vscode/
 .idea/
 *.swp

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,31 @@
+{
+	"$schema": "https://unpkg.com/knip@6/schema.json",
+	"entry": [
+		"src/app/**/page.{ts,tsx}",
+		"src/app/**/layout.{ts,tsx}",
+		"src/app/**/error.{ts,tsx}",
+		"src/app/**/loading.{ts,tsx}",
+		"src/app/**/not-found.{ts,tsx}",
+		"src/app/**/route.{ts,tsx}",
+		"src/app/**/template.{ts,tsx}",
+		"src/app/**/default.{ts,tsx}",
+		"src/app/**/icon{,0,1,2,3,4,5,6,7,8,9}.{ts,tsx}",
+		"src/app/**/apple-icon{,0,1,2}.{ts,tsx}",
+		"src/app/**/opengraph-image{,0,1,2}.{ts,tsx}",
+		"src/app/**/twitter-image{,0,1,2}.{ts,tsx}",
+		"src/app/**/sitemap.{ts,tsx}",
+		"src/app/**/robots.{ts,tsx}",
+		"src/app/**/manifest.{ts,tsx}",
+		"src/middleware.{ts,tsx}",
+		"proxy.ts",
+		"next.config.ts",
+		"drizzle.config.ts",
+		"playwright.config.ts",
+		"scripts/**/*.ts",
+		"tests/**/*.{test,spec}.ts",
+		"e2e/**/*.spec.ts"
+	],
+	"project": ["src/**/*.{ts,tsx}"],
+	"ignore": ["src/lib/_generated/**"],
+	"ignoreDependencies": ["tailwindcss"]
+}

--- a/scripts/generate-brand-tokens.ts
+++ b/scripts/generate-brand-tokens.ts
@@ -149,7 +149,7 @@ function parseThemeBlock(
 	return tokens
 }
 
-function emit(lightTokens: ParsedToken[], darkTokens: ParsedToken[]): string {
+function emit(lightTokens: ParsedToken[]): string {
 	const ts = new Date().toISOString()
 	const lines: string[] = [
 		'// AUTO-GENERATED FROM src/app/globals.css — DO NOT EDIT MANUALLY.',
@@ -165,23 +165,11 @@ function emit(lightTokens: ParsedToken[], darkTokens: ParsedToken[]): string {
 		lines.push(`\t${t.jsName}: '${t.hex}', // ${t.cssName}`)
 	}
 	lines.push('} as const', '')
-
-	if (darkTokens.length > 0) {
-		lines.push('export const BRAND_DARK = {')
-		for (const t of darkTokens) {
-			lines.push(`\t${t.jsName}: '${t.hex}', // ${t.cssName} (dark)`)
-		}
-		lines.push('} as const', '')
-	}
-
-	lines.push(
-		'export type BrandColor = keyof typeof BRAND',
-		darkTokens.length > 0
-			? 'export type BrandColorDark = keyof typeof BRAND_DARK'
-			: '',
-		''
-	)
-	return lines.filter(l => l !== undefined).join('\n')
+	// BRAND_DARK + BrandColor / BrandColorDark types were emitted previously
+	// but never consumed. Reintroduce here only if a runtime consumer of the
+	// dark palette or a keyof-typed prop surfaces; the dark token mirror is
+	// already covered by the CSS variables under `.dark { ... }`.
+	return lines.join('\n')
 }
 
 function stripTimestamp(content: string): string {
@@ -196,7 +184,7 @@ function main(): void {
 	const lightTokens = parseThemeBlock(css, '@theme')
 	const darkTokens = parseThemeBlock(css, '.dark')
 
-	const newContent = emit(lightTokens, darkTokens)
+	const newContent = emit(lightTokens)
 
 	let existing = ''
 	try {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -30,11 +30,8 @@ function Button({
 	)
 }
 
-// Re-export from button-variants so existing imports like
-// `import { buttonVariants } from '@/components/ui/button'` keep working
-// AND server components can `import { buttonVariants } from
-// '@/components/ui/button-variants'` to avoid pulling the client Button
-// module into a server render path. See button-variants.ts for the
-// background.
-export type { ButtonProps }
-export { Button, buttonVariants }
+// `ButtonProps` and `buttonVariants` are intentionally NOT re-exported —
+// server components must import them from `@/components/ui/button-variants`
+// to avoid pulling the client Button module into a server render path
+// (see button-variants.ts).
+export { Button }

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import * as React from 'react'
 
 import {
@@ -94,27 +94,13 @@ const PaginationNext = ({
 )
 PaginationNext.displayName = 'PaginationNext'
 
-const PaginationEllipsis = ({
-	className,
-	...props
-}: React.ComponentProps<'span'>) => (
-	<span
-		aria-hidden
-		className={cn('flex h-9 w-9 items-center justify-center', className)}
-		{...props}
-	>
-		<MoreHorizontal className="h-4 w-4" />
-		<span className="sr-only">More pages</span>
-	</span>
-)
-PaginationEllipsis.displayName = 'PaginationEllipsis'
-
+// `PaginationLink` is intentionally not exported — it is an internal
+// primitive used by PaginationNext/PaginationPrevious. Re-add to the
+// barrel below if a consumer needs to render a custom page link.
 export {
 	Pagination,
 	PaginationContent,
-	PaginationEllipsis,
 	PaginationItem,
-	PaginationLink,
 	PaginationNext,
 	PaginationPrevious
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -36,21 +36,6 @@ const TableBody = React.forwardRef<
 ))
 TableBody.displayName = 'TableBody'
 
-const TableFooter = React.forwardRef<
-	HTMLTableSectionElement,
-	React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-	<tfoot
-		ref={ref}
-		className={cn(
-			'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
-			className
-		)}
-		{...props}
-	/>
-))
-TableFooter.displayName = 'TableFooter'
-
 const TableRow = React.forwardRef<
 	HTMLTableRowElement,
 	React.HTMLAttributes<HTMLTableRowElement>
@@ -113,7 +98,6 @@ export {
 	TableBody,
 	TableCaption,
 	TableCell,
-	TableFooter,
 	TableHead,
 	TableHeader,
 	TableRow

--- a/src/lib/_generated/brand.ts
+++ b/src/lib/_generated/brand.ts
@@ -3,7 +3,7 @@
 //
 // Source: src/app/globals.css @theme {} (light) and .dark {} (dark)
 // Conversion: OKLCH -> sRGB hex (Bjorn Ottosson formulas, hand-rolled, no deps)
-// Last generated: 2026-05-10T09:07:56.732Z
+// Last generated: 2026-05-28T23:22:53.977Z
 
 export const BRAND = {
 	background: '#fafaf9', // --color-background
@@ -65,52 +65,3 @@ export const BRAND = {
 	borderSubtle: '#e3e8ef', // --color-border-subtle
 	borderStrong: '#a6afbb', // --color-border-strong
 } as const
-
-export const BRAND_DARK = {
-	background: '#03060b', // --color-background (dark)
-	foreground: '#edebe5', // --color-foreground (dark)
-	card: '#090d15', // --color-card (dark)
-	cardForeground: '#edebe5', // --color-card-foreground (dark)
-	popover: '#090d15', // --color-popover (dark)
-	popoverForeground: '#edebe5', // --color-popover-foreground (dark)
-	primary: '#6aa7f4', // --color-primary (dark)
-	primaryForeground: '#03060b', // --color-primary-foreground (dark)
-	secondary: '#151b24', // --color-secondary (dark)
-	secondaryForeground: '#e6e4df', // --color-secondary-foreground (dark)
-	muted: '#12161d', // --color-muted (dark)
-	mutedForeground: '#d1cdc3', // --color-muted-foreground (dark)
-	accent: '#f0a556', // --color-accent (dark)
-	accentForeground: '#110904', // --color-accent-foreground (dark)
-	accentText: '#ffbb6d', // --color-accent-text (dark)
-	destructive: '#e85854', // --color-destructive (dark)
-	destructiveForeground: '#fcf7f7', // --color-destructive-foreground (dark)
-	border: '#232933', // --color-border (dark)
-	input: '#0e1218', // --color-input (dark)
-	ring: '#6aa7f4', // --color-ring (dark)
-	textInverted: '#080b12', // --color-text-inverted (dark)
-	textPrimary: '#edebe5', // --color-text-primary (dark)
-	textSecondary: '#bab7af', // --color-text-secondary (dark)
-	textMuted: '#918f88', // --color-text-muted (dark)
-	surfaceBase: '#03060b', // --color-surface-base (dark)
-	surfaceRaised: '#090d15', // --color-surface-raised (dark)
-	surfaceElevated: '#101620', // --color-surface-elevated (dark)
-	surfaceOverlay: '#060910', // --color-surface-overlay (dark)
-	surfaceSunken: '#020306', // --color-surface-sunken (dark)
-	borderSubtle: '#171b22', // --color-border-subtle (dark)
-	borderStrong: '#3b4350', // --color-border-strong (dark)
-	destructiveLight: '#310d0c', // --color-destructive-light (dark)
-	destructiveMuted: '#290b0a', // --color-destructive-muted (dark)
-	destructiveText: '#f97770', // --color-destructive-text (dark)
-	successLight: '#002307', // --color-success-light (dark)
-	successMuted: '#001d06', // --color-success-muted (dark)
-	successText: '#4eb068', // --color-success-text (dark)
-	warningLight: '#351f00', // --color-warning-light (dark)
-	warningMuted: '#2b1900', // --color-warning-muted (dark)
-	warningText: '#dca744', // --color-warning-text (dark)
-	infoLight: '#001c34', // --color-info-light (dark)
-	infoMuted: '#00182b', // --color-info-muted (dark)
-	infoText: '#499fe3', // --color-info-text (dark)
-} as const
-
-export type BrandColor = keyof typeof BRAND
-export type BrandColorDark = keyof typeof BRAND_DARK

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -12,8 +12,8 @@
 import { createAuthClient } from 'better-auth/react'
 import { env } from '@/env'
 
-export const authClient = createAuthClient({
+const authClient = createAuthClient({
 	baseURL: env.NEXT_PUBLIC_BASE_URL
 })
 
-export const { signIn, signUp, signOut, useSession } = authClient
+export const { signIn, signUp, signOut } = authClient

--- a/src/lib/schemas/admin-calculator-leads.ts
+++ b/src/lib/schemas/admin-calculator-leads.ts
@@ -29,9 +29,3 @@ export const markConvertedSchema = z.object({
 export const deleteCalculatorLeadSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid calculator lead id.' })
 })
-
-export type MarkContactedInput = z.infer<typeof markContactedSchema>
-export type MarkConvertedInput = z.infer<typeof markConvertedSchema>
-export type DeleteCalculatorLeadInput = z.infer<
-	typeof deleteCalculatorLeadSchema
->

--- a/src/lib/schemas/admin-emails.ts
+++ b/src/lib/schemas/admin-emails.ts
@@ -28,7 +28,3 @@ export const cancelEmailSchema = z.object({
 export const deleteEmailSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid email id.' })
 })
-
-export type RetryEmailInput = z.infer<typeof retryEmailSchema>
-export type CancelEmailInput = z.infer<typeof cancelEmailSchema>
-export type DeleteEmailInput = z.infer<typeof deleteEmailSchema>

--- a/src/lib/schemas/admin-leads.ts
+++ b/src/lib/schemas/admin-leads.ts
@@ -33,7 +33,6 @@ export const updateLeadStatusSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid lead id.' }),
 	status: z.enum(LEAD_STATUSES, { message: 'Pick a valid status.' })
 })
-export type UpdateLeadStatusInput = z.infer<typeof updateLeadStatusSchema>
 
 export const addLeadNoteSchema = z.object({
 	leadId: z.string().uuid({ message: 'Invalid lead id.' }),
@@ -43,7 +42,6 @@ export const addLeadNoteSchema = z.object({
 		.min(1, 'Note cannot be empty.')
 		.max(4000, 'Note must be under 4000 characters.')
 })
-export type AddLeadNoteInput = z.infer<typeof addLeadNoteSchema>
 
 export const deleteLeadSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid lead id.' })

--- a/src/lib/schemas/admin-newsletter.ts
+++ b/src/lib/schemas/admin-newsletter.ts
@@ -14,9 +14,7 @@
  */
 import { z } from 'zod'
 
-export const SUBSCRIBER_STATUSES_FOR_SET = ['active', 'unsubscribed'] as const
-export type SubscriberStatusForSet =
-	(typeof SUBSCRIBER_STATUSES_FOR_SET)[number]
+const SUBSCRIBER_STATUSES_FOR_SET = ['active', 'unsubscribed'] as const
 
 // Bounced is observable (set by the email provider webhook) but not
 // operator-settable. If a use case appears, extend SUBSCRIBER_STATUSES_FOR_SET
@@ -32,6 +30,3 @@ export const setStatusSchema = z.object({
 export const deleteSubscriberSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid subscriber id.' })
 })
-
-export type SetStatusInput = z.infer<typeof setStatusSchema>
-export type DeleteSubscriberInput = z.infer<typeof deleteSubscriberSchema>

--- a/src/lib/schemas/auth-forms.ts
+++ b/src/lib/schemas/auth-forms.ts
@@ -32,6 +32,3 @@ export const signUpSchema = z.object({
 		.max(100, 'Name must be less than 100 characters')
 		.optional()
 })
-
-export type SignInInput = z.infer<typeof signInSchema>
-export type SignUpInput = z.infer<typeof signUpSchema>


### PR DESCRIPTION
## Summary

Knip-driven dead-code sweep. After this PR, `bunx knip` reports zero findings on a default run (no allowlists hiding work). 13 files changed, 80 net lines deleted, no behavior change, no public API surface affected beyond the trivial type aliases listed below.

## What was actually unused

| Surface | Symbol | Status |
|---|---|---|
| `src/components/ui/button.tsx` | `buttonVariants`, `ButtonProps` re-exports | Removed (consumers import from `button-variants.ts` directly) |
| `src/components/ui/pagination.tsx` | `PaginationEllipsis` component + export | Deleted (zero consumers internally or externally) |
| `src/components/ui/pagination.tsx` | `PaginationLink` export | Demoted to internal-only (still used by Prev/Next) |
| `src/components/ui/table.tsx` | `TableFooter` component + export | Deleted |
| `src/lib/auth/client.ts` | `authClient` export, `useSession` re-export | Made internal / dropped |
| `src/lib/schemas/admin-*.ts` + `auth-forms.ts` | 13 inferred-type aliases | Deleted (schemas remain public; types had zero consumers) |
| `src/lib/_generated/brand.ts` | `BRAND_DARK`, `BrandColor`, `BrandColorDark` | Generator updated to stop emitting |

## Tooling additions

- **`knip.json`** — Next.js App Router entry conventions (`icon\d*`, `apple-icon`, `opengraph-image`, `twitter-image`, `sitemap`, `robots`, `manifest`, `middleware`, `proxy`, scripts, tests). Without this, the next/font auto-discovered icon files (`src/app/icon0.tsx`, `src/app/icon1.tsx`) get false-positive-flagged. Also `ignoreDependencies: [\"tailwindcss\"]` because knip cannot resolve the `@import 'tailwindcss'` consumer in `globals.css`.
- **`.gitignore`** — `.codex/`, `.cursor/`, `.gemini/` added alongside `.claude/`. Per-user MCP/CLI configs from competing AI dev tools should never leak into the repo. The currently untracked `.codex/config.toml` and `.gemini/settings.json` on this workspace are personal MCP server bindings, not project state.

## Test plan

- [ ] `bunx knip --reporter compact` returns no findings
- [ ] `bun run lint && bun run typecheck && bun run test:unit && bun run build` all pass
- [ ] Admin pages still render (touched table.tsx and pagination.tsx)
- [ ] Sign-in / sign-up / sign-out still work (touched auth/client.ts)
- [ ] Theme tokens / Tailwind utilities unchanged (regenerated brand.ts)

[hudsor01]