### PR TITLE
fix(audit): 308-redirect duplicate CRM blog slug to canonical (#249)

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { Calendar, Clock, Tag } from 'lucide-react'
 import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
-import { notFound } from 'next/navigation'
+import { notFound, permanentRedirect } from 'next/navigation'
 import { AuthorCard } from '@/components/blog/AuthorCard'
 import { BlogPostContent } from '@/components/blog/BlogPostContent'
 import { RelatedPosts } from '@/components/blog/RelatedPosts'
@@ -17,11 +17,36 @@ interface BlogPostPageProps {
 	params: Promise<{ slug: string }>
 }
 
+/**
+ * Canonical slug map for posts that exist as duplicates in the DB.
+ * Visiting a key in this map permanently redirects to the value, so
+ * search engines converge on a single URL and inbound links keep
+ * working from either side (audit #249).
+ *
+ * Add an entry here whenever a duplicate post is discovered and the
+ * canonical one is identified. A future cleanup pass can drop the
+ * legacy row from the DB; the redirect is the contract that keeps
+ * old links honest in the meantime.
+ */
+const CANONICAL_SLUG_REDIRECTS: Record<string, string> = {
+	'why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency':
+		'why-your-business-needs-a-custom-crm-integration'
+}
+
 export async function generateMetadata({
 	params
 }: BlogPostPageProps): Promise<Metadata> {
 	const { slug } = await params
-	const post = await getPostBySlug(slug)
+
+	// Short-circuit metadata generation for duplicate slugs — the page
+	// component redirects on render, but a crawler-only metadata fetch
+	// (or anything that depends on `generateMetadata` without rendering
+	// the page) would otherwise see the duplicate post's title and
+	// excerpt. Returning the canonical post's metadata keeps the
+	// search-engine signal consistent with the redirect target.
+	const canonical = CANONICAL_SLUG_REDIRECTS[slug]
+	const lookupSlug = canonical ?? slug
+	const post = await getPostBySlug(lookupSlug)
 
 	if (!post) {
 		return {
@@ -83,6 +108,17 @@ export async function generateStaticParams() {
 
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
 	const { slug } = await params
+
+	// Permanent redirect for known-duplicate slugs before any DB work.
+	// `permanentRedirect()` returns a 308 which preserves request method
+	// (the relevant property for any future POST/PUT analytics beacons
+	// against the old URL) and signals to crawlers that the canonical
+	// URL has changed.
+	const canonical = CANONICAL_SLUG_REDIRECTS[slug]
+	if (canonical) {
+		permanentRedirect(`/blog/${canonical}`)
+	}
+
 	const post = await getPostBySlug(slug)
 
 	if (!post) {


### PR DESCRIPTION
## Summary

Closes #249.

Two posts existed at:

- `/blog/why-your-business-needs-a-custom-crm-integration` (canonical)
- `/blog/why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency` (duplicate)

Same hero, opening paragraph, illustration, dates, and tags. Classic SEO duplicate-content footgun — search engines split ranking signal across two URLs.

## Fix

Adds a `CANONICAL_SLUG_REDIRECTS` map at the top of `/blog/[slug]/page.tsx`. The longer slug 308-redirects to the shorter one **both** at page render **and** inside `generateMetadata`, so a crawler-only metadata fetch sees the canonical post's title and excerpt rather than the duplicate's. Inbound links from either side keep working.

```ts
const CANONICAL_SLUG_REDIRECTS: Record<string, string> = {
  'why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency':
    'why-your-business-needs-a-custom-crm-integration'
}
```

Future cleanup pass can drop the duplicate row from the DB. The redirect is the contract that keeps old links honest in the meantime; adding the next duplicate is a one-liner in the map.

## Test plan

- [ ] Visit `/blog/why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency` — 308-redirected to the canonical short slug
- [ ] Visit `/blog/why-your-business-needs-a-custom-crm-integration` — renders normally
- [ ] Open DevTools and check the metadata returned for the long slug — title + excerpt match the canonical post

[hudsor01]