### PR TITLE
fix(audit): form polish batch — newsletter, contact, lead scoring (#258 #264 #276 #277)

### DIFF
--- a/src/components/forms/NewsletterSignup.tsx
+++ b/src/components/forms/NewsletterSignup.tsx
@@ -54,6 +54,11 @@ function NewsletterSignupContent({
 				email: value.email,
 				source: variant
 			})
+			// Clear the input after a successful subscribe so the
+			// "Subscribed" badge isn't sitting next to the user's still-
+			// filled-in address — audit #264 noted that pairing reads as
+			// ambiguous ("already subscribed? resubmit?").
+			form.reset()
 		}
 	})
 

--- a/src/lib/schemas/common.ts
+++ b/src/lib/schemas/common.ts
@@ -1,12 +1,16 @@
 import { z } from 'zod'
 
-// Common validation patterns
+// Common validation patterns. `.email()` covers both empty + malformed
+// input with a single error message — chaining `.min(1, 'required')`
+// before it surfaces both errors at once on an empty submit and reads
+// as buggy in the UI (audit #258). Trim + lowercase happen first so a
+// whitespace-only submission ('   ') normalises to '' and fails
+// `.email()` rather than slipping past the `.min(1)` gate.
 export const emailSchema = z
 	.string()
-	.min(1, 'Email is required')
-	.email('Please enter a valid email address')
-	.toLowerCase()
 	.trim()
+	.toLowerCase()
+	.email('Please enter a valid email address')
 
 export const phoneSchema = z
 	.string()

--- a/tests/unit/contact-lead-scoring.test.ts
+++ b/tests/unit/contact-lead-scoring.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Lock the contract that `scoreLeadFromContactData` is enum-agnostic for
+ * the `service` field — `hasSpecificService` only checks `service !==
+ * 'other'`, so any new option value picks up the SPECIFIC_SERVICE
+ * bonus and any future service-specific scoring branch must be added
+ * explicitly (audit #277).
+ */
+import { describe, expect, it } from 'bun:test'
+import {
+	type ContactFormData,
+	scoreLeadFromContactData
+} from '@/lib/schemas/contact'
+
+const BASE: ContactFormData = {
+	firstName: 'Riley',
+	lastName: 'Sanders',
+	email: 'riley@example.com',
+	phone: '',
+	company: '',
+	bestTimeToContact: 'anytime',
+	budget: 'under-5k',
+	timeline: 'flexible',
+	message: 'Hello, looking for help.'
+}
+
+describe('scoreLeadFromContactData service enum coverage', () => {
+	for (const service of [
+		'website-design',
+		'seo',
+		'booking-payments'
+	] as const) {
+		it(`awards SPECIFIC_SERVICE points for "${service}"`, () => {
+			const out = scoreLeadFromContactData({ ...BASE, service })
+			expect(out.factors.hasSpecificService).toBe(true)
+		})
+	}
+
+	it('does NOT award SPECIFIC_SERVICE points for "other"', () => {
+		const out = scoreLeadFromContactData({ ...BASE, service: 'other' })
+		expect(out.factors.hasSpecificService).toBe(false)
+	})
+
+	it('does NOT award SPECIFIC_SERVICE points when service is omitted', () => {
+		// Strip the `service` field entirely; ContactFormData allows it.
+		const { service: _omit, ...rest } = { ...BASE, service: 'other' as const }
+		const out = scoreLeadFromContactData(rest as ContactFormData)
+		expect(out.factors.hasSpecificService).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary

4 medium-severity audit issues in one focused PR. Each is a small, contained fix; batched here because they all touch the same form/validation surface.

### #258 — Newsletter dual error message

`emailSchema` chained `.min(1, 'Email is required')` AND `.email('Please enter a valid email address')` — both fire on an empty string, so submitting an empty newsletter form showed two contradicting messages at once. Replaced with `.trim().toLowerCase().email()` so empty input gates on a single `.email()` error. Whitespace-only normalises to `''` first and fails the same gate.

### #264 — Subscribed state leaves email filled in

After a successful subscribe the button flipped to \"Subscribed\" but the email stayed in the input — ambiguous (\"already subscribed? resubmit?\"). `onSubmit` now calls `form.reset()` after the mutation so the input clears and the badge stands alone.

### #276 — Contact submit button reported as no inflight visual

Verified that `src/hooks/form-hook.tsx:284-296` already wires the button as `disabled={!canSubmit || isSubmitting}` and swaps in the loading label. The audit's observation was almost certainly the pre-hydration window (now POST-method-protected by #237) — no code change needed for the inflight UX itself. Closing on verification.

### #277 — Lead-scoring service options enum coverage

Already addressed by #250 because `scoreLeadFromContactData` uses `data.service !== 'other'` (enum-agnostic). Adds `tests/unit/contact-lead-scoring.test.ts` locking the contract: every new enum value (website-design / seo / booking-payments) awards the SPECIFIC_SERVICE bonus and \"other\" does not. A future service-specific scoring branch has to be added explicitly, and an enum rollback fails CI.

## Test plan

- [ ] Submit empty newsletter — single error \"Please enter a valid email address\"
- [ ] Submit valid email → button flips to \"Subscribed\" AND input clears
- [ ] Contact form submit → button disables + shows \"Submitting...\" during inflight
- [ ] All 775 unit tests pass (5 new from contact-lead-scoring)

[hudsor01]