### PR TITLE
feat(blog): tag counts + active state on chip cloud (#274)

### DIFF
--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react'
 import { BlogPostCard } from '@/components/blog/BlogPostCard'
 import { TagList } from '@/components/blog/TagList'
 import { Button } from '@/components/ui/button'
-import { getFeaturedPosts, getPosts, getTags } from '@/lib/blog'
+import { getFeaturedPosts, getPosts, getTagsWithCounts } from '@/lib/blog'
 
 export const metadata: Metadata = {
 	title: 'Small Business Web Design Blog | Hudson Digital',
@@ -101,11 +101,12 @@ async function AllPostsSection() {
 }
 
 async function TagsSection() {
-	const tags = await getTags()
-	if (tags.length === 0) {
+	const tags = await getTagsWithCounts()
+	const populated = tags.filter(tag => tag.count > 0)
+	if (populated.length === 0) {
 		return null
 	}
-	return <TagList tags={tags} />
+	return <TagList tags={populated} />
 }
 
 function PostListSkeleton() {

--- a/src/app/(public)/blog/tag/[slug]/page.tsx
+++ b/src/app/(public)/blog/tag/[slug]/page.tsx
@@ -1,8 +1,14 @@
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { BlogPostCard } from '@/components/blog/BlogPostCard'
+import { TagList } from '@/components/blog/TagList'
 import { BackLink } from '@/components/utilities/BackLink'
-import { getPostsByTag, getTagBySlug, getTags } from '@/lib/blog'
+import {
+	getPostsByTag,
+	getTagBySlug,
+	getTags,
+	getTagsWithCounts
+} from '@/lib/blog'
 
 interface TagPageProps {
 	params: Promise<{ slug: string }>
@@ -56,7 +62,11 @@ export default async function TagPage({ params }: TagPageProps) {
 		notFound()
 	}
 
-	const posts = await getPostsByTag(tag.slug)
+	const [posts, allTags] = await Promise.all([
+		getPostsByTag(tag.slug),
+		getTagsWithCounts()
+	])
+	const populatedTags = allTags.filter(t => t.count > 0 || t.slug === tag.slug)
 
 	return (
 		<div className="min-h-screen bg-background">
@@ -75,6 +85,11 @@ export default async function TagPage({ params }: TagPageProps) {
 						<p className="text-xl text-muted-foreground max-w-2xl mx-auto">
 							{tag.description}
 						</p>
+					)}
+					{populatedTags.length > 1 && (
+						<div className="mt-comfortable flex justify-center">
+							<TagList tags={populatedTags} activeSlug={tag.slug} />
+						</div>
 					)}
 				</div>
 			</section>

--- a/src/components/blog/TagList.tsx
+++ b/src/components/blog/TagList.tsx
@@ -1,28 +1,52 @@
 import { Tag } from 'lucide-react'
 import Link from 'next/link'
 import type { BlogTag } from '@/lib/blog'
+import { cn } from '@/lib/utils'
+
+type TagWithCount = BlogTag & { count?: number }
 
 interface TagListProps {
-	tags: BlogTag[]
+	tags: Array<BlogTag | TagWithCount>
+	activeSlug?: string
 }
 
-export function TagList({ tags }: TagListProps) {
+export function TagList({ tags, activeSlug }: TagListProps) {
 	if (tags.length === 0) {
 		return null
 	}
 
 	return (
 		<div className="flex flex-wrap gap-2">
-			{tags.map(tag => (
-				<Link
-					key={tag.id}
-					href={`/blog/tag/${tag.slug}`}
-					className="flex items-center gap-1 text-sm px-3 py-1 text-accent hover:text-accent-foreground hover:bg-accent border border-accent/30 rounded-md transition-colors"
-				>
-					<Tag className="w-4 h-4" />
-					{tag.name}
-				</Link>
-			))}
+			{tags.map(tag => {
+				const isActive = tag.slug === activeSlug
+				const count = (tag as TagWithCount).count
+				return (
+					<Link
+						key={tag.id}
+						href={`/blog/tag/${tag.slug}`}
+						aria-current={isActive ? 'page' : undefined}
+						className={cn(
+							'flex items-center gap-1 text-sm px-3 py-1 border rounded-md transition-colors',
+							isActive
+								? 'text-accent-foreground bg-accent border-accent'
+								: 'text-accent border-accent/30 hover:text-accent-foreground hover:bg-accent'
+						)}
+					>
+						<Tag className="w-4 h-4" />
+						{tag.name}
+						{typeof count === 'number' && (
+							<span
+								className={cn(
+									'tabular-nums text-xs',
+									isActive ? 'opacity-90' : 'opacity-70'
+								)}
+							>
+								({count})
+							</span>
+						)}
+					</Link>
+				)
+			})}
 		</div>
 	)
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -5,7 +5,7 @@
 
 import 'server-only'
 
-import { and, desc, eq, inArray } from 'drizzle-orm'
+import { and, count, desc, eq, inArray } from 'drizzle-orm'
 import { cacheLife, cacheTag } from 'next/cache'
 import { db } from '@/lib/db'
 import { reportError } from '@/lib/error-tracking'
@@ -253,6 +253,54 @@ export async function getPostBySlug(slug: string): Promise<BlogPost | null> {
 			op: 'getPostBySlug'
 		})
 		return null
+	}
+}
+
+/**
+ * Tags + per-tag count of PUBLISHED posts. Used by `/blog` to render
+ * `Tag (12)`-style chip labels (audit #274). Tags with zero published
+ * posts are still returned so the operator can see them in the UI
+ * even before any post is published against them.
+ */
+export async function getTagsWithCounts(): Promise<
+	Array<BlogTag & { count: number }>
+> {
+	'use cache'
+	cacheLife('days')
+	cacheTag('blog-tags')
+
+	try {
+		const rows = await db
+			.select({
+				id: blogTags.id,
+				slug: blogTags.slug,
+				name: blogTags.name,
+				description: blogTags.description,
+				count: count(blogPosts.id)
+			})
+			.from(blogTags)
+			.leftJoin(blogPostTags, eq(blogPostTags.tagId, blogTags.id))
+			.leftJoin(
+				blogPosts,
+				and(
+					eq(blogPosts.id, blogPostTags.postId),
+					eq(blogPosts.published, true)
+				)
+			)
+			.groupBy(blogTags.id, blogTags.slug, blogTags.name, blogTags.description)
+			.orderBy(blogTags.name)
+			.limit(500)
+		return rows.map(row => ({
+			id: row.id,
+			slug: row.slug,
+			name: row.name,
+			description: row.description ?? undefined,
+			count: Number(row.count)
+		}))
+	} catch (error) {
+		logger.error('Failed to fetch blog tags with counts', error)
+		reportError(error, { module: 'blog', op: 'getTagsWithCounts' })
+		return []
 	}
 }
 

--- a/tests/unit/blog.test.ts
+++ b/tests/unit/blog.test.ts
@@ -15,6 +15,7 @@ function createQueryChain(result: unknown[] = []) {
 		'innerJoin',
 		'where',
 		'orderBy',
+		'groupBy',
 		'limit',
 		'offset'
 	]
@@ -82,7 +83,8 @@ mock.module('drizzle-orm', () => ({
 	eq: mock((...args: unknown[]) => args),
 	desc: mock((col: unknown) => col),
 	and: mock((...args: unknown[]) => args),
-	inArray: mock((...args: unknown[]) => args)
+	inArray: mock((...args: unknown[]) => args),
+	count: mock((col: unknown) => ({ __agg: 'count', col }))
 }))
 
 // Import after all mocks
@@ -95,7 +97,8 @@ import {
 	getPostsByAuthor,
 	getPostsByTag,
 	getTagBySlug,
-	getTags
+	getTags,
+	getTagsWithCounts
 } from '@/lib/blog'
 
 // ─── Test Fixtures ──────────────────────────────────────────────────────────
@@ -180,6 +183,54 @@ describe('Blog Data Layer', () => {
 		test('returns empty array when no tags exist', async () => {
 			resetMockDb([])
 			const tags = await getTags()
+			expect(tags).toEqual([])
+		})
+	})
+
+	describe('getTagsWithCounts', () => {
+		test('coerces SQL count to a number and preserves description', async () => {
+			// Drizzle returns counts as bigint-like strings in postgres; the
+			// production query path must normalize them so JSX can render
+			// `({count})` without `NaN` or string concatenation surprises.
+			const rows = [
+				{
+					id: 'tag-1',
+					slug: 'web-dev',
+					name: 'Web Development',
+					description: 'Desc',
+					count: '12'
+				},
+				{
+					id: 'tag-2',
+					slug: 'business',
+					name: 'Business',
+					description: null,
+					count: 0
+				}
+			]
+			resetMockDb(rows)
+
+			const tags = await getTagsWithCounts()
+
+			expect(tags).toHaveLength(2)
+			expect(tags[0]).toEqual({
+				id: 'tag-1',
+				slug: 'web-dev',
+				name: 'Web Development',
+				description: 'Desc',
+				count: 12
+			})
+			expect(tags[1]?.description).toBeUndefined()
+			expect(tags[1]?.count).toBe(0)
+		})
+
+		test('returns empty array on DB error', async () => {
+			selectCallIndex = 0
+			selectResults = []
+			mockSelect.mockImplementationOnce(() => {
+				throw new Error('boom')
+			})
+			const tags = await getTagsWithCounts()
 			expect(tags).toEqual([])
 		})
 	})


### PR DESCRIPTION
## Summary

- `getTagsWithCounts()` joins `blog_tags` -> `blog_post_tags` -> `blog_posts` (published-only) with a COUNT, returning each tag with a normalized number `count`. Same cache profile as `getTags()` (`'days'` + `'blog-tags'`).
- `TagList` accepts `activeSlug` and renders `(N)` when a count is attached, with a filled accent style for the active chip and `aria-current="page"`.
- `/blog` filters to tags with at least one published post.
- `/blog/tag/[slug]` renders the chip cloud below the header with the current tag highlighted, so users can pivot to other tags from a tag detail page.

Closes audit #274.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test tests/unit/blog.test.ts` (26 pass, +2 new for bigint coercion + DB-error fallback)
- [ ] Visual: counts render in chips, active chip looks selected on tag detail

[hudsor01]