### PR TITLE
fix(audit): swap ExternalLink → ArrowRight on internal View Services button (#246)

### DIFF
--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Rocket } from 'lucide-react'
+import { ArrowRight, Rocket } from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Suspense } from 'react'
@@ -207,7 +207,7 @@ export default function ShowcasePage() {
 							>
 								<Link href="/services">
 									View Services
-									<ExternalLink className="w-5 h-5" aria-hidden="true" />
+									<ArrowRight className="w-5 h-5" aria-hidden="true" />
 								</Link>
 							</Button>
 						</div>
@@ -272,7 +272,7 @@ export default function ShowcasePage() {
 									>
 										<Link href="/services">
 											View Services
-											<ExternalLink className="w-5 h-5" aria-hidden="true" />
+											<ArrowRight className="w-5 h-5" aria-hidden="true" />
 										</Link>
 									</Button>
 								</div>


### PR DESCRIPTION
## Summary

Closes #246.

The Showcase page rendered the `ExternalLink` icon (↗) next to a button linking to the internal `/services` route. The same page's `View Project` buttons (which DO go off-site) carry the same icon — so the contradiction was visible on a single screen.

Swaps the icon to `ArrowRight` for both occurrences (main hero + Suspense fallback hero). Drops the now-unused `ExternalLink` import.

## Test plan

- [ ] Visit `/showcase` — \"View Services\" button shows arrow-right icon, not external-link icon
- [ ] \"View Project\" buttons on the same page still carry the external-link icon (they're external)

[hudsor01]