### PR TITLE
fix(audit): resolve geography positioning to DFW-anchored, remote across the South (#248 #257)

### DIFF
--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -219,12 +219,20 @@ export default function ContactPage() {
 						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
 							Service Area
 						</p>
+						{/* Brand positioning resolved in favor of the canonical
+						    LocalBusiness JSON-LD areaServed ("Dallas-Fort Worth
+						    Metroplex" in seo-utils.ts:61-99) and the canonical
+						    site-wide metadata title ("Dallas-Fort Worth Web Design"
+						    in app/layout.tsx + opengraph-image.tsx). Audit #248
+						    flagged the prior "Nationwide" claim as conflicting with
+						    those signals and with the site's TX-headquartered
+						    address (1301 Cherry Hill Ln, Lewisville, TX 75067). */}
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							We Serve Clients Nationwide
+							Dallas-Fort Worth headquarters. Remote across the South.
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Primarily serving TX, FL, GA, OK and surrounding states, fully
-							remote for all projects.
+							Local-first in the DFW metroplex; remote-capable across TX, FL,
+							GA, OK, and the surrounding states.
 						</p>
 					</div>
 


### PR DESCRIPTION
## Summary

Closes #248 and #257 in one commit because they share the same root question (\"what's the brand's geography?\") and the answer for one resolves the other.

## Evidence

Research surfaced three conflicting positioning claims on the live site, anchored against canonical sources:

| Claim | Source | Authority |
|---|---|---|
| \"Dallas-Fort Worth Web Design\" | `app/layout.tsx`, `opengraph-image.tsx`, `seo-config.ts` | Tab title + OG image, site-wide |
| `areaServed: \"Dallas-Fort Worth Metroplex\"` | `src/lib/seo-utils.ts:61-99` (LocalBusiness JSON-LD) | Schema.org, crawled by search engines |
| Address: 1301 Cherry Hill Ln, Lewisville, TX 75067 | `src/lib/constants/business.ts` | BUSINESS_INFO singleton |
| \"We Serve Clients Nationwide\" | `src/app/(public)/contact/page.tsx:223` | Outlier — no other source backs it |
| \"Primarily serving TX, FL, GA, OK\" | `src/app/(public)/contact/page.tsx:226` | Adjacent-states remote capability |

The Nationwide claim is the **only** one not backed by another canonical source. Resolving the conflict in favor of the LocalBusiness JSON-LD areaServed + tab title + actual address: **DFW headquartered, remote across the South**.

## Fix

Contact page banner + sub now read:

> **Dallas-Fort Worth headquarters. Remote across the South.**
> Local-first in the DFW metroplex; remote-capable across TX, FL, GA, OK, and the surrounding states.

## Why this closes #257 too

The Texas TTL Calculator on `/tools` was the audit's downstream callout — it only makes sense if the brand is TX-anchored. With this resolution, it is. No change to the tools index.

## What is intentionally unchanged

- `src/app/(public)/locations/page.tsx` (\"across the US\") — multi-state landing pages are an SEO play, and the new contact-page copy doesn't claim nationwide *service*, only remote capability for adjacent states.
- Non-TX state files (`src/lib/locations/{florida,georgia,oklahoma,…}.ts`) — same SEO play, kept.

Inline comment in `contact/page.tsx` cross-references the canonical sources so a future contributor can see why this string was chosen.

## Test plan

- [ ] Visit `/contact` — Service Area banner reads \"Dallas-Fort Worth headquarters. Remote across the South.\"
- [ ] Hero tab title still reads \"Dallas-Fort Worth Web Design\"
- [ ] `/locations` still routes to per-state landing pages
- [ ] `/tools` still shows the Texas TTL Calculator (consistent with TX-anchored brand)

[hudsor01]