### PR TITLE
fix(audit): polish bundle (#259/#262/#266/#268/#278/#279)

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -82,13 +82,13 @@ export default function AboutPage() {
 				/>
 				<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
 					<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-						About Us
+						About Me
 					</p>
 					<h1 className="text-page-title text-foreground leading-tight text-balance">
 						Built Around Your Business
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						Where real business experience meets the skill to build it. We make
+						Where real business experience meets the skill to build it. I make
 						small businesses a website that does justice to the reputation
 						they&apos;ve already earned.
 					</p>
@@ -100,13 +100,13 @@ export default function AboutPage() {
 				<div className="container-wide">
 					<div className="text-center mb-10">
 						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Our Story
+							My Story
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
 							The Experience Behind Your Website
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							We build websites the way a business owner thinks. Every choice is
+							I build websites the way a business owner thinks. Every choice is
 							measured against whether it brings customers in.
 						</p>
 					</div>
@@ -119,7 +119,7 @@ export default function AboutPage() {
 							</h3>
 							<div className="space-y-4 text-sm text-muted-foreground leading-relaxed">
 								<p>
-									Most agencies learned web development in bootcamps. We learned
+									Most agencies learned web development in bootcamps. I learned
 									it in the trenches of revenue operations, where every decision
 									either moves the business forward or holds it back.
 								</p>
@@ -128,7 +128,7 @@ export default function AboutPage() {
 									<strong className="text-accent">
 										hands-on revenue experience
 									</strong>{' '}
-									across growing businesses, we discovered something agencies
+									across growing businesses, I discovered something agencies
 									miss:{' '}
 									<strong className="text-info">
 										websites fail not because of bad code, but because they were
@@ -137,11 +137,11 @@ export default function AboutPage() {
 									.
 								</p>
 								<p>
-									That&apos;s why our clients see{' '}
+									That&apos;s why my clients see{' '}
 									<strong className="text-accent">
 										real, measurable results
 									</strong>{' '}
-									in months, not years. We don&apos;t just launch a{' '}
+									in months, not years. I don&apos;t just launch a{' '}
 									<Link href="/services" className="link-primary font-semibold">
 										professional website
 									</Link>{' '}
@@ -152,8 +152,8 @@ export default function AboutPage() {
 									</strong>
 								</p>
 								<p className="text-foreground font-semibold">
-									We&apos;re not another agency selling &quot;beautiful
-									websites&quot; that sit there doing nothing. We build websites
+									I&apos;m not another agency selling &quot;beautiful
+									websites&quot; that sit there doing nothing. I build websites
 									that earn their keep.{' '}
 									<Link href="/contact" className="link-primary">
 										Let&apos;s talk about your project
@@ -170,7 +170,7 @@ export default function AboutPage() {
 									<div className="w-12 h-12 rounded-lg bg-accent/10 border border-accent/20 flex items-center justify-center">
 										<Rocket className="w-5 h-5 text-accent" />
 									</div>
-									<h3 className="text-h3 text-foreground">Our Mission</h3>
+									<h3 className="text-h3 text-foreground">My Mission</h3>
 								</div>
 								<p className="text-sm text-muted-foreground leading-relaxed">
 									Make a great website accessible to every small business. No
@@ -186,16 +186,16 @@ export default function AboutPage() {
 									<div className="w-12 h-12 rounded-lg bg-accent/10 border border-accent/20 flex items-center justify-center">
 										<Eye className="w-5 h-5 text-accent" />
 									</div>
-									<h3 className="text-h3 text-foreground">Our Guarantee</h3>
+									<h3 className="text-h3 text-foreground">My Guarantee</h3>
 								</div>
 								<p className="text-sm text-muted-foreground leading-relaxed">
-									If the KPI we agree on at kickoff (typically conversion rate,
-									qualified leads per month, or revenue per visitor)
-									doesn&apos;t improve over its installed-analytics baseline
-									within 90 days, I keep working (up to 3 additional revision
-									rounds covering optimization scope) at no extra cost until it
-									does. Baseline is measured from analytics installed on day one
-									of the engagement.
+									If the KPI I agree to with you at kickoff (typically
+									conversion rate, qualified leads per month, or revenue per
+									visitor) doesn&apos;t improve over its installed-analytics
+									baseline within 90 days, I keep working (up to 3 additional
+									revision rounds covering optimization scope) at no extra cost
+									until it does. Baseline is measured from analytics installed
+									on day one of the engagement.
 								</p>
 							</div>
 						</div>
@@ -208,10 +208,10 @@ export default function AboutPage() {
 				<div className="container-wide">
 					<div className="text-center mb-10">
 						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Our Toolkit
+							My Toolkit
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							What We Build With
+							What I Build With
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
 							Proven tools. Modern technology. Everything chosen because it
@@ -289,8 +289,8 @@ export default function AboutPage() {
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
 							Why trust a former revenue operations professional to build your
-							website? Because they understand something most agencies
-							don&apos;t: a website is only worth what it brings in.
+							website? Because I understand something most agencies don&apos;t:
+							a website is only worth what it brings in.
 						</p>
 					</div>
 
@@ -385,13 +385,13 @@ export default function AboutPage() {
 				<div className="container-wide">
 					<div className="text-center mb-10">
 						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							Our Principles
+							My Principles
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							How We Work
+							How I Work
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							The core beliefs behind every website we build.
+							The core beliefs behind every website I build.
 						</p>
 					</div>
 
@@ -404,7 +404,7 @@ export default function AboutPage() {
 								Performance First
 							</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								Every millisecond matters. We build for speed because fast sites
+								Every millisecond matters. I build for speed because fast sites
 								convert better, rank higher, and deliver a better experience for
 								your customers.
 							</p>
@@ -430,7 +430,7 @@ export default function AboutPage() {
 								Built to Grow With You
 							</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								We build for growth. Your website and systems grow with your
+								I build for growth. Your website and systems grow with your
 								business, no expensive rebuilds when you scale.
 							</p>
 						</div>

--- a/src/app/(public)/tools/ToolsCatalog.tsx
+++ b/src/app/(public)/tools/ToolsCatalog.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { ArrowRight, Search } from 'lucide-react'
+import Link from 'next/link'
+import { useId, useMemo, useState } from 'react'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { TOOL_CATEGORIES, TOOLS, type ToolEntry } from './tools-data'
+
+/**
+ * Client-side filtered catalog. Search is a substring match over
+ * title, description, and benefits (audit #278). Categories
+ * (#262) anchor each block so a small business owner finds the
+ * relevant tools without scrolling past unrelated ones.
+ */
+function matches(tool: ToolEntry, query: string): boolean {
+	if (!query) {
+		return true
+	}
+	const haystack = [tool.title, tool.description, ...tool.benefits]
+		.join(' ')
+		.toLowerCase()
+	return haystack.includes(query.toLowerCase())
+}
+
+export default function ToolsCatalog() {
+	const [query, setQuery] = useState('')
+	const searchId = useId()
+
+	const trimmed = query.trim()
+	const grouped = useMemo(() => {
+		return TOOL_CATEGORIES.map(category => ({
+			category,
+			items: TOOLS.filter(
+				tool => tool.category === category.id && matches(tool, trimmed)
+			)
+		})).filter(group => group.items.length > 0)
+	}, [trimmed])
+
+	const visibleCount = grouped.reduce((n, g) => n + g.items.length, 0)
+	const noResults = trimmed.length > 0 && visibleCount === 0
+
+	return (
+		<div className="space-y-sections">
+			<div className="max-w-xl">
+				<label htmlFor={searchId} className="sr-only">
+					Search tools
+				</label>
+				<div className="relative">
+					<Search
+						aria-hidden="true"
+						className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
+					/>
+					<Input
+						id={searchId}
+						type="search"
+						value={query}
+						onChange={e => setQuery(e.target.value)}
+						placeholder="Search tools by name or keyword"
+						className="pl-9"
+						aria-describedby={
+							trimmed.length > 0 ? `${searchId}-status` : undefined
+						}
+					/>
+				</div>
+				<p id={`${searchId}-status`} className="sr-only" aria-live="polite">
+					{trimmed.length === 0
+						? ''
+						: visibleCount === 0
+							? 'No tools match your search.'
+							: `${visibleCount} ${visibleCount === 1 ? 'tool' : 'tools'} matching "${trimmed}".`}
+				</p>
+			</div>
+
+			{noResults ? (
+				<div className="rounded-xl border border-border bg-surface-raised p-8 text-center">
+					<p className="text-sm text-muted-foreground">
+						No tools match &ldquo;{trimmed}&rdquo;. Try a broader keyword like
+						&ldquo;invoice&rdquo;, &ldquo;ROI&rdquo;, or &ldquo;JSON&rdquo;.
+					</p>
+				</div>
+			) : (
+				grouped.map(({ category, items }) => (
+					<section
+						key={category.id}
+						aria-labelledby={`tools-cat-${category.id}`}
+					>
+						<div className="mb-comfortable">
+							<h2
+								id={`tools-cat-${category.id}`}
+								className="text-h2 text-foreground mb-2"
+							>
+								{category.title}
+							</h2>
+							<p className="text-sm text-muted-foreground max-w-2xl">
+								{category.intro}
+							</p>
+						</div>
+
+						<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+							{items.map(tool => (
+								<Card
+									key={tool.href}
+									variant="glassLight"
+									size="lg"
+									hover={true}
+									className="group flex flex-col"
+								>
+									<div className="w-12 h-12 rounded-lg bg-accent/10 border border-accent/20 flex items-center justify-center mb-6">
+										<tool.Icon className="h-5 w-5 text-accent" />
+									</div>
+
+									<h3 className="text-h3 text-foreground mb-3">{tool.title}</h3>
+
+									<p className="text-sm text-muted-foreground leading-relaxed mb-4 flex-1">
+										{tool.description}
+									</p>
+
+									<ul className="mb-6 space-y-2">
+										{tool.benefits.map(benefit => (
+											<li
+												key={benefit}
+												className="flex items-start gap-2 text-sm text-muted-foreground"
+											>
+												<div className="mt-1 h-3 w-3 shrink-0 rounded-full bg-accent/30 border border-accent/50" />
+												{benefit}
+											</li>
+										))}
+									</ul>
+
+									<Link
+										href={tool.href}
+										className="inline-flex items-center gap-1.5 text-sm font-semibold text-accent hover:text-accent/80 transition-colors"
+									>
+										{tool.cta}
+										<ArrowRight className="h-4 w-4" />
+									</Link>
+								</Card>
+							))}
+						</div>
+					</section>
+				))
+			)}
+		</div>
+	)
+}

--- a/src/app/(public)/tools/page.tsx
+++ b/src/app/(public)/tools/page.tsx
@@ -1,28 +1,15 @@
 /**
  * Tools Landing Page
- * Showcases all free calculator tools
+ * Server shell — metadata + static sections. Catalog (grid + search +
+ * categories) lives in ToolsCatalog as a client component so the
+ * filter state stays out of the hydration boundary for the static
+ * surrounds.
  */
 
-import {
-	ArrowRight,
-	Briefcase,
-	Calculator,
-	Car,
-	Code2,
-	DollarSign,
-	FileSignature,
-	FileText,
-	Home,
-	Receipt,
-	Tags,
-	TrendingUp,
-	Zap
-} from 'lucide-react'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { TOOL_ROUTES } from '@/lib/constants/routes'
+import ToolsCatalog from './ToolsCatalog'
 
 export const metadata: Metadata = {
 	title: 'Free Business Tools & Calculators | Hudson Digital Solutions',
@@ -34,171 +21,6 @@ export const metadata: Metadata = {
 			'Interactive tools to help you make data-driven decisions about your website.'
 	}
 }
-
-const tools = [
-	{
-		title: 'ROI Calculator',
-		description:
-			'Calculate how much additional revenue you could generate by improving your website conversion rate.',
-		href: TOOL_ROUTES.ROI_CALCULATOR,
-		Icon: TrendingUp,
-		benefits: [
-			'See potential revenue increase',
-			'Understand conversion impact',
-			'Data-driven decision making'
-		],
-		cta: 'Calculate ROI'
-	},
-	{
-		title: 'Website Cost Estimator',
-		description:
-			'Get an instant estimate for your website project based on your specific requirements and features.',
-		href: TOOL_ROUTES.COST_ESTIMATOR,
-		Icon: Calculator,
-		benefits: [
-			'Transparent pricing breakdown',
-			'Timeline estimates',
-			'Feature-based pricing'
-		],
-		cta: 'Estimate Cost'
-	},
-	{
-		title: 'Performance Savings Calculator',
-		description:
-			'Discover how much revenue you are losing due to slow website performance with real PageSpeed analysis.',
-		href: TOOL_ROUTES.PERFORMANCE_CALCULATOR,
-		Icon: Zap,
-		benefits: [
-			'Real performance analysis',
-			'Revenue impact calculation',
-			'Core Web Vitals insights'
-		],
-		cta: 'Analyze Performance'
-	},
-	{
-		title: 'Texas TTL Calculator',
-		description:
-			'Calculate tax, title, and license fees plus monthly payment estimates for vehicle purchases in Texas.',
-		href: TOOL_ROUTES.TTL_CALCULATOR,
-		Icon: Car,
-		benefits: [
-			'Tax, title, and license fees',
-			'Monthly payment estimates',
-			'Texas-specific calculations'
-		],
-		cta: 'Calculate Fees'
-	},
-	{
-		title: 'Mortgage Calculator',
-		description:
-			'Calculate your monthly mortgage payment including principal, interest, taxes, insurance, and PMI.',
-		href: TOOL_ROUTES.MORTGAGE_CALCULATOR,
-		Icon: Home,
-		benefits: [
-			'Principal and interest breakdown',
-			'Includes taxes and insurance',
-			'PMI calculations'
-		],
-		cta: 'Calculate Payment'
-	},
-	{
-		title: 'Tip Calculator',
-		description:
-			'Calculate tip amounts and split the bill fairly among multiple people for any dining occasion.',
-		href: TOOL_ROUTES.TIP_CALCULATOR,
-		Icon: Receipt,
-		benefits: [
-			'Split bills fairly',
-			'Custom tip percentages',
-			'Per-person amounts'
-		],
-		cta: 'Calculate Tip'
-	},
-	{
-		title: 'Paystub Calculator',
-		description:
-			'Generate detailed payroll breakdowns with federal and state tax calculations and net pay.',
-		href: TOOL_ROUTES.PAYSTUB_CALCULATOR,
-		Icon: DollarSign,
-		benefits: [
-			'Federal and state tax withholding',
-			'Detailed deduction breakdown',
-			'Net pay calculation'
-		],
-		cta: 'Generate Paystub'
-	},
-	{
-		title: 'Contract Generator',
-		description:
-			'Create professional contracts ready for signature with customizable terms and PDF download.',
-		href: TOOL_ROUTES.CONTRACT_GENERATOR,
-		Icon: FileSignature,
-		benefits: [
-			'Professional contract templates',
-			'Downloadable PDF output',
-			'Customizable terms'
-		],
-		cta: 'Generate Contract'
-	},
-	{
-		title: 'Invoice Generator',
-		description:
-			'Create professional invoices with line items, totals, and tax, ready to download as PDF.',
-		href: TOOL_ROUTES.INVOICE_GENERATOR,
-		Icon: FileText,
-		benefits: [
-			'Professional invoice layout',
-			'Line item support',
-			'PDF download ready'
-		],
-		cta: 'Create Invoice'
-	},
-	{
-		title: 'Proposal Generator',
-		description:
-			'Create professional project proposals for clients with scope, timeline, and pricing. PDF included.',
-		href: TOOL_ROUTES.PROPOSAL_GENERATOR,
-		Icon: Briefcase,
-		benefits: [
-			'Client-ready proposals',
-			'Project scope templates',
-			'PDF export included'
-		],
-		cta: 'Create Proposal'
-	},
-	{
-		title: 'JSON Formatter',
-		description:
-			'Format, validate, and minify JSON data online with syntax error detection and instant feedback.',
-		href: TOOL_ROUTES.JSON_FORMATTER,
-		Icon: Code2,
-		benefits: [
-			'Format and validate JSON',
-			'Minify for production',
-			'Syntax error detection'
-		],
-		cta: 'Format JSON'
-	},
-	{
-		title: 'Meta Tag Generator',
-		description:
-			'Generate SEO-optimized meta tags, Open Graph, and Twitter Card markup for your web pages.',
-		href: TOOL_ROUTES.META_TAG_GENERATOR,
-		Icon: Tags,
-		benefits: [
-			'Open Graph markup',
-			'Twitter Card support',
-			'SEO meta tag preview'
-		],
-		cta: 'Generate Tags'
-	}
-	// The Testimonial Collector tool is admin-only — gated behind an
-	// ADMIN_SECRET bearer token. Linking it from the public tools index
-	// surfaced an "Enter admin token" UI to anyone who clicked through
-	// (audit #242). The route is intentionally left in place so an
-	// operator can still hit it directly with the token; removing it
-	// from this listing is the discoverability fix.
-]
 
 export default function ToolsPage() {
 	return (
@@ -227,54 +49,10 @@ export default function ToolsPage() {
 				</div>
 			</section>
 
-			{/* Tools Grid */}
+			{/* Catalog (categories + search) */}
 			<section className="py-section-sm px-4 sm:px-6">
 				<div className="container-wide">
-					<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-						{tools.map(tool => (
-							<Card
-								key={tool.href}
-								variant="glassLight"
-								size="lg"
-								hover={true}
-								className="group flex flex-col"
-							>
-								{/* Icon */}
-								<div className="w-12 h-12 rounded-lg bg-accent/10 border border-accent/20 flex items-center justify-center mb-6">
-									<tool.Icon className="h-5 w-5 text-accent" />
-								</div>
-
-								{/* Content */}
-								<h3 className="text-h3 text-foreground mb-3">{tool.title}</h3>
-
-								<p className="text-sm text-muted-foreground leading-relaxed mb-4 flex-1">
-									{tool.description}
-								</p>
-
-								{/* Benefits */}
-								<ul className="mb-6 space-y-2">
-									{tool.benefits.map((benefit, index) => (
-										<li
-											key={index}
-											className="flex items-start gap-2 text-sm text-muted-foreground"
-										>
-											<div className="mt-1 h-3 w-3 shrink-0 rounded-full bg-accent/30 border border-accent/50" />
-											{benefit}
-										</li>
-									))}
-								</ul>
-
-								{/* CTA */}
-								<Link
-									href={tool.href}
-									className="inline-flex items-center gap-1.5 text-sm font-semibold text-accent hover:text-accent/80 transition-colors"
-								>
-									{tool.cta}
-									<ArrowRight className="h-4 w-4" />
-								</Link>
-							</Card>
-						))}
-					</div>
+					<ToolsCatalog />
 				</div>
 			</section>
 

--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -1,0 +1,235 @@
+import {
+	Briefcase,
+	Calculator,
+	Car,
+	Code2,
+	DollarSign,
+	FileSignature,
+	FileText,
+	Home,
+	Receipt,
+	Tags,
+	TrendingUp,
+	Zap
+} from 'lucide-react'
+import { TOOL_ROUTES } from '@/lib/constants/routes'
+
+export type ToolCategoryId = 'website' | 'business' | 'developers'
+
+export interface ToolCategory {
+	id: ToolCategoryId
+	title: string
+	intro: string
+}
+
+/**
+ * Display order on the tools index. Audit #262: the grid used to mix
+ * website tools, generic personal-finance calculators, vendor
+ * paperwork, and a dev utility into one stream so a small business
+ * owner looking for ROI had to scroll past a mortgage calculator and
+ * a JSON formatter. Categories anchor each block.
+ */
+export const TOOL_CATEGORIES: readonly ToolCategory[] = [
+	{
+		id: 'website',
+		title: 'For Your Website',
+		intro:
+			'Calculators that quantify what a better website is worth: revenue, performance, scope, SEO.'
+	},
+	{
+		id: 'business',
+		title: 'For Your Business',
+		intro:
+			'Day-to-day paperwork and personal-finance math you can run without spinning up a separate tool.'
+	},
+	{
+		id: 'developers',
+		title: 'For Developers',
+		intro: 'Quick utilities that save a round trip to a second tab.'
+	}
+] as const
+
+export interface ToolEntry {
+	title: string
+	description: string
+	href: string
+	Icon: React.ComponentType<{ className?: string }>
+	benefits: string[]
+	cta: string
+	category: ToolCategoryId
+}
+
+export const TOOLS: readonly ToolEntry[] = [
+	{
+		title: 'ROI Calculator',
+		description:
+			'Calculate how much additional revenue you could generate by improving your website conversion rate.',
+		href: TOOL_ROUTES.ROI_CALCULATOR,
+		Icon: TrendingUp,
+		benefits: [
+			'See potential revenue increase',
+			'Understand conversion impact',
+			'Data-driven decision making'
+		],
+		cta: 'Calculate ROI',
+		category: 'website'
+	},
+	{
+		title: 'Website Cost Estimator',
+		description:
+			'Get an instant estimate for your website project based on your specific requirements and features.',
+		href: TOOL_ROUTES.COST_ESTIMATOR,
+		Icon: Calculator,
+		benefits: [
+			'Transparent pricing breakdown',
+			'Timeline estimates',
+			'Feature-based pricing'
+		],
+		cta: 'Estimate Cost',
+		category: 'website'
+	},
+	{
+		title: 'Performance Savings Calculator',
+		description:
+			'Discover how much revenue you are losing due to slow website performance with real PageSpeed analysis.',
+		href: TOOL_ROUTES.PERFORMANCE_CALCULATOR,
+		Icon: Zap,
+		benefits: [
+			'Real performance analysis',
+			'Revenue impact calculation',
+			'Core Web Vitals insights'
+		],
+		cta: 'Analyze Performance',
+		category: 'website'
+	},
+	{
+		title: 'Meta Tag Generator',
+		description:
+			'Generate SEO-optimized meta tags, Open Graph, and Twitter Card markup for your web pages.',
+		href: TOOL_ROUTES.META_TAG_GENERATOR,
+		Icon: Tags,
+		benefits: [
+			'Open Graph markup',
+			'Twitter Card support',
+			'SEO meta tag preview'
+		],
+		cta: 'Generate Tags',
+		category: 'website'
+	},
+	{
+		title: 'Texas TTL Calculator',
+		description:
+			'Calculate tax, title, and license fees plus monthly payment estimates for vehicle purchases in Texas.',
+		href: TOOL_ROUTES.TTL_CALCULATOR,
+		Icon: Car,
+		benefits: [
+			'Tax, title, and license fees',
+			'Monthly payment estimates',
+			'Texas-specific calculations'
+		],
+		cta: 'Calculate Fees',
+		category: 'business'
+	},
+	{
+		title: 'Mortgage Calculator',
+		description:
+			'Calculate your monthly mortgage payment including principal, interest, taxes, insurance, and PMI.',
+		href: TOOL_ROUTES.MORTGAGE_CALCULATOR,
+		Icon: Home,
+		benefits: [
+			'Principal and interest breakdown',
+			'Includes taxes and insurance',
+			'PMI calculations'
+		],
+		cta: 'Calculate Payment',
+		category: 'business'
+	},
+	{
+		title: 'Tip Calculator',
+		description:
+			'Calculate tip amounts and split the bill fairly among multiple people for any dining occasion.',
+		href: TOOL_ROUTES.TIP_CALCULATOR,
+		Icon: Receipt,
+		benefits: [
+			'Split bills fairly',
+			'Custom tip percentages',
+			'Per-person amounts'
+		],
+		cta: 'Calculate Tip',
+		category: 'business'
+	},
+	{
+		title: 'Paystub Calculator',
+		description:
+			'Generate detailed payroll breakdowns with federal and state tax calculations and net pay.',
+		href: TOOL_ROUTES.PAYSTUB_CALCULATOR,
+		Icon: DollarSign,
+		benefits: [
+			'Federal and state tax withholding',
+			'Detailed deduction breakdown',
+			'Net pay calculation'
+		],
+		cta: 'Generate Paystub',
+		category: 'business'
+	},
+	{
+		title: 'Contract Generator',
+		description:
+			'Create professional contracts ready for signature with customizable terms and PDF download.',
+		href: TOOL_ROUTES.CONTRACT_GENERATOR,
+		Icon: FileSignature,
+		benefits: [
+			'Professional contract templates',
+			'Downloadable PDF output',
+			'Customizable terms'
+		],
+		cta: 'Generate Contract',
+		category: 'business'
+	},
+	{
+		title: 'Invoice Generator',
+		description:
+			'Create professional invoices with line items, totals, and tax, ready to download as PDF.',
+		href: TOOL_ROUTES.INVOICE_GENERATOR,
+		Icon: FileText,
+		benefits: [
+			'Professional invoice layout',
+			'Line item support',
+			'PDF download ready'
+		],
+		cta: 'Create Invoice',
+		category: 'business'
+	},
+	{
+		title: 'Proposal Generator',
+		description:
+			'Create professional project proposals for clients with scope, timeline, and pricing. PDF included.',
+		href: TOOL_ROUTES.PROPOSAL_GENERATOR,
+		Icon: Briefcase,
+		benefits: [
+			'Client-ready proposals',
+			'Project scope templates',
+			'PDF export included'
+		],
+		cta: 'Create Proposal',
+		category: 'business'
+	},
+	{
+		title: 'JSON Formatter',
+		description:
+			'Format, validate, and minify JSON data online with syntax error detection and instant feedback.',
+		href: TOOL_ROUTES.JSON_FORMATTER,
+		Icon: Code2,
+		benefits: [
+			'Format and validate JSON',
+			'Minify for production',
+			'Syntax error detection'
+		],
+		cta: 'Format JSON',
+		category: 'developers'
+	}
+	// The Testimonial Collector tool is admin-only (gated behind an
+	// ADMIN_SECRET bearer). It was de-listed in audit #242 and the
+	// route is intentionally left in place so an operator can hit it
+	// directly with the token.
+] as const

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -241,6 +241,17 @@ body {
 	max-width: 100vw;
 }
 
+/* Reserve the vertical scrollbar gutter on every page so short pages
+ * (e.g. /tools) and tall pages (e.g. /showcase) render with the same
+ * inline width. Without this, the fixed <nav> centers against the
+ * viewport including the scrollbar on tall pages but excluding it on
+ * short pages, so the active-state pill drifts horizontally between
+ * routes (audit #268). `stable` reserves the space regardless of
+ * whether the page actually overflows. */
+html {
+	scrollbar-gutter: stable;
+}
+
 /* `@theme inline` inlines font tokens into Tailwind utility classes at
  * build time but does NOT emit `--font-sans` (etc.) as runtime custom
  * properties on `:root`. Bare `var(--font-sans)` consumers (body rule

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -83,6 +83,12 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 			}}
 			className={`p-2 sm:p-5 md:p-8 w-full rounded-md gap-2 border max-w-3xl mx-auto ${className}`}
 		>
+			{/* Audit #266: standardize on label + helper-text-below. Drop
+			    placeholders that just repeat the label (e.g. "Enter your
+			    first name" under a "First Name" label is noise). Keep
+			    example-style placeholders that show formatting (email,
+			    phone) and hide the dropdown placeholders behind the label
+			    via `Select…`. */}
 			<FieldGroup className="grid md:grid-cols-6 gap-4 mb-6">
 				{/* First Name */}
 				<div className="md:col-span-3">
@@ -90,7 +96,6 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.TextField
 								label="First Name"
-								placeholder="Enter your first name"
 								autoComplete="given-name"
 								required
 							/>
@@ -104,7 +109,6 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.TextField
 								label="Last Name"
-								placeholder="Enter your last name"
 								autoComplete="family-name"
 								required
 							/>
@@ -118,7 +122,7 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.EmailField
 								label="Email Address"
-								placeholder="Enter your email address"
+								placeholder="name@company.com"
 								required
 							/>
 						)}
@@ -131,7 +135,7 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.PhoneField
 								label="Phone (Optional)"
-								placeholder="Enter your phone number"
+								placeholder="(555) 123-4567"
 							/>
 						)}
 					</form.AppField>
@@ -143,7 +147,6 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.TextField
 								label="Company (Optional)"
-								placeholder="Enter your company name"
 								autoComplete="organization"
 							/>
 						)}
@@ -184,6 +187,7 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 								label="Budget Range"
 								options={budgetOptions}
 								placeholder="Select budget range"
+								hint="A rough number is fine. Helps me scope the right plan."
 							/>
 						)}
 					</form.AppField>
@@ -208,9 +212,9 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 						{field => (
 							<field.TextareaField
 								label="Message"
-								placeholder="Tell us about your project..."
 								rows={6}
 								required
+								hint="A few sentences on the business and what you want the new site to do."
 							/>
 						)}
 					</form.AppField>

--- a/src/hooks/form-hook.tsx
+++ b/src/hooks/form-hook.tsx
@@ -46,6 +46,15 @@ interface GenericFieldProps {
 	options?: Array<{ value: string; label: string }>
 	rows?: number
 	required?: boolean
+	/**
+	 * Helper text rendered below the field. Hidden when a validation
+	 * error is present so the error owns the description slot. Audit
+	 * #266: this is the canonical hint pattern used by
+	 * `CalculatorInput` (`src/components/calculators/CalculatorInput.tsx`)
+	 * — keeping both surfaces on the same convention avoids two
+	 * different hint UIs for the same primitive.
+	 */
+	hint?: string
 }
 
 function RequiredMarker() {
@@ -66,16 +75,19 @@ function GenericField({
 	autoComplete,
 	options,
 	rows = 4,
-	required
+	required,
+	hint
 }: GenericFieldProps) {
 	const field = useFieldContext<string>()
 	const fieldId = field.name
 	const errorId = `${fieldId}-error`
+	const hintId = `${fieldId}-hint`
 	const hasError = field.state.meta.errors.length > 0
+	const showHint = !hasError && Boolean(hint)
 
 	const ariaProps = {
 		'aria-invalid': hasError ? ('true' as const) : undefined,
-		'aria-describedby': hasError ? errorId : undefined,
+		'aria-describedby': hasError ? errorId : showHint ? hintId : undefined,
 		'aria-required': required ? ('true' as const) : undefined
 	}
 
@@ -163,6 +175,11 @@ function GenericField({
 				{required && <RequiredMarker />}
 			</FieldLabel>
 			{renderField()}
+			{showHint && (
+				<p id={hintId} className="text-xs text-muted-foreground">
+					{hint}
+				</p>
+			)}
 			<FieldError id={errorId} errors={field.state.meta.errors} />
 		</Field>
 	)
@@ -178,13 +195,15 @@ interface TextFieldProps {
 	placeholder?: string
 	autoComplete?: string
 	required?: boolean
+	hint?: string
 }
 
 function TextField({
 	label,
 	placeholder,
 	autoComplete,
-	required
+	required,
+	hint
 }: TextFieldProps) {
 	return (
 		<GenericField
@@ -193,28 +212,31 @@ function TextField({
 			placeholder={placeholder}
 			autoComplete={autoComplete}
 			required={required}
+			hint={hint}
 		/>
 	)
 }
 
-function EmailField({ label, placeholder, required }: TextFieldProps) {
+function EmailField({ label, placeholder, required, hint }: TextFieldProps) {
 	return (
 		<GenericField
 			type="email"
 			label={label}
 			placeholder={placeholder}
 			required={required}
+			hint={hint}
 		/>
 	)
 }
 
-function PhoneField({ label, placeholder, required }: TextFieldProps) {
+function PhoneField({ label, placeholder, required, hint }: TextFieldProps) {
 	return (
 		<GenericField
 			type="tel"
 			label={label}
 			placeholder={placeholder}
 			required={required}
+			hint={hint}
 		/>
 	)
 }
@@ -224,13 +246,15 @@ interface SelectFieldProps {
 	placeholder?: string
 	options: Array<{ value: string; label: string }>
 	required?: boolean
+	hint?: string
 }
 
 function SelectField({
 	label,
 	placeholder,
 	options,
-	required
+	required,
+	hint
 }: SelectFieldProps) {
 	return (
 		<GenericField
@@ -239,6 +263,7 @@ function SelectField({
 			placeholder={placeholder}
 			options={options}
 			required={required}
+			hint={hint}
 		/>
 	)
 }
@@ -248,13 +273,15 @@ interface TextareaFieldProps {
 	placeholder?: string
 	rows?: number
 	required?: boolean
+	hint?: string
 }
 
 function TextareaField({
 	label,
 	placeholder,
 	rows = 4,
-	required
+	required,
+	hint
 }: TextareaFieldProps) {
 	return (
 		<GenericField
@@ -263,6 +290,7 @@ function TextareaField({
 			placeholder={placeholder}
 			rows={rows}
 			required={required}
+			hint={hint}
 		/>
 	)
 }

--- a/tests/unit/forms.test.tsx
+++ b/tests/unit/forms.test.tsx
@@ -65,10 +65,13 @@ describe('ContactForm Component', () => {
 		)
 		renderWithQueryClient(<ContactForm />)
 
-		// Check for all required fields using placeholders
-		expect(screen.getByPlaceholderText(/first name/i)).toBeInTheDocument()
-		expect(screen.getByPlaceholderText(/last name/i)).toBeInTheDocument()
-		expect(screen.getByPlaceholderText(/email address/i)).toBeInTheDocument()
+		// Audit #266: form-hook fields are now keyed to their labels, not
+		// "Enter your X" placeholders. Querying by accessible label is
+		// the canonical Testing Library pattern and remains stable as
+		// placeholder copy changes.
+		expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
+		expect(screen.getByLabelText(/last name/i)).toBeInTheDocument()
+		expect(screen.getByLabelText(/email address/i)).toBeInTheDocument()
 	})
 
 	it('should render input fields with proper types', async () => {
@@ -77,8 +80,7 @@ describe('ContactForm Component', () => {
 		)
 		renderWithQueryClient(<ContactForm />)
 
-		// Email field should have email type
-		const emailInput = screen.getByPlaceholderText(/email address/i)
+		const emailInput = screen.getByLabelText(/email address/i)
 		expect(emailInput.getAttribute('type')).toBe('email')
 	})
 
@@ -89,9 +91,8 @@ describe('ContactForm Component', () => {
 		const user = userEvent.setup()
 		renderWithQueryClient(<ContactForm />)
 
-		const emailInput = screen.getByPlaceholderText(/email address/i)
+		const emailInput = screen.getByLabelText(/email address/i)
 
-		// Type valid email
 		await user.type(emailInput, 'test@example.com')
 
 		expect(emailInput).toHaveValue('test@example.com')
@@ -148,7 +149,7 @@ describe('ContactForm Component', () => {
 
 		renderWithQueryClient(<ContactForm />)
 
-		const nameInput = screen.getByPlaceholderText(/first name/i)
+		const nameInput = screen.getByLabelText(/first name/i)
 		await user.type(nameInput, 'John')
 		expect(nameInput).toHaveValue('John')
 	})
@@ -159,7 +160,7 @@ describe('ContactForm Component', () => {
 		)
 		renderWithQueryClient(<ContactForm />)
 
-		const nameInput = screen.getByPlaceholderText(/first name/i)
+		const nameInput = screen.getByLabelText(/first name/i)
 		// shadcn Input uses these standard classes
 		expect(nameInput).toHaveClass('rounded-md')
 		expect(nameInput).toHaveClass('border')


### PR DESCRIPTION
## Summary

Last sweep of medium/low audit items short of a real feature.

- **#268** nav pixel drift: `html { scrollbar-gutter: stable; }` in `globals.css`. Reserving the scrollbar gutter on every page removes the horizontal shift between a tall page (showcase) and a short page (tools), which made the active-state pill look misaligned across routes.
- **#262 / #278** tools index: split into \"For Your Website\", \"For Your Business\", \"For Developers\" with intros, plus a client-side search input that filters by title/description/benefits. Server `page.tsx` keeps metadata + static surrounds; client work moved to `ToolsCatalog.tsx`. New `tools-data.ts` is the single source for catalog entries.
- **#259 / #279** about-page voice: normalize entirely to first-person singular. Eyebrows (\"Our Story\" to \"My Story\"), headings (\"How We Work\" to \"How I Work\"), founder bio (third-person intro replaced with \"Because I understand...\"), and all body copy.
- **#266** form patterns: `form-hook.tsx` field components now take an optional `hint` prop and render `text-xs text-muted-foreground` helper text below the input, hidden when a validation error is present and wired via `aria-describedby`. Matches the existing `CalculatorInput` pattern. ContactForm drops redundant \"Enter your X\" placeholders (label is the source of truth), keeps example formats on email + phone, and uses `hint` on budget + message to give a single line of useful guidance. Tests now query by accessible label, not placeholder.

Closes audit #259, #262, #266, #268, #278, #279.

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] \`bun test tests/\` (777 pass)
- [ ] Visual: tools index categories render, search filters live, no drift between pages
- [ ] Visual: about page reads in consistent first-person singular
- [ ] Visual: contact form hint copy appears under budget + message

[hudsor01]