### PR TITLE
fix(audit): footer overflow at narrow desktop widths (#244)

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -177,6 +177,13 @@ export default function Footer() {
 							</p>
 
 							<div className="space-y-3">
+								{/* Shorter copy than the hero/nav CTA ("Get My Free
+								    Website Plan") for two reasons: (a) the footer card
+								    column is ~240px at md and the longer string truncated
+								    to "Get My Free Websit" (audit #244); (b) CTA
+								    saturation — the long form appears multiple times above
+								    this card on the same page, so a tighter footer
+								    variant reduces the repetition. */}
 								<Button
 									asChild
 									variant="default"
@@ -184,24 +191,35 @@ export default function Footer() {
 									trackConversion={true}
 									className="w-full"
 								>
-									<Link href={ROUTES.CONTACT}>Get My Free Website Plan</Link>
+									<Link href={ROUTES.CONTACT}>Get My Free Plan</Link>
 								</Button>
 
+								{/* `min-w-0` on the flex parent unlocks `truncate` on the
+								    text child. Without it the email (~30 chars) overflows
+								    the 1-of-4 column at narrow desktop widths and pushes
+								    "…com" out of the rounded chip (audit #244). */}
 								<a
 									href={`mailto:${BUSINESS_INFO.email}`}
-									className="flex-center gap-tight w-full px-4 py-3 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:border-accent hover:bg-accent/5 transition-smooth focus-ring"
+									className="flex-center gap-tight w-full min-w-0 px-4 py-3 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:border-accent hover:bg-accent/5 transition-smooth focus-ring"
 								>
-									<Mail className="h-4 w-4" />
-									<span className="text-xs">{BUSINESS_INFO.email}</span>
+									<Mail className="h-4 w-4 shrink-0" />
+									<span
+										className="text-xs truncate"
+										title={BUSINESS_INFO.email}
+									>
+										{BUSINESS_INFO.email}
+									</span>
 								</a>
 
 								{BUSINESS_INFO.phone && (
 									<a
 										href={`tel:${BUSINESS_INFO.phone.replace(/\D/g, '')}`}
-										className="flex-center gap-tight w-full px-4 py-3 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:border-accent hover:bg-accent/5 transition-smooth focus-ring"
+										className="flex-center gap-tight w-full min-w-0 px-4 py-3 rounded-lg border border-border text-muted-foreground hover:text-foreground hover:border-accent hover:bg-accent/5 transition-smooth focus-ring"
 									>
-										<Phone className="h-4 w-4" />
-										<span className="text-xs">{BUSINESS_INFO.phone}</span>
+										<Phone className="h-4 w-4 shrink-0" />
+										<span className="text-xs truncate">
+											{BUSINESS_INFO.phone}
+										</span>
 									</a>
 								)}
 							</div>
@@ -210,7 +228,10 @@ export default function Footer() {
 
 					{/* Bottom Section */}
 					<div className="border-t border-white/10 pt-8">
-						<div className="flex flex-col md:flex-row md:items-center md:justify-between gap-y-3 gap-x-content">
+						{/* `flex-wrap` so the three rows (copyright / socials / legal)
+						    can drop to a second line below ~md instead of clipping
+						    "Terms o…" off the right edge (audit #244). */}
+						<div className="flex flex-col md:flex-row md:flex-wrap md:items-center md:justify-between gap-y-3 gap-x-content">
 							{/* Copyright */}
 							<div className="text-xs text-muted-foreground">
 								© {CURRENT_YEAR} Hudson Digital Solutions. All rights reserved.


### PR DESCRIPTION
## Summary

Closes #244.

At a 942px content viewport (common for laptop browsers with a side panel open) three footer surfaces clipped:

| # | Surface | Symptom | Root cause |
|---|---|---|---|
| 1 | Email chip | \"…com\" overflowed off the right edge | Flex parent had no `min-w-0`, so `truncate` on the child had nothing to work against |
| 2 | \"Get My Free Website Plan\" button | Rendered as \"Get My Free Websit\" | `button-variants` applies `whitespace-nowrap` site-wide |
| 3 | Bottom utility row | \"Terms of Service\" clipped to \"Terms o…\" | `md:flex-row md:justify-between` with no `flex-wrap` |

## Fixes

- **Email + phone chips**: `min-w-0` on the anchor flex container, `truncate` + `title` on the text child, `shrink-0` on the icon. Email now truncates with an ellipsis instead of overflowing; operators read the full address via the title tooltip.
- **Footer CTA**: shortened to \"Get My Free Plan\" with an inline comment explaining the divergence from the canonical hero/nav copy. Also partially addresses the CTA-saturation finding from the audit triage — by the time a visitor scrolls to the footer the long string has already appeared 5+ times on the page.
- **Bottom utility row**: `md:flex-wrap` so the three rows can drop to a second line below md instead of clipping.

## Test plan

- [ ] Resize to ~942px content width — email chip truncates with ellipsis, no horizontal overflow
- [ ] Same width — \"Terms of Service\" no longer clipped (wraps to second row)
- [ ] Same width — footer CTA reads in full as \"Get My Free Plan\"
- [ ] Hero CTA + nav CTA still read \"Get My Free Website Plan\" (canonical copy unchanged)

[hudsor01]