### PR TITLE
fix(audit): visual polish — OR divider + footer card repurposed (#270 #272 verifies #265 #275)

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -443,16 +443,20 @@ export default function HomePage() {
 						</ul>
 					</div>
 
-					{/* OR divider for the alternative path */}
+					{/* OR divider — tightened per audit #270. Previously full-
+					    width tracking-widest lines plus generous gap-4 read as
+					    a horizontal rule with a label attached; now narrower
+					    line caps and gap-3 nudge the "or" into reading as the
+					    soft transition between the two CTAs. */}
 					<div
 						aria-hidden="true"
-						className="mt-12 flex items-center gap-4 max-w-md mx-auto"
+						className="mt-10 flex items-center gap-3 max-w-xs mx-auto"
 					>
-						<span className="h-px flex-1 bg-border" />
-						<span className="text-xs uppercase tracking-widest text-muted-foreground">
+						<span className="h-px flex-1 bg-border/60" />
+						<span className="text-[0.65rem] uppercase tracking-wider text-muted-foreground">
 							or
 						</span>
-						<span className="h-px flex-1 bg-border" />
+						<span className="h-px flex-1 bg-border/60" />
 					</div>
 
 					<div className="mt-8">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,6 @@
 
 import { CheckCircle, Clock, Mail, Phone, Rocket } from 'lucide-react'
 import Link from 'next/link'
-import { Button } from '@/components/ui/button'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { ROUTES } from '@/lib/constants/routes'
 import { cn } from '@/lib/utils'
@@ -170,34 +169,23 @@ export default function Footer() {
 							</nav>
 						</div>
 
-						{/* CTA Section */}
+						{/* Contact section. Previously titled "Ready for the
+						    Website You've Earned?" + a "Get My Free Plan" button,
+						    which duplicated the closing-CTA card immediately above
+						    in the homepage's last section (audit #272). Repurposed
+						    as a direct-contact panel so the section earns its own
+						    keep — email and phone are the unique value vs. the
+						    form-routing CTA card above. */}
 						<div className="md:col-span-1">
 							<h4 className="text-foreground font-semibold mb-heading">
-								Ready for the Website You&apos;ve Earned?
+								Prefer to reach out directly?
 							</h4>
 							<p className="text-xs text-muted-foreground mb-heading">
-								Get your free website plan: pages, timeline, and cost, mapped
-								out for your business.
+								Email or call. Fastest path to a quote without filling out a
+								form.
 							</p>
 
 							<div className="space-y-3">
-								{/* Shorter copy than the hero/nav CTA ("Get My Free
-								    Website Plan") for two reasons: (a) the footer card
-								    column is ~240px at md and the longer string truncated
-								    to "Get My Free Websit" (audit #244); (b) CTA
-								    saturation — the long form appears multiple times above
-								    this card on the same page, so a tighter footer
-								    variant reduces the repetition. */}
-								<Button
-									asChild
-									variant="default"
-									size="default"
-									trackConversion={true}
-									className="w-full"
-								>
-									<Link href={ROUTES.CONTACT}>Get My Free Plan</Link>
-								</Button>
-
 								{/* `min-w-0` on the flex parent unlocks `truncate` on the
 								    text child. Without it the email (~30 chars) overflows
 								    the 1-of-4 column at narrow desktop widths and pushes


### PR DESCRIPTION
## Summary

Two code changes + two verification closures.

### #270 — OR divider tightened

Full-width tracking-widest lines + `gap-4` + `text-xs` read as a horizontal rule with a label hanging off it — too heavy for a 2-char word. Tightened to `max-w-xs` container, `gap-3`, line opacity 60%, and `text-[0.65rem] tracking-wider`. The \"or\" now reads as a soft transition between the two CTAs rather than a section break.

### #272 — Footer card repurposed as direct-contact panel

The footer card titled \"Ready for the Website You've Earned?\" ran a \"Get My Free Plan\" button that duplicated the closing-CTA card immediately above on the homepage. Repurposed the card as a direct-contact panel — \"Prefer to reach out directly?\" + email + phone — so the section earns its own keep. The duplicate button is gone; the unique email + phone touchpoints are now the section's reason to exist. Drops the unused `Button` import.

### Verification-only closures

- **#265** (external-link icon inconsistency): PR #282 already swapped the showcase \"View Services\" button to `ArrowRight`. Remaining `ExternalLink` uses in `TestimonialCollectorClient`, `portfolio/[slug]`, `showcase/[slug]` all point at off-site URLs — legitimate. No further code change needed.
- **#275** (skeleton loader shape mismatch): PR #241 removed the Suspense fallback on `showcase/[slug]` entirely. No skeleton renders on that path anymore.

### Deferred

- **#268** (top nav active-state drift on Showcase): needs dev-server pixel inspection to diagnose.
- **#274** (blog tag counts + active state): own PR.

## Test plan

- [ ] Visit `/` — OR divider reads softly, not as a section break
- [ ] Visit any page — footer card now reads \"Prefer to reach out directly?\" with email + phone, no CTA button
- [ ] `bunx knip` reports no new orphans
- [ ] All 770 tests pass

[hudsor01]