### PR TITLE
fix(audit): hard-stop looping decorative animations under prefers-reduced-motion (#269)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -338,6 +338,16 @@ button,
 	.card-hover-glow:hover {
 		transform: none !important;
 	}
+	/* Looping decorative carets and idle indicators get hard-stopped
+	 * (rather than just shortened to 0.01ms) so the animation never
+	 * re-fires and CPU work for offscreen pulses is zero. Audit #269
+	 * called out the blink as the most noticeable remaining offender
+	 * after the Showcase H1 typewriter was removed (#243). */
+	.animate-blink,
+	.animate-pulse {
+		animation: none !important;
+		opacity: 1 !important;
+	}
 }
 
 /* Utilities used in components */


### PR DESCRIPTION
## Summary

Closes #269.

The global `@media (prefers-reduced-motion: reduce)` block already shortens `animation-duration` and `transition-duration` to `0.01ms` on every element — that's the WCAG 2.3.3 default and addresses most motion sensitivity. But `.animate-blink` (and the related `.animate-pulse` used by skeleton loaders) keep RE-firing through their infinite loop with that effectively-zero duration — the CPU work is small but non-zero and the visual cue is technically still present each iteration.

## Fix

Adds an explicit override inside the reduced-motion media query that hard-stops both classes via `animation: none` and pins `opacity: 1` so the user never sees a half-faded element:

```css
.animate-blink,
.animate-pulse {
  animation: none !important;
  opacity: 1 !important;
}
```

The typewriter caret that originally inspired this audit issue was removed in #243, but the blink class is still used as a generic caret marker elsewhere and the pulse class drives several skeleton loaders that fire on initial load.

## Deferred

#266 (form label/placeholder/hint patterns inconsistent between Contact form and Performance Calculator) needs a `hint` prop added to `form-hook.tsx`'s `GenericField` API plus consumer updates — worth its own focused PR rather than batched here.

## Test plan

- [ ] Toggle macOS \"Reduce motion\" on. Visit any page with a blinking caret or skeleton loader — no animation visible, no flicker
- [ ] Toggle off again — animations resume

[hudsor01]