### PR TITLE
fix(audit): drop hardcoded fabricated-looking testimonials from public pages (#256)

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -14,7 +14,6 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { SEO_CONFIG } from '@/lib/seo-config'
@@ -53,39 +52,14 @@ export const metadata: Metadata = {
 	}
 }
 
-const testimonials = [
-	{
-		testimonialId: 1 as const,
-		name: 'Sarah Mitchell',
-		company: 'Bright Spark Consulting',
-		role: 'Founder',
-		content:
-			'Within a month of the new site going live, our inquiries had doubled. It finally looks like the company we actually are.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: '2x inquiries'
-	},
-	{
-		testimonialId: 2 as const,
-		name: 'Marcus Holt',
-		company: 'Gulf Coast Roofing',
-		role: 'Operations Manager',
-		content:
-			'We never had a real website before. Now customers find us on Google, see our work, and book a quote straight from the site.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: 'Found on Google'
-	}
-] satisfies Array<{
-	testimonialId: number
-	name: string
-	company: string
-	role: string
-	content: string
-	rating: number
-	service: string
-	highlight: string
-}>
+// Hardcoded "Sarah Mitchell" + "Marcus Holt" testimonials were dropped
+// per audit #256 — they predate the DB-backed admin/testimonials CRUD
+// and were unverifiable (no posted_at, no company URL, no commit
+// history naming them as real clients). The DB schema
+// (`src/lib/schemas/content.ts:15-38`) is the canonical source going
+// forward; the public testimonials section returns when admin seeds
+// real rows. Removing fabricated copy reads more honest than
+// maintaining it.
 
 export default function AboutPage() {
 	return (
@@ -460,39 +434,6 @@ export default function AboutPage() {
 								business, no expensive rebuilds when you scale.
 							</p>
 						</div>
-					</div>
-				</div>
-			</section>
-
-			{/* Testimonials Section */}
-			<section className="py-section-sm px-4 sm:px-6">
-				<div className="container-wide">
-					<div className="text-center mb-10">
-						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Client Results
-						</p>
-						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							What Our Clients Say
-						</h2>
-						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Real businesses. Real results.
-						</p>
-					</div>
-					<div className="grid md:grid-cols-2 gap-6">
-						{testimonials.map(t => (
-							<Card
-								key={t.testimonialId}
-								variant="testimonial"
-								testimonialId={t.testimonialId}
-								name={t.name}
-								company={t.company}
-								role={t.role}
-								content={t.content}
-								rating={t.rating}
-								service={t.service}
-								highlight={t.highlight}
-							/>
-						))}
 					</div>
 				</div>
 			</section>

--- a/src/app/(public)/locations/[slug]/page.tsx
+++ b/src/app/(public)/locations/[slug]/page.tsx
@@ -8,7 +8,6 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import {
 	generateLocalBusinessSchema,
@@ -20,39 +19,9 @@ interface LocationPageProps {
 	params: Promise<{ slug: string }>
 }
 
-const locationTestimonials = [
-	{
-		testimonialId: 1 as const,
-		name: 'Sarah Mitchell',
-		company: 'Bright Spark Consulting',
-		role: 'Founder',
-		content:
-			'Within a month of the new site going live, our inquiries had doubled. It finally looks like the company we actually are.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: '2x inquiries'
-	},
-	{
-		testimonialId: 2 as const,
-		name: 'Marcus Holt',
-		company: 'Gulf Coast Roofing',
-		role: 'Operations Manager',
-		content:
-			'We never had a real website before. Now customers find us on Google, see our work, and book a quote straight from the site.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: 'Found on Google'
-	}
-] satisfies Array<{
-	testimonialId: number
-	name: string
-	company: string
-	role: string
-	content: string
-	rating: number
-	service: string
-	highlight: string
-}>
+// Hardcoded testimonials dropped per audit #256 — same fabricated
+// Sarah Mitchell / Marcus Holt copy as about + services pages. The
+// admin/testimonials CRUD seeds real rows when available.
 
 export function generateStaticParams() {
 	return getAllLocationSlugs().map(slug => ({ slug }))
@@ -206,36 +175,6 @@ export default async function LocationPage({ params }: LocationPageProps) {
 									{feature.description}
 								</p>
 							</div>
-						))}
-					</div>
-				</div>
-			</section>
-
-			{/* Testimonials Section */}
-			<section className="py-section-sm px-4 sm:px-6">
-				<div className="container-wide max-w-4xl mx-auto">
-					<div className="text-center mb-10">
-						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Client Results
-						</p>
-						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							What Our Clients Say
-						</h2>
-					</div>
-					<div className="grid md:grid-cols-2 gap-6">
-						{locationTestimonials.map(t => (
-							<Card
-								key={t.testimonialId}
-								variant="testimonial"
-								testimonialId={t.testimonialId}
-								name={t.name}
-								company={t.company}
-								role={t.role}
-								content={t.content}
-								rating={t.rating}
-								service={t.service}
-								highlight={t.highlight}
-							/>
 						))}
 					</div>
 				</div>

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -2,7 +2,6 @@ import { ArrowRight } from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
 import { ProcessSteps } from '@/components/ui/ProcessSteps'
 import { ServicesGrid } from '@/components/ui/ServicesGrid'
 import { SEO_CONFIG } from '@/lib/seo-config'
@@ -48,39 +47,10 @@ const stats: Stat[] = [
 	{ value: '2 hr', label: 'Response Time' }
 ]
 
-const testimonials = [
-	{
-		testimonialId: 1 as const,
-		name: 'Sarah Mitchell',
-		company: 'Bright Spark Consulting',
-		role: 'Founder',
-		content:
-			'Within a month of the new site going live, our inquiries had doubled. It finally looks like the company we actually are.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: '2x inquiries'
-	},
-	{
-		testimonialId: 2 as const,
-		name: 'Marcus Holt',
-		company: 'Gulf Coast Roofing',
-		role: 'Operations Manager',
-		content:
-			'We never had a real website before. Now customers find us on Google, see our work, and book a quote straight from the site.',
-		rating: 5 as const,
-		service: 'Website Design & Development',
-		highlight: 'Found on Google'
-	}
-] satisfies Array<{
-	testimonialId: number
-	name: string
-	company: string
-	role: string
-	content: string
-	rating: number
-	service: string
-	highlight: string
-}>
+// Hardcoded "Sarah Mitchell" + "Marcus Holt" testimonials dropped per
+// audit #256 (see also about/page.tsx). The DB-backed
+// admin/testimonials CRUD is the canonical source going forward; the
+// section returns when real seeded rows exist.
 
 export default function ServicesPage() {
 	return (
@@ -195,39 +165,6 @@ export default function ServicesPage() {
 						</p>
 					</div>
 					<ProcessSteps />
-				</div>
-			</section>
-
-			{/* Testimonials Section */}
-			<section className="py-section-sm px-4 sm:px-6">
-				<div className="container-wide">
-					<div className="text-center mb-10">
-						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Client Results
-						</p>
-						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							What Our Clients Say
-						</h2>
-						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Real businesses. Real results.
-						</p>
-					</div>
-					<div className="grid md:grid-cols-2 gap-6">
-						{testimonials.map(t => (
-							<Card
-								key={t.testimonialId}
-								variant="testimonial"
-								testimonialId={t.testimonialId}
-								name={t.name}
-								company={t.company}
-								role={t.role}
-								content={t.content}
-								rating={t.rating}
-								service={t.service}
-								highlight={t.highlight}
-							/>
-						))}
-					</div>
 				</div>
 			</section>
 


### PR DESCRIPTION
## Summary

Closes #256.

The \"Sarah Mitchell / Bright Spark Consulting\" and \"Marcus Holt / Gulf Coast Roofing\" testimonials appeared on `/about`, `/services`, and `/locations/[slug]` with **identical copy across all three files**. The audit triage flagged credibility — no posting dates, no company URLs, no way to verify either name as a real client.

## Evidence

Research surfaced canonical signals that these were placeholder copy, not real quotes:

- Hardcoded in three page files, not DB-backed
- DB schema (`src/lib/schemas/content.ts:15-38`) has no `posted_at` or `company_url` column → even if these were ever real, the system couldn't have rendered them with the verifying metadata the audit asks for
- Predate the admin/testimonials CRUD shipped in PR #215 (commit `cf37d1c`)
- No commit message in repo history references either name
- The content/quote/highlight blocks copy-paste verbatim across the three files — not how real client quotes accumulate

## Fix

Removes the testimonial sections + the const definitions + the now-unused `Card` import from all three files. The admin/testimonials CRUD is the canonical source going forward — when real seeded rows exist, the section comes back with real attribution.

Each file carries a brief comment pointing at the schema location so a future contributor knows where the canonical source lives.

| File | Change |
|---|---|
| `src/app/(public)/about/page.tsx` | drop const + section + Card import |
| `src/app/(public)/services/page.tsx` | drop const + section + Card import |
| `src/app/(public)/locations/[slug]/page.tsx` | drop const + section + Card import |

## Test plan

- [ ] `/about`, `/services`, `/locations/<slug>` render without the testimonial section
- [ ] `bunx knip` reports no new orphan exports
- [ ] When admin seeds a real testimonial via /admin/testimonials, a follow-up PR can re-add the section sourced from the DB (out of scope here)

## Net diff

3 files changed, 15 insertions(+), 198 deletions(-)

[hudsor01]