### PR TITLE
chore(scripts): Neon orphan preview-branch cleanup script

### DIFF
--- a/scripts/neon-cleanup-orphans.sh
+++ b/scripts/neon-cleanup-orphans.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Delete orphan Neon preview branches that survived their PR closing,
+# freeing quota slots so future PRs don't fail at "Create Neon Branch".
+#
+# Usage:
+#   1. Put your Neon API key in .env.neon.local (NEON_API_KEY=...)
+#   2. Run from project root:   bash scripts/neon-cleanup-orphans.sh
+#
+# Refuses to delete `main` and `vercel-dev`. Prints the post-cleanup
+# inventory so you can confirm the project is back under the quota cap.
+
+set -euo pipefail
+
+PROJECT_ID="soft-bush-38066584"
+ENV_FILE=".env.neon.local"
+API="https://console.neon.tech/api/v2"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+	echo "Missing $ENV_FILE — paste NEON_API_KEY there first." >&2
+	exit 1
+fi
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+
+if [[ -z "${NEON_API_KEY:-}" ]]; then
+	echo "NEON_API_KEY is empty in $ENV_FILE." >&2
+	exit 1
+fi
+
+# Identified by the failure-diagnostic step on PR #302
+# (commit fd4216a). Refresh by re-running the diagnostic if the list
+# drifts.
+ORPHANS=(
+	"preview/chore/audit-fix-visual-polish"
+	"preview/chore/audit-fix-form-polish"
+	"preview/chore/audit-fix-copy-voice-dates"
+	"preview/chore/v5-audit"
+	"preview/pr-227-chore/v5-audit"
+	"preview/pr-297-chore/audit-fix-copy-voice-dates"
+	"preview/dependabot/npm_and_yarn/react-email-6.3.3"
+	"preview/dependabot/npm_and_yarn/production-dependencies-91f93ffcad"
+)
+PROTECTED=("main" "vercel-dev")
+
+echo "Fetching current branch inventory..."
+all=$(curl -sS -H "Authorization: Bearer $NEON_API_KEY" \
+	"$API/projects/$PROJECT_ID/branches")
+
+before=$(jq -r '.branches | length' <<<"$all")
+echo "Before: $before branches"
+echo
+
+for name in "${ORPHANS[@]}"; do
+	for guard in "${PROTECTED[@]}"; do
+		if [[ "$name" == "$guard" ]]; then
+			echo "REFUSING to touch protected branch '$name'"
+			continue 2
+		fi
+	done
+
+	bid=$(jq -r --arg n "$name" '.branches[] | select(.name==$n) | .id' <<<"$all")
+	if [[ -z "$bid" ]]; then
+		printf '  skip   %s (not present)\n' "$name"
+		continue
+	fi
+
+	printf '  delete %-65s id=%s ... ' "$name" "$bid"
+	code=$(curl -sS -o /tmp/neon-del.json -w "%{http_code}" -X DELETE \
+		-H "Authorization: Bearer $NEON_API_KEY" \
+		"$API/projects/$PROJECT_ID/branches/$bid")
+	echo "HTTP $code"
+	if [[ ! "$code" =~ ^2 ]]; then
+		cat /tmp/neon-del.json
+		echo
+	fi
+done
+
+echo
+echo "Post-cleanup inventory:"
+curl -sS -H "Authorization: Bearer $NEON_API_KEY" \
+	"$API/projects/$PROJECT_ID/branches" \
+	| jq '{count:(.branches|length),names:[.branches[].name]}'


### PR DESCRIPTION
## Summary

Codify the recovery path for the Neon \`BRANCHES_LIMIT_EXCEEDED\` failure we hit earlier today. The diagnostic step shipped in PR #302 makes the cause visible; this makes the cleanup reproducible without having to copy-paste a one-off curl pipeline next time.

- \`scripts/neon-cleanup-orphans.sh\` reads \`NEON_API_KEY\` from \`.env.neon.local\` (gitignored by the existing \`.env*\` rule), iterates a hardcoded ORPHANS list, refuses to touch \`main\` and \`vercel-dev\`, deletes each branch via Neon's v2 API, and prints before/after inventory.
- Run from project root with \`bash scripts/neon-cleanup-orphans.sh\`.
- If the leak recurs, refresh the ORPHANS list from the diagnostic step's \"Branch inventory\" group in the failed workflow run.

## Test plan

- [x] Already used end-to-end today: 8 orphans deleted, project back at 2/10 branches, next PR succeeded at \"Create Neon Branch\"

[hudsor01]