### PR TITLE
chore(ci): diagnose Neon create-branch 422 failures

### DIFF
--- a/.github/workflows/neon-branch.yml
+++ b/.github/workflows/neon-branch.yml
@@ -56,6 +56,53 @@ jobs:
           api_key: ${{ secrets.NEON_API_KEY }}
           expires_at: ${{ env.EXPIRES_AT }}
 
+      # When the action above fails it only logs "AxiosError: 422" and
+      # hides the response body, so root cause (quota? duplicate name?
+      # invalid expires_at?) was invisible. This step runs ONLY on
+      # failure of the create step and surfaces what Neon actually
+      # said plus the current branch inventory + project limits.
+      #
+      # Security: BRANCH_NAME contains `github.head_ref`-derived input
+      # which is untrusted (a branch name can legally contain ", \, or
+      # other JSON-breaking characters). Validate against an allowlist
+      # regex before any use, and build the JSON body with `jq -n`
+      # (not string interpolation) so escaping is delegated to jq.
+      - name: Diagnose Neon API failure
+        if: failure() && steps.create_neon_branch.outcome == 'failure'
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+          BRANCH_NAME: preview/pr-${{ github.event.number }}-${{ needs.setup.outputs.branch }}
+        run: |
+          set +e
+          if ! printf '%s' "$BRANCH_NAME" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "BRANCH_NAME contains unexpected characters; aborting diagnostic."
+            exit 0
+          fi
+
+          echo "::group::Re-attempting create, capturing full response body"
+          BODY="$(jq -n --arg name "$BRANCH_NAME" --arg expires "$EXPIRES_AT" \
+            '{branch:{name:$name,expires_at:$expires}}')"
+          curl -sS -w "\nHTTP_STATUS:%{http_code}\n" \
+            -X POST \
+            -H "Authorization: Bearer ${NEON_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d "$BODY" \
+            "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches"
+          echo "::endgroup::"
+
+          echo "::group::Branch inventory"
+          curl -sS -H "Authorization: Bearer ${NEON_API_KEY}" \
+            "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}/branches" \
+            | jq '{count: (.branches | length), names: [.branches[].name]}'
+          echo "::endgroup::"
+
+          echo "::group::Project limits"
+          curl -sS -H "Authorization: Bearer ${NEON_API_KEY}" \
+            "https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}" \
+            | jq '.project | {branch_logical_size_limit, pg_version, settings, default_endpoint_settings, quota: .settings.quota}'
+          echo "::endgroup::"
+
       # `drizzle-kit push` is intentionally not run here. Upstream
       # drizzle-kit (#5329) errors out when `pg_cron` or `hypopg` are
       # installed in the target database; both are installed on this


### PR DESCRIPTION
## Summary

The recurring \"Create Neon Branch\" red X on every PR shows only \`AxiosError: Request failed with status code 422\` because \`neondatabase/create-branch-action@v6\` swallows the API response body. This adds a failure-only diagnostic step that:

1. Replays the create-branch call with curl and prints the full response (real error message).
2. Lists the current branch inventory + count (to test the \"hit the 10-branch quota\" hypothesis).
3. Dumps project settings/quota so we can see if there's an account-side cap we missed.

On the next failing run we'll know exactly why Neon is rejecting it and can apply the actual root-cause fix.

## Security

\`BRANCH_NAME\` is built from \`github.head_ref\`-derived input (\`needs.setup.outputs.branch\`). Validated against an allowlist regex (\`^[A-Za-z0-9._/-]+$\`) before any use, and the JSON request body is constructed via \`jq -n --arg\` so escaping is delegated to jq, not string interpolation.

## Test plan

- [x] Workflow YAML parses (will be validated by GH on push)
- [ ] PR's own \"Create Neon Branch\" run fails as expected and the new step prints the real 422 response

[hudsor01]