### PR TITLE
feat(tools): add Comma Separator (column to comma-separated series)

### DIFF
--- a/src/app/(public)/tools/comma-separator/CommaSeparatorClient.tsx
+++ b/src/app/(public)/tools/comma-separator/CommaSeparatorClient.tsx
@@ -1,0 +1,179 @@
+/**
+ * Comma Separator
+ * Turn a space, tab, or newline separated list into a comma-separated one.
+ */
+
+'use client'
+
+import { useId, useMemo, useState } from 'react'
+import type { ToolAction } from '@/components/layout/ToolPageLayout'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { trackEvent } from '@/lib/analytics'
+import {
+	commaSeparate,
+	countItems,
+	type QuoteStyle
+} from '@/lib/list-formatter'
+import { logger } from '@/lib/logger'
+
+const QUOTE_OPTIONS: ReadonlyArray<{ value: QuoteStyle; label: string }> = [
+	{ value: 'none', label: 'None' },
+	{ value: 'single', label: "Single ' '" },
+	{ value: 'double', label: 'Double " "' }
+]
+
+// Multi-line so the placeholder itself demonstrates the headline use
+// case: pasting a column of values (one per line) from a spreadsheet.
+const PLACEHOLDER = '1\n2\n3\n4\n5'
+
+export default function CommaSeparatorClient() {
+	const [input, setInput] = useState('')
+	const [quote, setQuote] = useState<QuoteStyle>('none')
+	const [dedupe, setDedupe] = useState(false)
+	const quoteFieldId = useId()
+	const dedupeFieldId = useId()
+
+	const output = useMemo(
+		() => commaSeparate(input, { quote, dedupe }),
+		[input, quote, dedupe]
+	)
+	const itemCount = useMemo(
+		() => countItems(input, { dedupe }),
+		[input, dedupe]
+	)
+	const hasResult = output.length > 0
+
+	const copyToClipboard = async () => {
+		if (!output) {
+			return
+		}
+		try {
+			await navigator.clipboard.writeText(output)
+			trackEvent('calculator_used', {
+				calculator_type: 'comma-separator',
+				action: 'copy',
+				item_count: itemCount
+			})
+		} catch (error) {
+			// Fallback for browsers without the async clipboard API.
+			logger.debug('Clipboard API unavailable, using fallback', {
+				error: error instanceof Error ? error.message : String(error)
+			})
+			const textArea = document.createElement('textarea')
+			textArea.value = output
+			document.body.appendChild(textArea)
+			textArea.select()
+			document.execCommand('copy')
+			document.body.removeChild(textArea)
+		}
+	}
+
+	const clearAll = () => {
+		setInput('')
+	}
+
+	const actions: ToolAction[] = [
+		{ type: 'copy', label: 'Copy', onClick: copyToClipboard }
+	]
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			<div>
+				<div className="flex items-center justify-between mb-subheading">
+					<label
+						htmlFor="comma-separator-input"
+						className="block text-sm font-medium text-foreground"
+					>
+						Your column or list
+					</label>
+					<button
+						type="button"
+						onClick={clearAll}
+						className="text-xs text-muted-foreground hover:text-foreground"
+					>
+						Clear
+					</button>
+				</div>
+				<textarea
+					id="comma-separator-input"
+					value={input}
+					onChange={event => setInput(event.target.value)}
+					className="w-full rounded-md border border-border bg-background px-4 py-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-accent"
+					rows={8}
+					placeholder={PLACEHOLDER}
+					spellCheck={false}
+				/>
+				<p className="mt-2 text-xs text-muted-foreground">
+					Paste a column of values (one per line) from a spreadsheet, or any
+					space or tab separated list. Items are joined with a comma and a
+					space.
+				</p>
+			</div>
+
+			<div className="flex flex-wrap items-center gap-content">
+				<div className="flex items-center gap-tight">
+					<label
+						htmlFor={quoteFieldId}
+						className="text-sm text-muted-foreground"
+					>
+						Wrap each item:
+					</label>
+					<select
+						id={quoteFieldId}
+						value={quote}
+						onChange={event => setQuote(event.target.value as QuoteStyle)}
+						className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+					>
+						{QUOTE_OPTIONS.map(option => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<label
+					htmlFor={dedupeFieldId}
+					className="flex items-center gap-tight text-sm text-muted-foreground"
+				>
+					<input
+						id={dedupeFieldId}
+						type="checkbox"
+						checked={dedupe}
+						onChange={event => setDedupe(event.target.checked)}
+						className="rounded border-border text-accent focus:ring-accent"
+					/>
+					Remove duplicates
+				</label>
+			</div>
+		</div>
+	)
+
+	const resultSlot = output ? (
+		<div>
+			<pre className="w-full rounded-md border border-border bg-background p-4 overflow-x-auto">
+				<code className="text-sm text-foreground whitespace-pre-wrap break-all font-mono">
+					{output}
+				</code>
+			</pre>
+			<div className="mt-2 flex gap-content text-xs text-muted-foreground">
+				<span>
+					{itemCount} {itemCount === 1 ? 'item' : 'items'}
+				</span>
+			</div>
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="Comma Separator"
+			description="Convert a column of values into a comma-separated series. Paste a spreadsheet column or any space-separated list."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Paste a column on the left to see it as a comma-separated series"
+			actions={actions}
+		/>
+	)
+}

--- a/src/app/(public)/tools/comma-separator/page.tsx
+++ b/src/app/(public)/tools/comma-separator/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * Comma Separator
+ * Convert space/tab/newline separated lists into comma-separated text.
+ */
+
+import type { Metadata } from 'next'
+import CommaSeparatorClient from './CommaSeparatorClient'
+
+export const metadata: Metadata = {
+	title: 'Comma Separator - Column to Comma Separated List | Hudson Digital',
+	description:
+		'Free tool to convert a column of values into a comma-separated list. Paste a spreadsheet column or space-separated list and get a clean comma-separated series, with optional quotes.'
+}
+
+export default function CommaSeparatorPage() {
+	return <CommaSeparatorClient />
+}

--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -7,6 +7,7 @@ import {
 	FileSignature,
 	FileText,
 	Home,
+	List,
 	Receipt,
 	Tags,
 	TrendingUp,
@@ -228,6 +229,20 @@ export const TOOLS: readonly ToolEntry[] = [
 			'Syntax error detection'
 		],
 		cta: 'Format JSON',
+		category: 'developers'
+	},
+	{
+		title: 'Comma Separator',
+		description:
+			'Convert a column of values into a comma-separated series. Paste a spreadsheet column or any space-separated list and get clean, comma-separated output.',
+		href: TOOL_ROUTES.COMMA_SEPARATOR,
+		Icon: List,
+		benefits: [
+			'Spreadsheet column to comma-separated series',
+			'Optional single or double quotes',
+			'Remove duplicate items'
+		],
+		cta: 'Separate List',
 		category: 'developers'
 	}
 	// The Testimonial Collector tool is admin-only (gated behind an

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -41,5 +41,6 @@ export const TOOL_ROUTES = {
 	PROPOSAL_GENERATOR: '/tools/proposal-generator',
 	JSON_FORMATTER: '/tools/json-formatter',
 	META_TAG_GENERATOR: '/tools/meta-tag-generator',
+	COMMA_SEPARATOR: '/tools/comma-separator',
 	TESTIMONIAL_COLLECTOR: '/tools/testimonial-collector'
 } as const

--- a/src/lib/list-formatter.ts
+++ b/src/lib/list-formatter.ts
@@ -1,0 +1,85 @@
+/**
+ * List formatter utilities.
+ *
+ * Converts a loosely-separated list (spaces, tabs, newlines, or a mix)
+ * into a clean comma-separated list. Built for the "Comma Separator"
+ * tool: paste `1 2 3 4 5`, get `1, 2, 3, 4, 5`.
+ */
+
+export type QuoteStyle = 'none' | 'single' | 'double'
+
+export interface CommaSeparateOptions {
+	/** Wrap each item in quotes (for SQL `IN (...)` / array literals). Default 'none'. */
+	quote?: QuoteStyle
+	/** Drop duplicate items, keeping first occurrence. Default false. */
+	dedupe?: boolean
+}
+
+const QUOTE_CHAR: Record<QuoteStyle, string> = {
+	none: '',
+	single: "'",
+	double: '"'
+}
+
+const JOINER = ', '
+
+/**
+ * Split raw input into clean tokens.
+ *
+ * - Splits on runs of ANY whitespace (space, tab, newline, and Unicode
+ *   spaces like non-breaking space, since JS `\s` covers them), so a
+ *   pasted column or multi-space input both normalize.
+ * - Strips leading/trailing commas from each token. This makes the
+ *   transform idempotent: re-running it on `1, 2, 3` yields `1, 2, 3`
+ *   rather than `1,, 2,, 3`, and it tolerates input that is already
+ *   partly comma-separated. Commas INSIDE a token (e.g. `1,000`) are
+ *   preserved.
+ * - Drops empty tokens, so leading/trailing whitespace and blank lines
+ *   do not produce empty items.
+ */
+export function tokenizeList(input: string): string[] {
+	if (typeof input !== 'string' || input.length === 0) {
+		return []
+	}
+	return input
+		.split(/\s+/u)
+		.map(token => token.replace(/^,+|,+$/g, ''))
+		.filter(token => token.length > 0)
+}
+
+/**
+ * Number of items the output will contain. Pass the same options used
+ * for `commaSeparate` so the count matches the rendered list — most
+ * importantly, with `dedupe` on the count reflects the deduped result
+ * (otherwise the UI would show e.g. "5 items" beside a 3-item output).
+ */
+export function countItems(
+	input: string,
+	options: CommaSeparateOptions = {}
+): number {
+	const tokens = tokenizeList(input)
+	return options.dedupe ? new Set(tokens).size : tokens.length
+}
+
+/**
+ * Convert whitespace-separated input into a comma-separated string.
+ * Returns an empty string for blank/whitespace-only input.
+ */
+export function commaSeparate(
+	input: string,
+	options: CommaSeparateOptions = {}
+): string {
+	const { quote = 'none', dedupe = false } = options
+	const tokens = tokenizeList(input)
+	const items = dedupe ? Array.from(new Set(tokens)) : tokens
+	const wrap = QUOTE_CHAR[quote]
+	// Escape the quote char inside each token by doubling it (the SQL and
+	// ANSI standard: O'Brien -> 'O''Brien'). Without this, the quote
+	// option — advertised for SQL `IN (...)` and array literals — would
+	// emit unbalanced, injectable output for any value containing the
+	// quote character.
+	const rendered = wrap
+		? items.map(token => `${wrap}${token.replaceAll(wrap, wrap + wrap)}${wrap}`)
+		: items
+	return rendered.join(JOINER)
+}

--- a/tests/unit/list-formatter.test.ts
+++ b/tests/unit/list-formatter.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Comma Separator transform — contract + edge cases.
+ * Locks the behavior of src/lib/list-formatter.ts.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+	commaSeparate,
+	countItems,
+	tokenizeList
+} from '@/lib/list-formatter'
+
+describe('commaSeparate', () => {
+	test('the headline case: space separated numbers to comma list', () => {
+		expect(commaSeparate('1 2 3 4 5')).toBe('1, 2, 3, 4, 5')
+	})
+
+	test('words separated by spaces', () => {
+		expect(commaSeparate('apple banana cherry')).toBe('apple, banana, cherry')
+	})
+
+	test('collapses runs of multiple spaces', () => {
+		expect(commaSeparate('1   2  3')).toBe('1, 2, 3')
+	})
+
+	test('trims leading and trailing whitespace', () => {
+		expect(commaSeparate('   1 2 3   ')).toBe('1, 2, 3')
+	})
+
+	test('handles tabs as separators', () => {
+		expect(commaSeparate('1\t2\t3')).toBe('1, 2, 3')
+	})
+
+	test('handles newlines (a pasted column)', () => {
+		expect(commaSeparate('1\n2\n3')).toBe('1, 2, 3')
+	})
+
+	// The headline use case: a spreadsheet column (one value per line,
+	// often with a trailing newline and CRLF line endings from Windows).
+	test('converts a spreadsheet column (CRLF + trailing newline) to a series', () => {
+		expect(commaSeparate('Alice\r\nBob\r\nCarol\r\n')).toBe(
+			'Alice, Bob, Carol'
+		)
+	})
+
+	test('column of numbers to comma-separated series', () => {
+		expect(commaSeparate('10\n20\n30\n40')).toBe('10, 20, 30, 40')
+	})
+
+	test('handles mixed whitespace including blank lines', () => {
+		expect(commaSeparate('1\n\n2 \t 3\n')).toBe('1, 2, 3')
+	})
+
+	test('handles Unicode whitespace (non-breaking space)', () => {
+		expect(commaSeparate('1 2 3')).toBe('1, 2, 3')
+	})
+
+	test('single item returns itself', () => {
+		expect(commaSeparate('1')).toBe('1')
+	})
+
+	test('empty input returns empty string', () => {
+		expect(commaSeparate('')).toBe('')
+	})
+
+	test('whitespace-only input returns empty string', () => {
+		expect(commaSeparate('   \n\t  ')).toBe('')
+	})
+
+	// Idempotency: running the tool on already-comma-separated text must
+	// not double up commas. This is what edge-comma stripping buys us.
+	test('is idempotent on already comma-separated input', () => {
+		const once = commaSeparate('1 2 3')
+		expect(once).toBe('1, 2, 3')
+		expect(commaSeparate(once)).toBe('1, 2, 3')
+	})
+
+	test('tolerates input that is already partly comma-separated', () => {
+		expect(commaSeparate('1, 2, 3')).toBe('1, 2, 3')
+		expect(commaSeparate('1,2,3')).toBe('1,2,3') // no whitespace = single token, edge commas trimmed
+	})
+
+	test('preserves commas inside a token (thousands separators)', () => {
+		expect(commaSeparate('1,000 2,000')).toBe('1,000, 2,000')
+	})
+
+	test('strips stray leading/trailing commas per token', () => {
+		expect(commaSeparate(',1 2, ,3,')).toBe('1, 2, 3')
+	})
+
+	// Lock intentional behavior surfaced by the battle test:
+	// a standalone all-comma token is dropped (keeps the transform
+	// idempotent), and a no-whitespace comma string is a single token
+	// (so "1,000" thousands separators survive).
+	test('drops a standalone all-comma token', () => {
+		expect(commaSeparate('1 ,,, 2')).toBe('1, 2')
+	})
+
+	test('no-whitespace comma string stays one token', () => {
+		expect(commaSeparate('1,2,3')).toBe('1,2,3')
+	})
+
+	describe('quote option', () => {
+		test('single quotes wrap each item', () => {
+			expect(commaSeparate('1 2 3', { quote: 'single' })).toBe(
+				"'1', '2', '3'"
+			)
+		})
+
+		test('double quotes wrap each item', () => {
+			expect(commaSeparate('a b c', { quote: 'double' })).toBe(
+				'"a", "b", "c"'
+			)
+		})
+
+		test('quote none is the default and adds no quotes', () => {
+			expect(commaSeparate('a b', { quote: 'none' })).toBe('a, b')
+		})
+
+		test('empty input stays empty even with quotes on', () => {
+			expect(commaSeparate('', { quote: 'single' })).toBe('')
+		})
+
+		// Battle-test: the quote option is advertised for SQL/arrays, so an
+		// embedded quote must be escaped (doubled) or it emits broken,
+		// injectable output.
+		test('single-quote mode doubles an embedded apostrophe (valid SQL)', () => {
+			expect(commaSeparate("O'Brien Smith", { quote: 'single' })).toBe(
+				"'O''Brien', 'Smith'"
+			)
+		})
+
+		test('double-quote mode doubles an embedded double quote (ANSI)', () => {
+			expect(commaSeparate('say "hi"', { quote: 'double' })).toBe(
+				'"say", """hi"""'
+			)
+		})
+
+		test('escaping composes with dedupe', () => {
+			expect(
+				commaSeparate("O'Brien O'Brien Smith", {
+					quote: 'single',
+					dedupe: true
+				})
+			).toBe("'O''Brien', 'Smith'")
+		})
+	})
+
+	describe('dedupe option', () => {
+		test('removes duplicates, keeping first occurrence order', () => {
+			expect(commaSeparate('3 1 2 1 3', { dedupe: true })).toBe('3, 1, 2')
+		})
+
+		test('dedupe off keeps duplicates', () => {
+			expect(commaSeparate('1 1 2', { dedupe: false })).toBe('1, 1, 2')
+		})
+
+		test('dedupe combines with quoting', () => {
+			expect(commaSeparate('a a b', { dedupe: true, quote: 'double' })).toBe(
+				'"a", "b"'
+			)
+		})
+
+		test('dedupe is case-sensitive (A and a are different items)', () => {
+			expect(commaSeparate('A a A', { dedupe: true })).toBe('A, a')
+		})
+	})
+
+	describe('robustness', () => {
+		test('large input does not choke and preserves count', () => {
+			const n = 5000
+			const input = Array.from({ length: n }, (_, i) => String(i)).join(' ')
+			const out = commaSeparate(input)
+			expect(out.split(', ').length).toBe(n)
+			expect(out.startsWith('0, 1, 2')).toBe(true)
+			expect(out.endsWith('4998, 4999')).toBe(true)
+		})
+
+		test('does not interpret items as HTML/code (no escaping, raw passthrough)', () => {
+			expect(commaSeparate('<b> & "x"')).toBe('<b>, &, "x"')
+		})
+
+		test('preserves emoji and multibyte tokens', () => {
+			expect(commaSeparate('a 🚀 b')).toBe('a, 🚀, b')
+		})
+	})
+})
+
+describe('countItems', () => {
+	test('counts tokens', () => {
+		expect(countItems('1 2 3')).toBe(3)
+	})
+
+	test('blank input counts zero', () => {
+		expect(countItems('   ')).toBe(0)
+	})
+
+	test('matches the number of comma-joined items produced', () => {
+		const input = '  a  b\tc\nd '
+		expect(countItems(input)).toBe(commaSeparate(input).split(', ').length)
+	})
+
+	// Battle-test: the count must reflect dedupe so the UI label matches
+	// the rendered/copied output and analytics aren't over-reported.
+	test('is option-aware: dedupe count matches deduped output length', () => {
+		expect(countItems('1 2 3 2 1', { dedupe: true })).toBe(3)
+	})
+
+	test('without dedupe still counts raw tokens (no regression)', () => {
+		expect(countItems('1 2 3 2 1')).toBe(5)
+	})
+
+	test('comma-trimmed duplicates are counted after dedupe', () => {
+		expect(countItems(',1 1 1,', { dedupe: true })).toBe(1)
+	})
+})
+
+describe('tokenizeList', () => {
+	test('returns an array of clean tokens', () => {
+		expect(tokenizeList(' 1 2  3 ')).toEqual(['1', '2', '3'])
+	})
+
+	test('empty input returns empty array', () => {
+		expect(tokenizeList('')).toEqual([])
+	})
+
+	// Guards the non-string path used defensively in the util.
+	test('non-string input returns empty array', () => {
+		// @ts-expect-error intentional: exercising the runtime guard
+		expect(tokenizeList(null)).toEqual([])
+		// @ts-expect-error intentional: exercising the runtime guard
+		expect(tokenizeList(undefined)).toEqual([])
+	})
+})


