### PR TITLE
chore: unexport ToolCategoryId to satisfy knip

### DIFF
--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -14,7 +14,9 @@ import {
 } from 'lucide-react'
 import { TOOL_ROUTES } from '@/lib/constants/routes'
 
-export type ToolCategoryId = 'website' | 'business' | 'developers'
+// Not exported: only referenced internally by ToolCategory/ToolEntry below.
+// No external module imports it, so keeping it unexported satisfies knip.
+type ToolCategoryId = 'website' | 'business' | 'developers'
 
 export interface ToolCategory {
 	id: ToolCategoryId


### PR DESCRIPTION
## Summary

Clears the last `knip` "unused exported type" finding (pre-existing from #301). `ToolCategoryId` is only referenced internally by `ToolCategory.id` and `ToolEntry.category`; no module imports it, so dropping the `export` keyword resolves the finding with zero behavior change.

After this, `bun run knip` reports **zero** unused exports/types.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run knip` (exit 0, clean)

[hudsor01]