### PR TITLE
feat: global command palette (cmdk) for site-wide search (#263)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "better-auth": "1.6.11",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "cmdk": "1.1.1",
         "drizzle-orm": "0.45.2",
         "lucide-react": "1.16.0",
         "nuqs": "2.8.9",
@@ -973,6 +974,8 @@
     "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "color-name": ["color-name@2.1.0", "", {}, "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg=="],
 

--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "",
-    "css": "app/globals.css",
+    "css": "src/app/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"better-auth": "1.6.11",
 		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",
+		"cmdk": "1.1.1",
 		"drizzle-orm": "0.45.2",
 		"lucide-react": "1.16.0",
 		"nuqs": "2.8.9",

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -22,6 +22,8 @@
  * route-group layout owns its own.
  */
 import type { ReactNode } from 'react'
+import { Suspense } from 'react'
+import CommandPaletteData from '@/components/cmdk/CommandPaletteData'
 import Footer from '@/components/layout/Footer'
 import NavbarLight from '@/components/layout/Navbar'
 import ScrollToTop from '@/components/utilities/ScrollToTop'
@@ -30,6 +32,14 @@ export default function PublicLayout({ children }: { children: ReactNode }) {
 	return (
 		<>
 			<NavbarLight />
+			{/* Global command palette (audit #263). Singleton mount across
+			    the public route group — admin/auth layouts intentionally
+			    omit it. Async server component fetches recent posts +
+			    showcase items behind a Suspense boundary so the rest of
+			    the chrome streams immediately. */}
+			<Suspense fallback={null}>
+				<CommandPaletteData />
+			</Suspense>
 			{/* The skip-link target lives here (a real <main> landmark, not a
 			    wrapping <div>) so assistive technology landmark navigation
 			    (NVDA Insert+F7, JAWS R) finds a single named region per page.

--- a/src/components/cmdk/CommandPalette.tsx
+++ b/src/components/cmdk/CommandPalette.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	CommandDialog,
 	CommandEmpty,
@@ -58,6 +58,11 @@ function isTypingTarget(event: KeyboardEvent): boolean {
 export default function CommandPalette({ entries }: CommandPaletteProps) {
 	const router = useRouter()
 	const [open, setOpen] = useState(false)
+	// The keydown effect has [] deps so it captures `open` once. Mirror the
+	// latest value into a ref so the handler can read current open-state
+	// without re-subscribing the listener on every toggle.
+	const openRef = useRef(open)
+	openRef.current = open
 
 	const grouped = useMemo(() => {
 		const map = new Map<PaletteGroup, PaletteEntry[]>()
@@ -83,7 +88,12 @@ export default function CommandPalette({ entries }: CommandPaletteProps) {
 			if (!event.metaKey && !event.ctrlKey) {
 				return
 			}
-			if (isTypingTarget(event)) {
+			// When the palette is OPEN, Radix has moved focus into the cmdk
+			// search input (a native type="text" input), which the typing
+			// guard would treat as "user is typing" and refuse to toggle.
+			// Only honor the guard while the palette is CLOSED, so page text
+			// fields keep Cmd+K but the open palette can still close itself.
+			if (!openRef.current && isTypingTarget(event)) {
 				return
 			}
 			event.preventDefault()
@@ -121,10 +131,16 @@ export default function CommandPalette({ entries }: CommandPaletteProps) {
 						{items.map(entry => (
 							<CommandItem
 								key={entry.id}
+								// cmdk dedupes/selects by `value`. Showcase entries
+								// carry no description or keywords, so without the
+								// unique id two same-titled items would share a
+								// value (dual-highlight + Enter mis-route). id is
+								// `<kind>:<db-unique-slug>`, so it disambiguates.
 								value={[
 									entry.label,
 									entry.description ?? '',
-									...(entry.keywords ?? [])
+									...(entry.keywords ?? []),
+									entry.id
 								].join(' ')}
 								onSelect={() => handleSelect(entry.href)}
 							>

--- a/src/components/cmdk/CommandPalette.tsx
+++ b/src/components/cmdk/CommandPalette.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+	CommandDialog,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList
+} from '@/components/ui/command'
+import type { PaletteEntry, PaletteGroup } from './types'
+
+interface CommandPaletteProps {
+	entries: readonly PaletteEntry[]
+}
+
+const GROUP_ORDER: readonly PaletteGroup[] = [
+	'Tools',
+	'Pages',
+	'Blog',
+	'Showcase'
+]
+
+/**
+ * Detect input-like targets so the keyboard shortcut doesn't hijack typing.
+ * Targets the user is actively typing into (text inputs, textareas,
+ * contenteditable surfaces) must keep ownership of Cmd+K.
+ */
+function isTypingTarget(event: KeyboardEvent): boolean {
+	const target = event.target
+	if (!(target instanceof HTMLElement)) {
+		return false
+	}
+	if (target.isContentEditable) {
+		return true
+	}
+	if (target instanceof HTMLTextAreaElement) {
+		return true
+	}
+	if (target instanceof HTMLInputElement) {
+		// Allow palette shortcut from buttons/checkboxes etc.; block only text-like.
+		const blocking = new Set([
+			'text',
+			'search',
+			'email',
+			'url',
+			'tel',
+			'password',
+			'number'
+		])
+		return blocking.has(target.type.toLowerCase())
+	}
+	return false
+}
+
+export default function CommandPalette({ entries }: CommandPaletteProps) {
+	const router = useRouter()
+	const [open, setOpen] = useState(false)
+
+	const grouped = useMemo(() => {
+		const map = new Map<PaletteGroup, PaletteEntry[]>()
+		for (const entry of entries) {
+			const bucket = map.get(entry.group)
+			if (bucket) {
+				bucket.push(entry)
+			} else {
+				map.set(entry.group, [entry])
+			}
+		}
+		return GROUP_ORDER.flatMap(group => {
+			const items = map.get(group)
+			return items && items.length > 0 ? [{ group, items }] : []
+		})
+	}, [entries])
+
+	useEffect(() => {
+		const handleKey = (event: KeyboardEvent) => {
+			if (event.key.toLowerCase() !== 'k') {
+				return
+			}
+			if (!event.metaKey && !event.ctrlKey) {
+				return
+			}
+			if (isTypingTarget(event)) {
+				return
+			}
+			event.preventDefault()
+			setOpen(prev => !prev)
+		}
+		const handleOpenRequest = () => setOpen(true)
+		document.addEventListener('keydown', handleKey)
+		window.addEventListener('palette:open', handleOpenRequest)
+		return () => {
+			document.removeEventListener('keydown', handleKey)
+			window.removeEventListener('palette:open', handleOpenRequest)
+		}
+	}, [])
+
+	const handleSelect = useCallback(
+		(href: string) => {
+			setOpen(false)
+			router.push(href)
+		},
+		[router]
+	)
+
+	return (
+		<CommandDialog
+			open={open}
+			onOpenChange={setOpen}
+			title="Site command palette"
+			description="Search pages, tools, and recent posts. Press Cmd K or Ctrl K to toggle."
+		>
+			<CommandInput placeholder="Search pages, tools, and posts" />
+			<CommandList>
+				<CommandEmpty>No results.</CommandEmpty>
+				{grouped.map(({ group, items }) => (
+					<CommandGroup key={group} heading={group}>
+						{items.map(entry => (
+							<CommandItem
+								key={entry.id}
+								value={[
+									entry.label,
+									entry.description ?? '',
+									...(entry.keywords ?? [])
+								].join(' ')}
+								onSelect={() => handleSelect(entry.href)}
+							>
+								<div className="flex flex-col">
+									<span className="text-sm font-medium text-foreground">
+										{entry.label}
+									</span>
+									{entry.description && (
+										<span className="text-xs text-muted-foreground line-clamp-1">
+											{entry.description}
+										</span>
+									)}
+								</div>
+							</CommandItem>
+						))}
+					</CommandGroup>
+				))}
+			</CommandList>
+		</CommandDialog>
+	)
+}

--- a/src/components/cmdk/CommandPaletteData.tsx
+++ b/src/components/cmdk/CommandPaletteData.tsx
@@ -1,0 +1,43 @@
+import { getPosts } from '@/lib/blog'
+import { getShowcaseItems } from '@/lib/showcase'
+import CommandPalette from './CommandPalette'
+import { STATIC_PALETTE_ENTRIES } from './static-index'
+import type { PaletteEntry } from './types'
+
+/**
+ * Server-side palette hydrator. Reads blog posts + showcase items
+ * through their cached helpers (each wrapped in 'use cache' with
+ * 'hours' lifetime) and passes a single merged entries array to the
+ * client component. Both fetchers return `[]` on failure so the
+ * palette degrades gracefully when the database is unreachable.
+ */
+export default async function CommandPaletteData() {
+	const [postsResult, showcase] = await Promise.all([
+		getPosts({ limit: 50 }),
+		getShowcaseItems()
+	])
+
+	const blogEntries: PaletteEntry[] = postsResult.posts.map(post => ({
+		id: `blog:${post.slug}`,
+		label: post.title,
+		description: post.excerpt || undefined,
+		href: `/blog/${post.slug}`,
+		group: 'Blog',
+		keywords: post.tags.map(t => t.name)
+	}))
+
+	const showcaseEntries: PaletteEntry[] = showcase.map(item => ({
+		id: `showcase:${item.slug}`,
+		label: item.title,
+		href: `/showcase/${item.slug}`,
+		group: 'Showcase'
+	}))
+
+	const entries: PaletteEntry[] = [
+		...STATIC_PALETTE_ENTRIES,
+		...blogEntries,
+		...showcaseEntries
+	]
+
+	return <CommandPalette entries={entries} />
+}

--- a/src/components/cmdk/CommandPaletteTrigger.tsx
+++ b/src/components/cmdk/CommandPaletteTrigger.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+/**
+ * Discoverability affordance for the global command palette. Opens the
+ * palette by dispatching the `palette:open` window event that
+ * `CommandPalette.tsx` listens for. Keyboard users can still trigger
+ * via Cmd+K / Ctrl+K without ever seeing this button (it is hidden on
+ * narrow viewports where the hint would crowd the nav).
+ *
+ * Detects platform on mount to render the correct modifier glyph
+ * ("Cmd" on Apple, "Ctrl" elsewhere). Defaults to "Ctrl" during SSR
+ * so the markup is deterministic.
+ */
+export default function CommandPaletteTrigger() {
+	const [modifier, setModifier] = useState<'Ctrl' | 'Cmd'>('Ctrl')
+
+	useEffect(() => {
+		const platform =
+			typeof navigator === 'undefined' ? '' : navigator.platform || ''
+		if (/(Mac|iPhone|iPad|iPod)/i.test(platform)) {
+			setModifier('Cmd')
+		}
+	}, [])
+
+	const handleClick = () => {
+		window.dispatchEvent(new CustomEvent('palette:open'))
+	}
+
+	return (
+		<button
+			type="button"
+			onClick={handleClick}
+			aria-label="Open command palette"
+			className={cn(
+				'hidden lg:inline-flex items-center gap-2 px-3 py-1.5 rounded-md',
+				'text-xs text-muted-foreground',
+				'border border-border hover:text-foreground hover:bg-muted',
+				'transition-smooth focus-ring'
+			)}
+		>
+			<Search className="h-3.5 w-3.5" aria-hidden="true" />
+			<span>Search</span>
+			<span
+				className="flex items-center gap-1 ml-1 text-[10px] font-mono opacity-80"
+				aria-hidden="true"
+			>
+				<kbd className="px-1.5 py-0.5 rounded border border-border bg-muted/50">
+					{modifier}
+				</kbd>
+				<kbd className="px-1.5 py-0.5 rounded border border-border bg-muted/50">
+					K
+				</kbd>
+			</span>
+		</button>
+	)
+}

--- a/src/components/cmdk/static-index.ts
+++ b/src/components/cmdk/static-index.ts
@@ -1,0 +1,146 @@
+import { TOOLS } from '@/app/(public)/tools/tools-data'
+import { ROUTES } from '@/lib/constants/routes'
+import type { PaletteEntry } from './types'
+
+/**
+ * Public top-level pages exposed in the command palette. Order is the
+ * order the operator wants the items to appear when there's no query.
+ * Utility pages (`/unsubscribe`) and dynamic listings whose value lives
+ * in their detail pages (the Blog/Showcase indexes themselves still
+ * appear because users may want to land on the listing) are included
+ * only when there's a clear discovery use case. Admin-only routes are
+ * never listed here.
+ */
+const PAGE_ENTRIES: readonly PaletteEntry[] = [
+	{
+		id: 'page:home',
+		label: 'Home',
+		description: 'Hudson Digital Solutions homepage',
+		href: ROUTES.HOME,
+		group: 'Pages',
+		keywords: ['index', 'landing']
+	},
+	{
+		id: 'page:services',
+		label: 'Services',
+		description: 'Website design, SEO, booking and payments',
+		href: ROUTES.SERVICES,
+		group: 'Pages',
+		keywords: ['offerings', 'what we do']
+	},
+	{
+		id: 'page:showcase',
+		label: 'Showcase',
+		description: 'Recent client work',
+		href: ROUTES.SHOWCASE,
+		group: 'Pages',
+		keywords: ['portfolio', 'projects', 'examples']
+	},
+	{
+		id: 'page:about',
+		label: 'About',
+		description: 'About Hudson Digital Solutions',
+		href: ROUTES.ABOUT,
+		group: 'Pages'
+	},
+	{
+		id: 'page:contact',
+		label: 'Contact',
+		description: 'Get your free website plan',
+		href: ROUTES.CONTACT,
+		group: 'Pages',
+		keywords: ['quote', 'consultation', 'reach out']
+	},
+	{
+		id: 'page:tools',
+		label: 'Tools',
+		description: 'Free business calculators and utilities',
+		href: '/tools',
+		group: 'Pages',
+		keywords: ['calculators', 'utilities']
+	},
+	{
+		id: 'page:blog',
+		label: 'Blog',
+		description: 'Practical insights for small businesses',
+		href: ROUTES.BLOG,
+		group: 'Pages',
+		keywords: ['articles', 'posts']
+	},
+	{
+		id: 'page:testimonials',
+		label: 'Testimonials',
+		description: 'Real results from real clients',
+		href: ROUTES.TESTIMONIALS,
+		group: 'Pages',
+		keywords: ['reviews', 'social proof']
+	},
+	{
+		id: 'page:faq',
+		label: 'FAQ',
+		description: 'Frequently asked questions',
+		href: ROUTES.FAQ,
+		group: 'Pages',
+		keywords: ['questions', 'help']
+	},
+	{
+		id: 'page:help',
+		label: 'Help',
+		description: 'Help articles and how-tos',
+		href: ROUTES.HELP,
+		group: 'Pages',
+		keywords: ['docs', 'support']
+	},
+	{
+		id: 'page:locations',
+		label: 'Locations',
+		description: 'Service areas we cover',
+		href: ROUTES.LOCATIONS,
+		group: 'Pages',
+		keywords: ['areas', 'cities', 'regions']
+	},
+	{
+		id: 'page:website-migration',
+		label: 'Website Migration',
+		description: 'Move an existing site without losing search rankings',
+		href: ROUTES.WEBSITE_MIGRATION,
+		group: 'Pages',
+		keywords: ['transfer', 'replatform']
+	},
+	{
+		id: 'page:switch-from-thryv',
+		label: 'Switch from Thryv',
+		description: 'How to leave Thryv and what to expect',
+		href: ROUTES.SWITCH_FROM_THRYV,
+		group: 'Pages',
+		keywords: ['thryv', 'migration']
+	},
+	{
+		id: 'page:privacy',
+		label: 'Privacy Policy',
+		href: ROUTES.PRIVACY,
+		group: 'Pages',
+		keywords: ['legal']
+	},
+	{
+		id: 'page:terms',
+		label: 'Terms of Service',
+		href: ROUTES.TERMS,
+		group: 'Pages',
+		keywords: ['legal']
+	}
+]
+
+const TOOL_ENTRIES: readonly PaletteEntry[] = TOOLS.map(tool => ({
+	id: `tool:${tool.href.replace(/^\/tools\//, '')}`,
+	label: tool.title,
+	description: tool.description,
+	href: tool.href,
+	group: 'Tools' as const,
+	keywords: tool.benefits
+}))
+
+export const STATIC_PALETTE_ENTRIES: readonly PaletteEntry[] = [
+	...TOOL_ENTRIES,
+	...PAGE_ENTRIES
+]

--- a/src/components/cmdk/types.ts
+++ b/src/components/cmdk/types.ts
@@ -22,8 +22,3 @@ export interface PaletteEntry {
 	/** Extra search terms beyond label + description. */
 	readonly keywords?: readonly string[]
 }
-
-export interface PaletteData {
-	readonly staticEntries: readonly PaletteEntry[]
-	readonly dynamicEntries: readonly PaletteEntry[]
-}

--- a/src/components/cmdk/types.ts
+++ b/src/components/cmdk/types.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared types for the global command palette (audit #263).
+ *
+ * The palette indexes static surfaces (tools, top-level public routes) and
+ * dynamic surfaces (recent blog posts, showcase items) into a single uniform
+ * shape so the client component renders one CommandGroup per group with no
+ * type narrowing at render time.
+ */
+
+export type PaletteGroup = 'Tools' | 'Pages' | 'Blog' | 'Showcase'
+
+export interface PaletteEntry {
+	/** Stable unique id used as React key + cmdk value. Format: `<kind>:<slug>`. */
+	readonly id: string
+	/** Visible label rendered in the CommandItem. */
+	readonly label: string
+	/** Optional secondary text rendered below the label. */
+	readonly description?: string
+	/** Internal href passed to router.push on select. */
+	readonly href: string
+	readonly group: PaletteGroup
+	/** Extra search terms beyond label + description. */
+	readonly keywords?: readonly string[]
+}
+
+export interface PaletteData {
+	readonly staticEntries: readonly PaletteEntry[]
+	readonly dynamicEntries: readonly PaletteEntry[]
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -4,6 +4,7 @@ import { ArrowRight, Menu, Rocket, X } from 'lucide-react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { memo, useCallback, useEffect, useState } from 'react'
+import CommandPaletteTrigger from '@/components/cmdk/CommandPaletteTrigger'
 import { Button } from '@/components/ui/button'
 import { ROUTES, TOOL_ROUTES } from '@/lib/constants/routes'
 import { cn } from '@/lib/utils'
@@ -110,6 +111,7 @@ const Navbar = memo(function Navbar() {
 
 					{/* Right — CTAs */}
 					<div className="flex-1 flex items-center justify-end gap-2">
+						<CommandPaletteTrigger />
 						<div className="hidden sm:flex items-center gap-2">
 							<Button
 								asChild

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -13,6 +13,9 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 
+// Not exported: only CommandDialog (below) consumes the root primitive in
+// this codebase. Keeping it internal keeps knip clean (the project prunes
+// unused shadcn surface rather than re-exporting the full registry).
 function Command({
 	className,
 	...props
@@ -147,7 +150,6 @@ function CommandItem({
 }
 
 export {
-	Command,
 	CommandDialog,
 	CommandEmpty,
 	CommandGroup,

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import type * as DialogPrimitive from '@radix-ui/react-dialog'
 import { Command as CommandPrimitive } from 'cmdk'
 import { SearchIcon } from 'lucide-react'
 import type * as React from 'react'
@@ -45,14 +44,18 @@ function CommandDialog({
 }) {
 	return (
 		<Dialog {...props}>
-			<DialogHeader className="sr-only">
-				<DialogTitle>{title}</DialogTitle>
-				<DialogDescription>{description}</DialogDescription>
-			</DialogHeader>
 			<DialogContent
 				className={cn('overflow-hidden p-0', className)}
 				showCloseButton={showCloseButton}
 			>
+				{/* Title/Description MUST be descendants of DialogContent so
+				    Radix wires aria-labelledby/aria-describedby onto the
+				    content node and the dialog is announced (and so Radix
+				    doesn't emit its missing-title warning). */}
+				<DialogHeader className="sr-only">
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>{description}</DialogDescription>
+				</DialogHeader>
 				<Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
 					{children}
 				</Command>
@@ -127,19 +130,6 @@ function CommandGroup({
 	)
 }
 
-function CommandSeparator({
-	className,
-	...props
-}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
-	return (
-		<CommandPrimitive.Separator
-			data-slot="command-separator"
-			className={cn('bg-border -mx-1 h-px', className)}
-			{...props}
-		/>
-	)
-}
-
 function CommandItem({
 	className,
 	...props
@@ -156,28 +146,6 @@ function CommandItem({
 	)
 }
 
-function CommandShortcut({
-	className,
-	...props
-}: React.ComponentProps<'span'>) {
-	return (
-		<span
-			data-slot="command-shortcut"
-			className={cn(
-				'text-muted-foreground ml-auto text-xs tracking-widest',
-				className
-			)}
-			{...props}
-		/>
-	)
-}
-
-// Re-export DialogPrimitive types so consumers don't need to import Radix
-// directly when they need the open-state-change handler shape.
-export type CommandDialogOpenChange = NonNullable<
-	React.ComponentProps<typeof DialogPrimitive.Root>['onOpenChange']
->
-
 export {
 	Command,
 	CommandDialog,
@@ -185,7 +153,5 @@ export {
 	CommandGroup,
 	CommandInput,
 	CommandItem,
-	CommandList,
-	CommandSeparator,
-	CommandShortcut
+	CommandList
 }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import type * as DialogPrimitive from '@radix-ui/react-dialog'
+import { Command as CommandPrimitive } from 'cmdk'
+import { SearchIcon } from 'lucide-react'
+import type * as React from 'react'
+
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle
+} from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+
+function Command({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+	return (
+		<CommandPrimitive
+			data-slot="command"
+			className={cn(
+				'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+function CommandDialog({
+	title = 'Command palette',
+	description = 'Search for a page, tool, or recent post.',
+	children,
+	className,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof Dialog> & {
+	title?: string
+	description?: string
+	className?: string
+	showCloseButton?: boolean
+}) {
+	return (
+		<Dialog {...props}>
+			<DialogHeader className="sr-only">
+				<DialogTitle>{title}</DialogTitle>
+				<DialogDescription>{description}</DialogDescription>
+			</DialogHeader>
+			<DialogContent
+				className={cn('overflow-hidden p-0', className)}
+				showCloseButton={showCloseButton}
+			>
+				<Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+					{children}
+				</Command>
+			</DialogContent>
+		</Dialog>
+	)
+}
+
+function CommandInput({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+	return (
+		<div
+			data-slot="command-input-wrapper"
+			className="flex h-9 items-center gap-2 border-b px-3"
+		>
+			<SearchIcon className="size-4 shrink-0 opacity-50" aria-hidden="true" />
+			<CommandPrimitive.Input
+				data-slot="command-input"
+				className={cn(
+					'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+					className
+				)}
+				{...props}
+			/>
+		</div>
+	)
+}
+
+function CommandList({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+	return (
+		<CommandPrimitive.List
+			data-slot="command-list"
+			className={cn(
+				'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+function CommandEmpty({
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+	return (
+		<CommandPrimitive.Empty
+			data-slot="command-empty"
+			className="py-6 text-center text-sm"
+			{...props}
+		/>
+	)
+}
+
+function CommandGroup({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+	return (
+		<CommandPrimitive.Group
+			data-slot="command-group"
+			className={cn(
+				'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+function CommandSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+	return (
+		<CommandPrimitive.Separator
+			data-slot="command-separator"
+			className={cn('bg-border -mx-1 h-px', className)}
+			{...props}
+		/>
+	)
+}
+
+function CommandItem({
+	className,
+	...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+	return (
+		<CommandPrimitive.Item
+			data-slot="command-item"
+			className={cn(
+				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+function CommandShortcut({
+	className,
+	...props
+}: React.ComponentProps<'span'>) {
+	return (
+		<span
+			data-slot="command-shortcut"
+			className={cn(
+				'text-muted-foreground ml-auto text-xs tracking-widest',
+				className
+			)}
+			{...props}
+		/>
+	)
+}
+
+// Re-export DialogPrimitive types so consumers don't need to import Radix
+// directly when they need the open-state-change handler shape.
+export type CommandDialogOpenChange = NonNullable<
+	React.ComponentProps<typeof DialogPrimitive.Root>['onOpenChange']
+>
+
+export {
+	Command,
+	CommandDialog,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandSeparator,
+	CommandShortcut
+}

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -18,7 +18,12 @@ export const ROUTES = {
 	WEBSITE_MIGRATION: '/website-migration',
 	PRIVACY: '/privacy',
 	TERMS: '/terms',
-	BLOG: '/blog'
+	BLOG: '/blog',
+	FAQ: '/faq',
+	HELP: '/help',
+	LOCATIONS: '/locations',
+	SWITCH_FROM_THRYV: '/switch-from-thryv',
+	TESTIMONIALS: '/testimonials'
 } as const
 
 /** Tool pages */

--- a/tests/unit/cmdk-static-index.test.ts
+++ b/tests/unit/cmdk-static-index.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Lock the static palette index contract:
+ *
+ *   - ids are unique (cmdk uses value-based deduping, but stable keys
+ *     prevent React reconciler churn when re-rendering).
+ *   - every entry resolves to an in-app route (`/...`), never an
+ *     external URL or anchor — the palette routes via Next.js's
+ *     useRouter and would not handle protocols.
+ *   - labels and descriptions never contain em-dash or en-dash, which
+ *     CLAUDE.md forbids in user-facing strings.
+ *   - every TOOLS entry from src/app/(public)/tools/tools-data.ts has
+ *     a corresponding palette entry, so adding a tool surfaces it in
+ *     the palette automatically. Audit #263.
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import { TOOLS } from '@/app/(public)/tools/tools-data'
+import { STATIC_PALETTE_ENTRIES } from '@/components/cmdk/static-index'
+
+const EM_DASH = String.fromCharCode(0x2014)
+const EN_DASH = String.fromCharCode(0x2013)
+
+describe('STATIC_PALETTE_ENTRIES', () => {
+	test('every id is unique', () => {
+		const ids = STATIC_PALETTE_ENTRIES.map(e => e.id)
+		const unique = new Set(ids)
+		expect(unique.size).toBe(ids.length)
+	})
+
+	test('every href starts with `/`', () => {
+		for (const entry of STATIC_PALETTE_ENTRIES) {
+			expect(entry.href.startsWith('/')).toBe(true)
+		}
+	})
+
+	test('no em-dash or en-dash in labels or descriptions', () => {
+		for (const entry of STATIC_PALETTE_ENTRIES) {
+			const corpus = `${entry.label} ${entry.description ?? ''}`
+			expect(corpus.includes(EM_DASH)).toBe(false)
+			expect(corpus.includes(EN_DASH)).toBe(false)
+		}
+	})
+
+	test('every TOOLS entry is represented exactly once', () => {
+		const toolHrefs = TOOLS.map(t => t.href).sort()
+		const palettedToolHrefs = STATIC_PALETTE_ENTRIES.filter(
+			e => e.group === 'Tools'
+		)
+			.map(e => e.href)
+			.sort()
+		expect(palettedToolHrefs).toEqual(toolHrefs)
+	})
+
+	test('group assignments only use the canonical four groups', () => {
+		const allowed = new Set(['Tools', 'Pages', 'Blog', 'Showcase'])
+		for (const entry of STATIC_PALETTE_ENTRIES) {
+			expect(allowed.has(entry.group)).toBe(true)
+		}
+	})
+})


### PR DESCRIPTION
## Summary

Audit #263: visitors had no shortcut to jump between pages, tools, or recent posts. cmdk gives the Vercel/Linear-style global palette that bypasses categorical navigation entirely.

### Architecture

- **shadcn `command` primitive** (`src/components/ui/command.tsx`) — hand-written to match the project's new-york-style shadcn conventions, wraps the existing Dialog primitive so the palette inherits the focus trap, escape-to-close, and overlay click. cmdk itself owns combobox/listbox ARIA and arrow-key navigation.
- **Server / client split** for SSR safety:
  - `CommandPaletteData.tsx` (server): reads `getPosts({limit:50})` + `getShowcaseItems()` through their cached helpers and hands a flat `PaletteEntry[]` to the client component.
  - `CommandPalette.tsx` (client): owns open/close state, the `Cmd+K`/`Ctrl+K` listener (with text-input guard + `e.preventDefault`), and a `palette:open` CustomEvent listener so any client component can request open without prop-drilling.
- **`static-index.ts`** composes 12 TOOLS entries + 15 public-route entries with stable ids and keyword arrays.
- **`CommandPaletteTrigger.tsx`** (button in Navbar) — visible affordance with a platform-aware \`Cmd K\` / \`Ctrl K\` kbd hint.
- Mounted as a Suspense-wrapped sibling of `NavbarLight` in the (public) layout. Singleton across marketing routes; admin/auth intentionally excluded.

### Other

- `components.json` css path corrected from \`app/globals.css\` to \`src/app/globals.css\` so future \`bunx shadcn add\` calls write to the real theme file.
- `ROUTES` extended with `FAQ`, `HELP`, `LOCATIONS`, `SWITCH_FROM_THRYV`, `TESTIMONIALS` — public dirs that existed but weren't in the constant.
- Unit tests lock the static-index contract (unique ids, internal hrefs, no em/en-dashes, every TOOLS entry represented, only canonical groups).

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun run lint\`
- [x] \`bun run build\` (production)
- [x] \`bun test tests/\` — 782 pass (5 new in tests/unit/cmdk-static-index.test.ts)
- [ ] Visual: Cmd+K opens palette, search filters, Enter navigates, Esc closes, trigger button visible at \`lg\` breakpoint+
- [ ] Visual: keyboard shortcut does not hijack typing in text inputs/textareas
- [ ] Visual: palette opens via the trigger button on platforms where Cmd K isn't reachable

Designed via parallel-scout workflow `wers2axhv` (4 parallel scouts + synthesis). No open questions surfaced.

[hudsor01]