### PR TITLE
chore(deps): bump react-email 6.1.1 to 6.3.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "drizzle-orm": "0.45.2",
         "lucide-react": "1.16.0",
         "nuqs": "2.8.9",
-        "react-email": "6.1.1",
+        "react-email": "6.3.3",
         "react-error-boundary": "6.1.2",
         "react-markdown": "10.1.0",
         "recharts": "3.8.1",
@@ -1521,7 +1521,7 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
-    "react-email": ["react-email@6.1.1", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.8", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "^0.28.0", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.6", "picospinner": "^3.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" }, "bin": { "email": "./dist/cli/index.mjs" } }, "sha512-5wITcaKhYPsW8IAx4d2zRCtKq0JJydxlH4qCfy1bltreRDIAbfJUdlW6gCiLMsFJN/QvC4r5adlIaqvJgRgXMw=="],
+    "react-email": ["react-email@6.3.3", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.8", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "^0.28.0", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.6", "picospinner": "^3.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" }, "bin": { "email": "./dist/cli/index.mjs" } }, "sha512-mkHgVfuoDLM1To/u0ZcdJy/3q1Z3SdOe1A5/GtsUqApP68RQOztBe+AOk3BIJC1POexnqwDZZwV+Pw+srVlH7Q=="],
 
     "react-error-boundary": ["react-error-boundary@6.1.2", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"drizzle-orm": "0.45.2",
 		"lucide-react": "1.16.0",
 		"nuqs": "2.8.9",
-		"react-email": "6.1.1",
+		"react-email": "6.3.3",
 		"react-error-boundary": "6.1.2",
 		"react-markdown": "10.1.0",
 		"recharts": "3.8.1",


### PR DESCRIPTION
Recreated on current `main` after #306 (react-error-boundary) merged and made the prior branch (#307) conflict on `package.json`/`bun.lock`. Supersedes #307 and the original dependabot #220.

All 10 templates in `src/emails/` import components from `'react-email'`; emails send via Resend's `react:` field (no explicit `render()`), so template compilation is the gate.

## Verification (on post-#306 base)
- All 13 imported components still exported by 6.3.3
- `bun run typecheck` clean
- `bun run lint` clean
- `bun run build` exit 0 (compiles every email template)
- `bun test tests/` — 782 pass (verified earlier)

[hudsor01]