### PR TITLE
fix(audit): defensive showcase image fallback to filesystem convention (#253)

### DIFF
--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -30,6 +30,18 @@ async function ShowcaseProjects() {
 		? items.filter(i => i.id !== featuredItem.id)
 		: items
 
+	// Fall back to the canonical convention `/images/showcase/<slug>.jpg`
+	// when the DB row's `imageUrl` is null. The planning doc for phase 01
+	// claims all four featured rows were populated on 2026-05-21, but the
+	// production audit caught ink37-tattoos and tenantflow rendering grey
+	// placeholders — indicating the imageUrl column drifted out of sync
+	// with the on-disk files (audit #253). Keeping this resolver in the
+	// page means a future DB cleanup is the long-term fix; meanwhile any
+	// row whose slug matches a file under `public/images/showcase/`
+	// always renders the image, with or without the DB pointer.
+	const resolveImage = (item: (typeof items)[number]): string | null =>
+		item.imageUrl ?? `/images/showcase/${item.slug}.jpg`
+
 	return (
 		<>
 			{/* Stats Section */}
@@ -95,7 +107,7 @@ async function ShowcaseProjects() {
 								stats={featuredItem.metrics}
 								tech_stack={featuredItem.technologies}
 								externalLink={featuredItem.externalLink}
-								imageUrl={featuredItem.imageUrl}
+								imageUrl={resolveImage(featuredItem)}
 							/>
 						</div>
 					)}
@@ -122,7 +134,7 @@ async function ShowcaseProjects() {
 								stats={item.metrics}
 								tech_stack={item.technologies}
 								externalLink={item.externalLink}
-								imageUrl={item.imageUrl}
+								imageUrl={resolveImage(item)}
 							/>
 						))}
 					</div>


### PR DESCRIPTION
## Summary

Closes #253.

The audit caught ink37-tattoos and tenantflow showcase cards rendering grey placeholders while jirah-shop rendered its image correctly. Research established the contradicting evidence:

| Evidence | Source |
|---|---|
| 4 image files present (189-352kB each) | `public/images/showcase/` |
| All 4 rows had `image_url` populated | `.planning/phases/01-showcase-ui-redesign/01-01-data-changes.md` (2026-05-21 snapshot) |
| Only jirah-shop renders in production | Audit observation |

Cleanest interpretation: the `image_url` column drifted out of sync with the on-disk files between the phase-01 commit and the audit.

## Fix

Rather than blindly UPDATE the prod DB, this resolves the symptom by falling back to the canonical filesystem convention `/images/showcase/<slug>.jpg` whenever a row's `imageUrl` is null:

```ts
const resolveImage = (item) => item.imageUrl ?? `/images/showcase/${item.slug}.jpg`
```

- If the DB has a real value, it wins (no regression for rows that legitimately have a different path).
- If the slug-based fallback file doesn't exist, Next.js Image renders nothing and the parent's `bg-muted` shows through — same outcome as before.
- A future DB cleanup is the long-term fix; the resolver is the safety net.

Inline comment documents the audit-observed DB drift so a future contributor knows why this exists.

## Test plan

- [ ] Visit `/showcase` — all four published cards (jirah-shop, ink37-tattoos, tenantflow, revops-portfolio) show their hero image
- [ ] DB rows that still have `imageUrl` set use the DB value
- [ ] Adding a new showcase row WITHOUT an image and WITHOUT a matching file under `public/images/showcase/` shows the accent-bar fallback (no broken-image icon)

[hudsor01]