### PR TITLE
fix(audit): showcase 404 skeleton flash (#241) + PageSpeed timeout + API key (#236)

### DIFF
--- a/src/app/(public)/showcase/[slug]/page.tsx
+++ b/src/app/(public)/showcase/[slug]/page.tsx
@@ -9,12 +9,12 @@ import { ArrowLeft, Clock, ExternalLink, Users } from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { Suspense } from 'react'
 import { CTASection } from '@/components/utilities/CTASection'
 import {
 	getAllShowcaseSlugs,
 	getShowcaseBySlug,
-	isDetailedShowcase
+	isDetailedShowcase,
+	type ShowcaseItem
 } from '@/lib/showcase'
 
 // Generate static params for all showcase items
@@ -75,14 +75,10 @@ export async function generateMetadata({
 	}
 }
 
-// Async component for showcase content
-async function ShowcaseContent({ slug }: { slug: string }) {
-	const item = await getShowcaseBySlug(slug)
-
-	if (!item) {
-		notFound()
-	}
-
+// Synchronous: the parent already awaited and notFound()'d on miss,
+// so by the time we render here we know `item` is real. Keeping the
+// extraction in its own function makes the JSX-heavy branch readable.
+function ShowcaseContent({ item }: { item: ShowcaseItem }) {
 	const isDetailed = isDetailedShowcase(item)
 	const metrics = Object.entries(item.metrics).map(([label, value]) => ({
 		label,
@@ -374,6 +370,20 @@ export default async function ShowcaseDetailPage({
 }) {
 	const { slug } = await params
 
+	// Await the DB lookup at the top of the route instead of inside a
+	// child Suspense boundary. Previously the Suspense fallback rendered
+	// a spinner + "Loading project..." for the duration of the Neon
+	// cold start, then notFound() fired, then the 404 page replaced
+	// it — leaving a confusing "loading then broken" flash for any
+	// unknown slug (audit #241). Awaiting here means the 404 path
+	// short-circuits before any UI mounts; the known-slug path still
+	// streams normally because Next.js renders the rest of the route
+	// only after this promise resolves.
+	const item = await getShowcaseBySlug(slug)
+	if (!item) {
+		notFound()
+	}
+
 	return (
 		<div className="min-h-screen bg-background">
 			{/* Back Button */}
@@ -389,19 +399,7 @@ export default async function ShowcaseDetailPage({
 				</div>
 			</div>
 
-			{/* Dynamic content with Suspense */}
-			<Suspense
-				fallback={
-					<div className="container-wide py-section text-center">
-						<div className="inline-block animate-spin rounded-full h-12 w-12 border-4 border-border border-t-accent" />
-						<p className="text-muted-foreground text-lg mt-4">
-							Loading project...
-						</p>
-					</div>
-				}
-			>
-				<ShowcaseContent slug={slug} />
-			</Suspense>
+			<ShowcaseContent item={item} />
 		</div>
 	)
 }

--- a/src/app/api/pagespeed/route.ts
+++ b/src/app/api/pagespeed/route.ts
@@ -4,6 +4,7 @@
  */
 
 import { connection, type NextRequest } from 'next/server'
+import { env } from '@/env'
 import { withRateLimit } from '@/lib/api/rate-limit-wrapper'
 import { errorResponse, successResponse } from '@/lib/api/responses'
 import { createServerLogger } from '@/lib/logger'
@@ -11,6 +12,13 @@ import { createServerLogger } from '@/lib/logger'
 const logger = createServerLogger('pagespeed-api')
 const PAGESPEED_API_URL =
 	'https://www.googleapis.com/pagespeedinsights/v5/runPagespeed'
+
+// Stay under Vercel Hobby's 10-second function ceiling. PageSpeed Insights
+// can legitimately take 30-60s for slow sites — without an explicit abort
+// the upstream call ran past Vercel's hard timeout, which surfaces to the
+// browser as a generic 500 and to logs as "PageSpeed API error: Object"
+// (audit #236). Fail fast with a useful message instead.
+const PAGESPEED_FETCH_TIMEOUT_MS = 9_000
 
 /**
  * Reject URLs that point at private/internal address space. The pagespeed
@@ -122,25 +130,46 @@ async function handlePageSpeed(request: NextRequest) {
 	// no request scope.
 	await connection()
 
-	try {
-		logger.info('Fetching PageSpeed data', { url })
+	const apiKey = env.PAGESPEED_API_KEY
+	const requestUrl = `${PAGESPEED_API_URL}?url=${encodeURIComponent(url)}&strategy=mobile&category=performance${
+		apiKey ? `&key=${encodeURIComponent(apiKey)}` : ''
+	}`
 
-		// Call PageSpeed Insights API
-		const response = await fetch(
-			`${PAGESPEED_API_URL}?url=${encodeURIComponent(url)}&strategy=mobile&category=performance`,
-			{
-				headers: {
-					'User-Agent': 'Hudson Digital Solutions Website Analyzer'
-				}
-			}
-		)
+	try {
+		logger.info('Fetching PageSpeed data', {
+			url,
+			hasApiKey: Boolean(apiKey)
+		})
+
+		// AbortSignal.timeout() rejects the fetch with a TimeoutError if the
+		// upstream call exceeds the budget. Caught below and translated to a
+		// 504 + a user-readable message that names the failure mode instead
+		// of the generic "Failed to analyze website" the route used to ship.
+		const response = await fetch(requestUrl, {
+			headers: {
+				'User-Agent': 'Hudson Digital Solutions Website Analyzer'
+			},
+			signal: AbortSignal.timeout(PAGESPEED_FETCH_TIMEOUT_MS)
+		})
 
 		if (!response.ok) {
 			logger.error(
 				'PageSpeed API error',
 				new Error(`Status: ${response.status}`)
 			)
-			return errorResponse('Failed to fetch performance data', response.status)
+			// 429 from Google = anonymous rate limit (no key) or per-project
+			// quota exhausted. Surface a different message so the operator
+			// knows to add or rotate PAGESPEED_API_KEY.
+			if (response.status === 429) {
+				return errorResponse(
+					'Rate limit hit on the PageSpeed API. Try again in a minute, or contact us if it keeps happening.',
+					429
+				)
+			}
+			return errorResponse(
+				'PageSpeed could not analyze that URL. Make sure the site is reachable from the public internet and try again.',
+				response.status
+			)
 		}
 
 		const data = (await response.json()) as PageSpeedResponse
@@ -177,10 +206,18 @@ async function handlePageSpeed(request: NextRequest) {
 
 		return successResponse({ metrics })
 	} catch (error) {
-		logger.error(
-			'PageSpeed API error',
-			error instanceof Error ? error : new Error(String(error))
-		)
+		const err = error instanceof Error ? error : new Error(String(error))
+		logger.error('PageSpeed API error', err)
+		// `AbortSignal.timeout()` rejects with a DOMException whose `name`
+		// is "TimeoutError" — distinguishable from generic fetch failures.
+		// Translating it to a 504 with a user-readable message keeps the
+		// tool honest when the upstream is simply slow (audit #236).
+		if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+			return errorResponse(
+				'PageSpeed took too long to analyze that URL. Slow sites can exceed our budget — try again, or run a Lighthouse audit in your browser DevTools instead.',
+				504
+			)
+		}
 		return errorResponse('Failed to analyze website performance', 500)
 	}
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -113,7 +113,14 @@ export const env = createEnv({
 		// /api/admin/images/upload route returns 503 when unset so the
 		// client UI hides the Upload button and the paste-URL fallback
 		// continues to work.
-		BLOB_READ_WRITE_TOKEN: z.string().optional()
+		BLOB_READ_WRITE_TOKEN: z.string().optional(),
+
+		// Google PageSpeed Insights API key (optional). The `/api/pagespeed`
+		// route falls back to unauthenticated requests when unset, but that
+		// path is rate-limited to ~5 req/sec across all anonymous traffic
+		// from a region — adding a key gets the project a per-project quota
+		// (25k req/day on the free tier).
+		PAGESPEED_API_KEY: z.string().optional()
 	},
 
 	/**
@@ -161,6 +168,7 @@ export const env = createEnv({
 		SENTRY_DSN: process.env.SENTRY_DSN,
 		SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
 		BLOB_READ_WRITE_TOKEN: process.env.BLOB_READ_WRITE_TOKEN,
+		PAGESPEED_API_KEY: process.env.PAGESPEED_API_KEY,
 
 		// Client
 		NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,


### PR DESCRIPTION
## Summary

Two unrelated critical-audit fixes that ended up on the same branch (sorry — was going to split but the squash-merge will collapse them to one commit on main anyway). Both touch separate routes and ship cleanly together.

---

### Fix 1 — Showcase 404 skeleton flash (#241)

`/showcase/<unknown-slug>` flashed a spinner + \"Loading project...\" for several seconds before swapping to the 404. The delay was Neon's scale-to-zero cold start: `getShowcaseBySlug()` was awaited INSIDE a child `<Suspense>` boundary, so the fallback rendered immediately while the DB query warmed up. Only after the null came back did `notFound()` fire and replace everything.

Visible sequence was \"loading then broken\" — reads as a broken detail page rather than an immediate 404.

**Fix**: hoist the DB lookup + `notFound()` guard to the top of `ShowcaseDetailPage`, BEFORE any JSX returns. Next.js holds the route until the await resolves; on a miss the framework swaps in the 404 page before anything mounts. `ShowcaseContent` becomes sync, takes a `ShowcaseItem` directly, no `<Suspense>` needed.

---

### Fix 2 — PageSpeed route fails gracefully (#236)

The Performance Savings Calculator advertised \"real PageSpeed analysis\" but returned \"Failed to analyze website\" for valid URLs. Console: `PageSpeed API error: Object`.

Root cause: the route fired an unbounded fetch at Google's PageSpeed Insights API. The API legitimately takes 30-60s for slow sites, but Vercel Hobby kills functions at 10s. The function got terminated mid-flight, the route's catch block ran against an undefined error shape, and the user saw a generic 500.

**Fixes**:
- Add `PAGESPEED_API_KEY` as an optional env var through `@/env`. When set, requests authenticate and get the per-project quota (25k req/day on the free tier) instead of sharing the regional anonymous bucket (5 req/sec). Unset → falls back to anonymous, still works.
- Wrap the fetch in `AbortSignal.timeout(9_000)` so we beat Vercel's 10-second guillotine and the catch sees a real `TimeoutError`.
- Split the catch into three branches:
  - `TimeoutError` / `AbortError` → 504 + copy that names the failure mode and points at Lighthouse DevTools as a workaround
  - Google 429 → 429 + \"try again in a minute\" message so the operator knows to add/rotate the key
  - Everything else → existing generic 500

**Operator follow-up**: drop a Google PageSpeed Insights API key into the Vercel project's env as `PAGESPEED_API_KEY` to lift the shared-anonymous rate limit. Key is free; instructions in the PageSpeed Insights API docs.

---

## Test plan

- [ ] `/showcase/<known-slug>` renders as before
- [ ] `/showcase/<unknown-slug>` lands on branded 404 with NO spinner flash
- [ ] `/tools/performance-calculator` with a valid URL: returns metrics OR a timeout-shaped error after ~9s (no more generic 500 after Vercel kills the function)
- [ ] Existing `tests/unit/api-pagespeed.test.ts` (4 tests) still passes

[hudsor01]