### PR DESCRIPTION
New developer tool requested directly: convert a **column of values** (one per line, e.g. a pasted spreadsheet column) or any space/tab/newline separated list into a clean comma-separated series.

```
1            →   1, 2, 3, 4, 5
2
3
4
5
```

## What's included
- **`src/lib/list-formatter.ts`** — pure, testable transform. Splits on any whitespace run, strips per-token edge commas (idempotent, tolerant of partly-comma'd input, preserves internal commas like `1,000`), drops empties. Options: `quote` (none/single/double) and `dedupe`.
- **Client tool + server page** following the `ToolPageLayout` pattern — live transform, copy action, item count, column-forward placeholder/copy.
- Registered in `tools-data.ts` (developers category) and `TOOL_ROUTES` — appears in the tools index, the in-page tools search, and the cmdk palette (type "comma" or "list").

## Battle-tested
Hardened via a 6-lens adversarial workflow (whitespace/Unicode, comma-stripping, quote safety, idempotency, dedupe/count, scale) + per-finding verification. Two confirmed defects found and fixed:
- **Quote escaping (was injectable):** single/double modes now double an embedded quote (SQL/ANSI standard), so `O'Brien` → `'O''Brien'` instead of the broken `'O'Brien'`. Makes the "for SQL/arrays" claim honest.
- **Dedupe-aware count:** the item count + analytics now match the rendered output when "Remove duplicates" is on (previously showed e.g. "5 items" beside a 3-item result).

## Test plan
- [x] 42 unit tests for the transform (CRLF/spreadsheet column, Unicode whitespace, idempotency, escaping, dedupe-count, large 5k input)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test tests/` — 824 pass
- [x] `bun run build` exit 0 (`/tools/comma-separator` prerendered static)

[hudsor01]