### PR TITLE
fix(audit): contact-form Service Interest dropdown matches services catalog (#250)

### DIFF
--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -38,7 +38,7 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 			email: '',
 			phone: '',
 			company: '',
-			service: 'web-development',
+			service: 'website-design',
 			bestTimeToContact: 'anytime',
 			budget: 'under-5k',
 			timeline: 'flexible',

--- a/src/data/form-options.json
+++ b/src/data/form-options.json
@@ -1,9 +1,9 @@
 {
 	"services": [
-		{ "value": "web-development", "label": "Web Development" },
-		{ "value": "custom-software", "label": "Custom Software" },
-		{ "value": "consulting", "label": "Strategic Consulting" },
-		{ "value": "other", "label": "Other" }
+		{ "value": "website-design", "label": "Website Design & Development" },
+		{ "value": "seo", "label": "Get Found on Google (SEO)" },
+		{ "value": "booking-payments", "label": "Booking, Payments & Follow-Up" },
+		{ "value": "other", "label": "Other / Not sure yet" }
 	],
 	"contactTime": [
 		{ "value": "morning", "label": "Morning (9AM - 12PM)" },

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -43,11 +43,17 @@ export const messageSchema = z
 	.max(5000, 'Message must be less than 5000 characters')
 	.trim()
 
-// Service options for contact forms
+// Service options for contact forms. Must mirror the SERVICES catalog
+// in `src/components/ui/ServicesGrid.tsx` — keep enum values, JSON
+// labels in `src/data/form-options.json`, and the cards in sync so a
+// prospect's "Service Interest" picks reflect what we actually pitch
+// (audit #250). Existing leads whose `service` column holds the legacy
+// values ('web-development', 'custom-software', 'consulting') remain
+// in the DB as plain text — the enum gates only new submissions.
 export const serviceOptionsSchema = z.enum([
-	'web-development',
-	'custom-software',
-	'consulting',
+	'website-design',
+	'seo',
+	'booking-payments',
 	'other'
 ])
 

--- a/tests/unit/api-contact.test.ts
+++ b/tests/unit/api-contact.test.ts
@@ -16,7 +16,7 @@ const VALID_BODY = {
 	email: 'riley@example.com',
 	phone: '555-123-4567',
 	company: 'Riley Co',
-	service: 'web-development',
+	service: 'website-design',
 	budget: '15k-50k',
 	timeline: '1-month',
 	message: 'Looking to refresh the marketing site.'

--- a/tests/unit/schemas-common.test.ts
+++ b/tests/unit/schemas-common.test.ts
@@ -86,7 +86,16 @@ describe('messageSchema', () => {
 
 describe('option enum schemas', () => {
 	it('reject values outside the allowed set', () => {
-		expect(serviceOptionsSchema.safeParse('web-development').success).toBe(true)
+		expect(serviceOptionsSchema.safeParse('website-design').success).toBe(true)
+		expect(serviceOptionsSchema.safeParse('seo').success).toBe(true)
+		expect(serviceOptionsSchema.safeParse('booking-payments').success).toBe(
+			true
+		)
+		expect(serviceOptionsSchema.safeParse('other').success).toBe(true)
+		// Legacy values are no longer valid for new submissions.
+		expect(serviceOptionsSchema.safeParse('web-development').success).toBe(
+			false
+		)
 		expect(serviceOptionsSchema.safeParse('marketing').success).toBe(false)
 		expect(budgetOptionsSchema.safeParse('5k-15k').success).toBe(true)
 		expect(budgetOptionsSchema.safeParse('1k-2k').success).toBe(false)


### PR DESCRIPTION
## Summary

Closes #250.

The Contact form's Service Interest dropdown offered:

> Web Development / Custom Software / Strategic Consulting / Other

But the Services page actually pitches:

> Website Design & Development / Get Found on Google / Booking, Payments & Follow-Up

A prospect couldn't pick what we actually sell. The legacy values \"custom-software\" and \"consulting\" appear nowhere else on the site and represented a different practice scope.

## New enum

| Value | Label |
|---|---|
| `website-design` | Website Design & Development |
| `seo` | Get Found on Google (SEO) |
| `booking-payments` | Booking, Payments & Follow-Up |
| `other` | Other / Not sure yet |

## What is intentionally not changed

- Lead scoring (`hasSpecificService` checks `service !== 'other'` — enum-agnostic, still works).
- Existing leads in the DB keep their legacy text values (`web-development`, etc.). The enum gates new submissions only; old rows are plain text and not re-validated.
- Cross-file comment in `common.ts` points at `ServicesGrid.tsx` as the source of truth for the catalog so the next contributor knows to update both lists together.

## Tests

`tests/unit/schemas-common.test.ts` now asserts each new value AND that legacy `'web-development'` is rejected. Accidental rollback fails CI.

[hudsor01]