### PR TITLE
fix(audit): footer Solutions links jump to in-page service anchors (#239)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,10 +10,14 @@ import { cn } from '@/lib/utils'
 const CURRENT_YEAR = new Date().getFullYear()
 
 const footerLinks = {
+	// Anchor IDs (`#design-build`, `#seo`, `#booking`) are owned by the
+	// SERVICES list in `src/components/ui/ServicesGrid.tsx` — keep the
+	// two lists in sync. Audit #239: the labels here used to land on the
+	// services index page with no anchor, leaving operators to scroll.
 	solutions: [
-		{ name: 'Website Design & Build', href: ROUTES.SERVICES },
-		{ name: 'Get Found on Google', href: ROUTES.SERVICES },
-		{ name: 'Booking & Payments', href: ROUTES.SERVICES },
+		{ name: 'Website Design & Build', href: `${ROUTES.SERVICES}#design-build` },
+		{ name: 'Get Found on Google', href: `${ROUTES.SERVICES}#seo` },
+		{ name: 'Booking & Payments', href: `${ROUTES.SERVICES}#booking` },
 		{ name: 'Recent Work', href: ROUTES.SHOWCASE }
 	],
 	company: [

--- a/src/components/ui/ServicesGrid.tsx
+++ b/src/components/ui/ServicesGrid.tsx
@@ -11,8 +11,12 @@
 import { BarChart3, Code2, Settings } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 
+// Slugs mirror the in-page anchors the Footer's "Solutions" links
+// target (`/services#design-build`, `/services#seo`, `/services#booking`).
+// Keep these in sync with the Footer link list (audit #239).
 const SERVICES = [
 	{
+		anchorId: 'design-build',
 		title: 'Website Design & Development',
 		description:
 			'A professional website built for your business from scratch: clean custom design, mobile-ready, and fast. Comes with an admin panel so you control your content without calling a developer.',
@@ -27,6 +31,7 @@ const SERVICES = [
 		gradient: 'bg-muted'
 	},
 	{
+		anchorId: 'seo',
 		title: 'Get Found on Google',
 		description:
 			'A great website only works if customers can find it. We build in the SEO, speed, and local-search details that put your business in front of the people already searching for what you do.',
@@ -41,6 +46,7 @@ const SERVICES = [
 		gradient: 'bg-info/20'
 	},
 	{
+		anchorId: 'booking',
 		title: 'Booking, Payments & Follow-Up',
 		description:
 			'Once your site is live, we can wire in the extras: let customers book online, take payments, and make sure no inquiry slips through the cracks.',
@@ -59,16 +65,23 @@ const SERVICES = [
 export function ServicesGrid() {
 	return (
 		<div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-			{SERVICES.map((service, index) => (
-				<Card
-					key={index}
-					variant="service"
-					title={service.title}
-					description={service.description}
-					features={service.features}
-					icon={service.icon}
-					gradient={service.gradient}
-				/>
+			{SERVICES.map(service => (
+				// The `scroll-mt-24` carve-out keeps the in-page anchor jump
+				// from hiding the card behind the sticky nav.
+				<div
+					key={service.anchorId}
+					id={service.anchorId}
+					className="scroll-mt-24"
+				>
+					<Card
+						variant="service"
+						title={service.title}
+						description={service.description}
+						features={service.features}
+						icon={service.icon}
+						gradient={service.gradient}
+					/>
+				</div>
 			))}
 		</div>
 	)


### PR DESCRIPTION
## Summary

Closes #239.

The Footer's Solutions section listed labels matching the three ServicesGrid cards on `/services`, but every `href` was just `ROUTES.SERVICES` — clicking Website Design & Build / Get Found on Google / Booking & Payments dumped the operator at the top of the services index and forced them to scroll to find the relevant card.

## Fix

| Change | File |
|---|---|
| Add `anchorId` to each entry in the `SERVICES` array; wrap each `Card` in a `<div id=\"{anchorId}\" class=\"scroll-mt-24\">` so the target card lands below the sticky nav instead of underneath it. | `src/components/ui/ServicesGrid.tsx` |
| Append the matching anchors to the three Solutions links: `/services#design-build`, `/services#seo`, `/services#booking`. | `src/components/layout/Footer.tsx` |

Both files carry inline comments cross-referencing each other so the two lists stay in sync.

## Test plan

- [ ] Click each of the three Solutions links in the footer — page scrolls to the matching service card with appropriate offset
- [ ] Direct visit to `/services#design-build`, `/services#seo`, `/services#booking` lands on the card

[hudsor01]