### PR TITLE
fix(audit): contact + newsletter form pre-hydration safety (#237 #238 #245)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -283,6 +283,20 @@ body {
 	outline-offset: 2px;
 }
 
+/* `:user-invalid` fires only after the user has interacted with a
+ * required/typed input and the value still fails native HTML5
+ * validation (Chrome / Firefox / Safari support since 2023). Cheap
+ * persistent inline error indicator for the audit-reported "no
+ * required-field highlights" complaint (#245). The `:focus` carve-out
+ * keeps the active field's primary focus ring instead of stacking
+ * red + primary outlines while the user types. */
+input:user-invalid:not(:focus),
+textarea:user-invalid:not(:focus),
+select:user-invalid:not(:focus) {
+	border-color: var(--destructive);
+	box-shadow: 0 0 0 1px var(--destructive);
+}
+
 /* WCAG 2.5.8 minimum touch targets — scoped to standalone interactive
  * controls only. Inline anchors are excluded so footer text links and
  * legal links don't get inflated to 44px wide and break mobile layout

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -69,6 +69,13 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 
 	return (
 		<form
+			// `method="post"` so a pre-hydration submit (user clicks Submit
+			// before React finishes mounting) at least uses POST and puts the
+			// payload in the body instead of leaking name/email/message into
+			// the URL as query params. The onSubmit handler still owns the
+			// happy path; this is a defense-in-depth fallback against the
+			// audit-reported GET behavior (#237).
+			method="post"
 			onSubmit={e => {
 				e.preventDefault()
 				e.stopPropagation()

--- a/src/components/forms/NewsletterSignup.tsx
+++ b/src/components/forms/NewsletterSignup.tsx
@@ -70,6 +70,7 @@ function NewsletterSignupContent({
 				</p>
 
 				<form
+					method="post"
 					onSubmit={e => {
 						e.preventDefault()
 						e.stopPropagation()
@@ -87,6 +88,7 @@ function NewsletterSignupContent({
 										id="newsletter-email-compact"
 										name="email"
 										type="email"
+										required
 										value={field.state.value}
 										onChange={e => field.handleChange(e.target.value)}
 										onBlur={field.handleBlur}
@@ -177,6 +179,7 @@ function NewsletterSignupContent({
 				</p>
 
 				<form
+					method="post"
 					onSubmit={e => {
 						e.preventDefault()
 						e.stopPropagation()
@@ -194,6 +197,7 @@ function NewsletterSignupContent({
 										id="newsletter-email-section"
 										name="email"
 										type="email"
+										required
 										value={field.state.value}
 										onChange={e => field.handleChange(e.target.value)}
 										onBlur={field.handleBlur}
@@ -291,6 +295,7 @@ function NewsletterSignupContent({
 					<p className="mt-1 text-sm text-muted-foreground">{description}</p>
 
 					<form
+						method="post"
 						onSubmit={e => {
 							e.preventDefault()
 							e.stopPropagation()
@@ -309,6 +314,7 @@ function NewsletterSignupContent({
 											id="newsletter-email"
 											name="email"
 											type="email"
+											required
 											value={field.state.value}
 											onChange={e => field.handleChange(e.target.value)}
 											onBlur={field.handleBlur}


### PR DESCRIPTION
## Summary

Closes #237, #238, and (partially) #245 from the site audit backlog.

The Contact and Newsletter forms are correctly wired client-side. But neither `<form>` element carried an explicit `method` or `action`, so a click before React hydrates falls back to the browser's default: **GET to the current URL with every field as a query param**. The audit caught that window:

- name / email / phone / message were leaking into the URL and server access logs
- the lead never reached the existing `/api/contact` POST endpoint

## Changes

| File | What |
|---|---|
| `ContactForm.tsx` | Add `method=\"post\"` to the `<form>`. PII no longer leaks into the URL on the pre-hydration race. |
| `NewsletterSignup.tsx` | Add `method=\"post\"` to all three variant `<form>`s (compact, section, Card) and `required` to all three email inputs. The Card variant previously had no `required` gate at all. |
| `globals.css` | Add a global `input/textarea/select:user-invalid:not(:focus)` rule that paints a red border + box-shadow on touched-and-still-invalid fields. Persistent inline highlight for #245 without taking on the TanStack Form schema-validator migration. |

## Why not the schema-validator migration

Tried `validators: { onSubmit: contactFormSchema }` first. The schema's optional fields (`phone?: string`, `service?: ...`) don't line up with the form-state's required-string defaults, so the TanStack Form StandardSchemaV1 adapter rejects with a `string | undefined` is not assignable to `string` error. Resolving that means either narrowing the schema or widening the form-state defaults — a separate refactor that should land in its own PR.

## Test plan

- [ ] Disable JS in DevTools, hit Submit on the contact form with all fields empty — browser blocks submission with native tooltip on the first required field
- [ ] Same, but with values entered — request fires as POST (body, not URL); the API rejects since it expects JSON, which is the worst case but at least PII is in the body
- [ ] Enable JS, fill the form, submit — TanStack Form takes over and POSTs JSON to `/api/contact` as before
- [ ] Touch a required field, leave it empty, tab away — red border appears via `:user-invalid`
- [ ] Same for newsletter signup in all three variants

[hudsor01]