### PR TITLE
fix(audit): remove testimonial-collector from public tools index + sitemap (#242)

### DIFF
--- a/src/app/(public)/tools/page.tsx
+++ b/src/app/(public)/tools/page.tsx
@@ -13,7 +13,6 @@ import {
 	FileSignature,
 	FileText,
 	Home,
-	MessageSquare,
 	Receipt,
 	Tags,
 	TrendingUp,
@@ -192,20 +191,13 @@ const tools = [
 			'SEO meta tag preview'
 		],
 		cta: 'Generate Tags'
-	},
-	{
-		title: 'Testimonial Collector',
-		description:
-			'Generate private collection links to gather client testimonials and manage feedback in one place.',
-		href: TOOL_ROUTES.TESTIMONIAL_COLLECTOR,
-		Icon: MessageSquare,
-		benefits: [
-			'Private collection links',
-			'Manage client feedback',
-			'Shareable testimonial forms'
-		],
-		cta: 'Collect Testimonials'
 	}
+	// The Testimonial Collector tool is admin-only — gated behind an
+	// ADMIN_SECRET bearer token. Linking it from the public tools index
+	// surfaced an "Enter admin token" UI to anyone who clicked through
+	// (audit #242). The route is intentionally left in place so an
+	// operator can still hit it directly with the token; removing it
+	// from this listing is the discoverability fix.
 ]
 
 export default function ToolsPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -90,8 +90,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		'contract-generator',
 		'performance-calculator',
 		'json-formatter',
-		'meta-tag-generator',
-		'testimonial-collector'
+		'meta-tag-generator'
+		// `testimonial-collector` is intentionally omitted — the tool is
+		// admin-only and was previously discoverable to public users via
+		// this sitemap entry + the tools index card. Audit #242.
 	].map(slug => ({
 		url: `${SITE_URL}/tools/${slug}`,
 		lastModified: BUILD_TIME,


### PR DESCRIPTION
## Summary

Closes #242.

The Testimonial Collector tool is admin-only — gated by an ADMIN_SECRET bearer token before it renders anything useful. But it was reachable from two public surfaces:

| Surface | Issue |
|---|---|
| `src/app/(public)/tools/page.tsx` | Listed as a card in the Free Business Tools grid. A small business owner clicking through hit an \"Enter admin token\" input on a `/tools/...` URL. |
| `src/app/sitemap.ts` | Enumerated alongside the public tools, so search engines indexed `/tools/testimonial-collector` and the admin-token UI surfaced in organic results. |

## Changes

- Drop the card from the tools listing
- Remove the now-unused `MessageSquare` import from `tools/page.tsx`
- Drop the slug from `sitemap.ts` with an inline comment so a future contributor does not re-add it

## Intentionally not changed

- The route file at `src/app/(public)/tools/testimonial-collector/` is kept in place. Operators who know the URL can still hit it directly; the admin-token gate already inside the component remains the auth boundary.
- The `TOOL_ROUTES.TESTIMONIAL_COLLECTOR` constant is kept for now. A follow-up could move it to admin routes once an admin landing page is built.

## Test plan

- [ ] Visit `/tools` — Testimonial Collector card no longer appears
- [ ] Visit `/sitemap.xml` — `/tools/testimonial-collector` no longer enumerated
- [ ] Visit `/tools/testimonial-collector` directly — admin-token gate still renders for authorized operators
- [ ] `bunx knip --reporter compact` — zero findings

[hudsor01]