### PR TITLE
chore(deps): bump react-error-boundary 6.1.1 to 6.1.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "lucide-react": "1.16.0",
         "nuqs": "2.8.9",
         "react-email": "6.1.1",
-        "react-error-boundary": "6.1.1",
+        "react-error-boundary": "6.1.2",
         "react-markdown": "10.1.0",
         "recharts": "3.8.1",
         "resend": "6.12.3",
@@ -1523,7 +1523,7 @@
 
     "react-email": ["react-email@6.1.1", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.8", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "^0.28.0", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.6", "picospinner": "^3.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" }, "bin": { "email": "./dist/cli/index.mjs" } }, "sha512-5wITcaKhYPsW8IAx4d2zRCtKq0JJydxlH4qCfy1bltreRDIAbfJUdlW6gCiLMsFJN/QvC4r5adlIaqvJgRgXMw=="],
 
-    "react-error-boundary": ["react-error-boundary@6.1.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w=="],
+    "react-error-boundary": ["react-error-boundary@6.1.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"lucide-react": "1.16.0",
 		"nuqs": "2.8.9",
 		"react-email": "6.1.1",
-		"react-error-boundary": "6.1.1",
+		"react-error-boundary": "6.1.2",
 		"react-markdown": "10.1.0",
 		"recharts": "3.8.1",
 		"resend": "6.12.3",


### PR DESCRIPTION
Supersedes dependabot #219, which conflicted with today's `package.json`/`bun.lock` changes (cmdk addition) and had only the Vercel check run (the main CI workflow doesn't trigger on dependabot PRs, so it was never typecheck/lint/test-verified).

Rebased onto current `main` and verified. Single consumer: `src/components/utilities/ErrorBoundary.tsx`. Patch release (README + types only per upstream).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test tests/` (782 pass)

Closes #219.

[hudsor01]