### PR TITLE
fix(audit): homogenize per-location stats to canonical brand numbers (#247)

### DIFF
--- a/src/lib/locations/arizona.ts
+++ b/src/lib/locations/arizona.ts
@@ -22,8 +22,8 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 			'Paradise Valley'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -195,7 +195,7 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 			'Winslow'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -281,7 +281,7 @@ export const ARIZONA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/arkansas.ts
+++ b/src/lib/locations/arkansas.ts
@@ -23,7 +23,7 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -65,8 +65,8 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 			'Lavaca'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 			'Paragould'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -238,7 +238,7 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -280,8 +280,8 @@ export const ARKANSAS_LOCATIONS: LocationData[] = [
 			'Mountain Pine'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/colorado.ts
+++ b/src/lib/locations/colorado.ts
@@ -22,8 +22,8 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 			'Lakewood'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '30+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 			'Beulah'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -238,7 +238,7 @@ export const COLORADO_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/florida.ts
+++ b/src/lib/locations/florida.ts
@@ -22,8 +22,8 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 			'Fort Lauderdale'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -108,8 +108,8 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 			'St. Augustine'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -151,8 +151,8 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 			'Wesley Chapel'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 			'Sanford'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '20+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -238,7 +238,7 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -281,7 +281,7 @@ export const FLORIDA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/georgia.ts
+++ b/src/lib/locations/georgia.ts
@@ -22,8 +22,8 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 			'Alpharetta'
 		],
 		stats: {
-			businesses: '20+',
-			projects: '35+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -151,8 +151,8 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 			'Ellerslie'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 			'Centerville'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const GEORGIA_LOCATIONS: LocationData[] = [
 			'Oconee County'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/louisiana.ts
+++ b/src/lib/locations/louisiana.ts
@@ -23,7 +23,7 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -65,8 +65,8 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 			'Kenner'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 			'Vinton'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 			'Richwood'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -280,8 +280,8 @@ export const LOUISIANA_LOCATIONS: LocationData[] = [
 			'Woodworth'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/new-mexico.ts
+++ b/src/lib/locations/new-mexico.ts
@@ -23,7 +23,7 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -65,8 +65,8 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 			'Corrales'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -108,8 +108,8 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 			'Hatch'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -151,8 +151,8 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 			'Corrales'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 			'Ruidoso'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const NEW_MEXICO_LOCATIONS: LocationData[] = [
 			'Durango'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/north-carolina.ts
+++ b/src/lib/locations/north-carolina.ts
@@ -23,7 +23,7 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -65,8 +65,8 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 			'Wake Forest'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 			'Kernersville'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 			'Hampstead'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -281,7 +281,7 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -323,8 +323,8 @@ export const NORTH_CAROLINA_LOCATIONS: LocationData[] = [
 			'Sanford'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/oklahoma.ts
+++ b/src/lib/locations/oklahoma.ts
@@ -22,8 +22,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Moore'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -108,8 +108,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Newcastle'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -151,8 +151,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Bixby'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Piedmont'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Medicine Park'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -280,8 +280,8 @@ export const OKLAHOMA_LOCATIONS: LocationData[] = [
 			'Glencoe'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/tennessee.ts
+++ b/src/lib/locations/tennessee.ts
@@ -23,7 +23,7 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -66,7 +66,7 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -109,7 +109,7 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -152,7 +152,7 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -194,8 +194,8 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 			'Springfield'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const TENNESSEE_LOCATIONS: LocationData[] = [
 			'Eagleville'
 		],
 		stats: {
-			businesses: '5+',
-			projects: '10+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [

--- a/src/lib/locations/texas.ts
+++ b/src/lib/locations/texas.ts
@@ -22,8 +22,8 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Richardson'
 		],
 		stats: {
-			businesses: '25+',
-			projects: 'Proven track record',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -65,8 +65,8 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Sugar Land'
 		],
 		stats: {
-			businesses: '30+',
-			projects: '60+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -108,8 +108,8 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Georgetown'
 		],
 		stats: {
-			businesses: '40+',
-			projects: '80+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -151,7 +151,7 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Boerne'
 		],
 		stats: {
-			businesses: '20+',
+			businesses: '10+',
 			projects: '40+',
 			satisfaction: '100%'
 		},
@@ -194,8 +194,8 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Keller'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '30+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -237,8 +237,8 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 			'Las Cruces'
 		],
 		stats: {
-			businesses: '15+',
-			projects: '25+',
+			businesses: '10+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -281,7 +281,7 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '20+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [
@@ -324,7 +324,7 @@ export const TEXAS_LOCATIONS: LocationData[] = [
 		],
 		stats: {
 			businesses: '10+',
-			projects: '15+',
+			projects: '40+',
 			satisfaction: '100%'
 		},
 		features: [


### PR DESCRIPTION
## Summary

Closes #247.

The 75 location entries in `src/lib/locations/{state}.ts` each shipped bespoke per-city numbers — Dallas: 25+ businesses; Houston: 30+/60+; Austin: 40+/80+. The sum across all cities far exceeded the canonical brand claim of \"40+ Projects Delivered / 10+ Businesses Served\" on the homepage and About page.

The audit triage called this credibility-damaging: \"numbers feel made up if they don't reconcile\".

## Evidence

Per-city stats inventory before this change:

| Field | Distinct values | Most-flagrant contradictions |
|---|---|---|
| `businesses` | `5+, 10+, 15+, 20+, 25+, 30+, 40+` | Houston 30+ + Austin 40+ alone exceed brand \"10+\" |
| `projects` | `10+, 15+, 20+, 25+, 30+, 35+, 40+, 60+, 80+, \"Proven track record\"` | Houston 60+ + Austin 80+ alone exceed brand \"40+\" |

Canonical brand-level claim already lives in three places (homepage hero, About founder bio, Showcase stat strip) at `10+ / 40+ / 100%`. The per-location pages don't need to invent different numbers — per-city distinctiveness comes from each city's copy, neighborhoods, and features lists, not from fake stat blocks.

## Fix

Standardizes all 75 location entries via `sd`:

```ts
{
  businesses: '10+',
  projects:   '40+',
  satisfaction: '100%'
}
```

Every location page now reads consistent with the homepage / About / Showcase. The contradiction the audit caught (Dallas: 25+ businesses but only 40+ projects across the whole brand) goes away.

## Intentionally unchanged

The canonical brand numbers themselves stay where the user has already chosen them — homepage hero (#244), About founder bio, Showcase stat strip (#241). This commit aligns the long tail of per-location pages to those choices, not the other way around.

## Test plan

- [ ] `/locations/dallas-tx` shows `10+ / 40+ / 100%`
- [ ] `/locations/houston-tx` shows the same
- [ ] Random sampling of 3-5 non-TX states (Florida, Georgia, Oklahoma) shows the same
- [ ] `bun run test:unit` passes (770 tests)

[hudsor01]