### PR TITLE
fix(audit): blog card preview ends at word boundary (#255)

### DIFF
--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -3,7 +3,13 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Card } from '@/components/ui/card'
 import type { BlogPost } from '@/lib/blog'
-import { formatDate } from '@/lib/utils'
+import { formatDate, truncateAtWord } from '@/lib/utils'
+
+// ~2 lines at the card's typography is ~180 chars worst case. Truncating
+// at a word boundary here means CSS `line-clamp-2` becomes a belt-and-
+// suspenders fallback for unusually wide rendering instead of the
+// primary cut, so the preview never ends mid-word (audit #255).
+const EXCERPT_MAX_CHARS = 180
 
 interface BlogPostCardProps {
 	post: BlogPost
@@ -60,7 +66,7 @@ export function BlogPostCard({
 						</h3>
 						{post.excerpt && (
 							<p className="text-muted-foreground line-clamp-2 mb-heading">
-								{post.excerpt}
+								{truncateAtWord(post.excerpt, EXCERPT_MAX_CHARS)}
 							</p>
 						)}
 						<div className="flex flex-wrap gap-content text-sm text-muted-foreground">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,26 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
+ * Word-aware truncation. Returns `text` unchanged when it fits inside
+ * `maxChars`; otherwise slices on the last whitespace before the limit
+ * and appends `…`. Prevents the audit-reported mid-word truncation
+ * pattern (e.g. "manually copy-paste informati") visible in blog card
+ * previews under CSS `line-clamp` (audit #255).
+ *
+ * Falls back to a hard slice + ellipsis when the input has no
+ * whitespace inside the budget — e.g. a long URL or hashed string.
+ */
+export function truncateAtWord(text: string, maxChars: number): string {
+	if (text.length <= maxChars) {
+		return text
+	}
+	const head = text.slice(0, maxChars)
+	const lastSpace = head.lastIndexOf(' ')
+	const cut = lastSpace > 0 ? head.slice(0, lastSpace) : head
+	return `${cut.trimEnd()}…`
+}
+
+/**
  * Detect potential injection attempts in user input
  * @param input - The input string to check
  * @param context - Optional context indicating how the input will be used (for stricter checks)

--- a/tests/unit/utils-truncate.test.ts
+++ b/tests/unit/utils-truncate.test.ts
@@ -1,0 +1,44 @@
+/**
+ * `truncateAtWord` covers blog card previews (audit #255) and is small
+ * enough that the test surface can be exhaustive. Add cases here when
+ * new edge cases come up — the function intentionally has no I/O so
+ * round-trips stay fast.
+ */
+import { describe, expect, it } from 'bun:test'
+import { truncateAtWord } from '@/lib/utils'
+
+describe('truncateAtWord', () => {
+	it('returns the input unchanged when it fits inside maxChars', () => {
+		expect(truncateAtWord('short text', 20)).toBe('short text')
+	})
+
+	it('returns the input unchanged when length equals maxChars exactly', () => {
+		expect(truncateAtWord('exactlymaxchars', 15)).toBe('exactlymaxchars')
+	})
+
+	it('slices on the last whitespace inside the head and appends an ellipsis', () => {
+		const input = 'The quick brown fox jumps over the lazy dog'
+		// head(25) = "The quick brown fox jumps"; lastIndexOf(' ') = 19;
+		// so cut = "The quick brown fox".
+		expect(truncateAtWord(input, 25)).toBe('The quick brown fox…')
+	})
+
+	it('strips trailing whitespace from the truncated head before appending the ellipsis', () => {
+		expect(truncateAtWord('a b c d e f g h i j', 8)).toBe('a b c d…')
+	})
+
+	it('falls back to a hard slice when the input has no whitespace inside the budget', () => {
+		const longHash = 'abcdefghijklmnopqrstuvwxyz'
+		expect(truncateAtWord(longHash, 10)).toBe('abcdefghij…')
+	})
+
+	it('does not split the audit-reported "manually copy-paste information" mid-word', () => {
+		const input =
+			'Stop wasting hours on tasks like manually copy-paste information between systems.'
+		const out = truncateAtWord(input, 50)
+		expect(out.endsWith('…')).toBe(true)
+		// "informati" must NOT appear as a terminal token (the audit's
+		// exact bug). Each non-final token must be a real word.
+		expect(out).not.toMatch(/informati…$/)
+	})
+})


### PR DESCRIPTION
## Summary

Closes #255.

The blog card excerpt was clamped to 2 lines via CSS `line-clamp-2`, which cuts at the rendered character boundary regardless of word boundary. The audit caught this in the wild:

> Stop wasting hours on tasks like manually copy-paste informati

(mid-word at \"informati\").

## Fix

- New utility `truncateAtWord(text, maxChars)` in `src/lib/utils.ts` — slices on the last whitespace inside the budget and appends an ellipsis. Falls back to a hard slice + ellipsis when the input has no whitespace inside the budget (rare — e.g. a long URL).
- `BlogPostCard` truncates to **180 chars** before rendering. The CSS `line-clamp-2` stays as a belt-and-suspenders fallback for unusually wide rendering, but the JS truncation is now the primary cut.
- `tests/unit/utils-truncate.test.ts` (6 cases including the exact \"manually copy-paste informati\" regression as a guard).

## Test plan

- [ ] Visit `/blog` — card previews never end mid-word
- [ ] All 6 truncation unit tests pass
- [ ] Detail-page excerpt (in the post header) is unaffected — full text still rendered

[hudsor01]