### PR TITLE
feat(tools): add LocalBusiness Schema Generator (JSON-LD)

### DIFF
--- a/src/app/(public)/tools/schema-generator/SchemaGeneratorClient.tsx
+++ b/src/app/(public)/tools/schema-generator/SchemaGeneratorClient.tsx
@@ -1,0 +1,438 @@
+/**
+ * LocalBusiness Schema Generator
+ * Build schema.org LocalBusiness JSON-LD for local SEO.
+ */
+
+'use client'
+
+import { useId, useMemo, useState } from 'react'
+import { CalculatorInput } from '@/components/calculators/CalculatorInput'
+import type { ToolAction } from '@/components/layout/ToolPageLayout'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { trackEvent } from '@/lib/analytics'
+import { logger } from '@/lib/logger'
+import {
+	buildLocalBusinessSchema,
+	type LocalBusinessType,
+	serializeSchema
+} from '@/lib/schema-generator'
+
+const BUSINESS_TYPES: ReadonlyArray<{
+	value: LocalBusinessType
+	label: string
+}> = [
+	{ value: 'LocalBusiness', label: 'Local Business (general)' },
+	{ value: 'ProfessionalService', label: 'Professional Service' },
+	{ value: 'Store', label: 'Store / Retail' },
+	{ value: 'Restaurant', label: 'Restaurant' },
+	{ value: 'FoodEstablishment', label: 'Food Establishment' },
+	{ value: 'MedicalBusiness', label: 'Medical Business' },
+	{ value: 'HealthAndBeautyBusiness', label: 'Health & Beauty' },
+	{ value: 'HomeAndConstructionBusiness', label: 'Home & Construction' },
+	{ value: 'AutomotiveBusiness', label: 'Automotive' },
+	{ value: 'LegalService', label: 'Legal Service' },
+	{ value: 'FinancialService', label: 'Financial Service' },
+	{ value: 'EntertainmentBusiness', label: 'Entertainment' }
+]
+
+const DAYS = [
+	'Monday',
+	'Tuesday',
+	'Wednesday',
+	'Thursday',
+	'Friday',
+	'Saturday',
+	'Sunday'
+] as const
+
+export default function SchemaGeneratorClient() {
+	const [type, setType] = useState<LocalBusinessType>('LocalBusiness')
+	const [name, setName] = useState('')
+	const [description, setDescription] = useState('')
+	const [url, setUrl] = useState('')
+	const [telephone, setTelephone] = useState('')
+	const [email, setEmail] = useState('')
+	const [image, setImage] = useState('')
+	const [priceRange, setPriceRange] = useState('')
+
+	const [street, setStreet] = useState('')
+	const [city, setCity] = useState('')
+	const [region, setRegion] = useState('')
+	const [postalCode, setPostalCode] = useState('')
+	const [country, setCountry] = useState('')
+
+	const [latitude, setLatitude] = useState('')
+	const [longitude, setLongitude] = useState('')
+
+	const [days, setDays] = useState<string[]>([])
+	const [opens, setOpens] = useState('')
+	const [closes, setCloses] = useState('')
+
+	const [socials, setSocials] = useState('')
+	const [includeScriptTag, setIncludeScriptTag] = useState(true)
+
+	const typeFieldId = useId()
+	const scriptTagFieldId = useId()
+
+	const output = useMemo(() => {
+		const schema = buildLocalBusinessSchema({
+			type,
+			name,
+			description,
+			url,
+			telephone,
+			email,
+			image,
+			priceRange,
+			address: { street, city, region, postalCode, country },
+			geo: { latitude, longitude },
+			openingHours: [{ days, opens, closes }],
+			sameAs: socials.split('\n')
+		})
+		return serializeSchema(schema, {
+			pretty: true,
+			scriptTag: includeScriptTag
+		})
+	}, [
+		type,
+		name,
+		description,
+		url,
+		telephone,
+		email,
+		image,
+		priceRange,
+		street,
+		city,
+		region,
+		postalCode,
+		country,
+		latitude,
+		longitude,
+		days,
+		opens,
+		closes,
+		socials,
+		includeScriptTag
+	])
+
+	const hasResult = name.trim().length > 0
+
+	// Inline feedback when a coordinate isn't a single decimal number — the
+	// most common mistake is pasting "lat, lng" into one field, which the
+	// generator silently drops. Mirror the generator's decimal-only rule.
+	const coordError = (raw: string, limit: number): string | undefined => {
+		const trimmed = raw.trim()
+		if (trimmed === '') {
+			return undefined
+		}
+		if (!/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+			return `Enter a single decimal number (${limit === 90 ? '-90 to 90' : '-180 to 180'}). Put latitude and longitude in separate fields.`
+		}
+		return undefined
+	}
+	const latError = coordError(latitude, 90)
+	const lngError = coordError(longitude, 180)
+
+	const toggleDay = (day: string) => {
+		setDays(prev =>
+			prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day]
+		)
+	}
+
+	const copyToClipboard = async () => {
+		if (!hasResult) {
+			return
+		}
+		try {
+			await navigator.clipboard.writeText(output)
+			trackEvent('calculator_used', {
+				calculator_type: 'schema-generator',
+				action: 'copy',
+				business_type: type
+			})
+		} catch (error) {
+			logger.debug('Clipboard API unavailable, using fallback', {
+				error: error instanceof Error ? error.message : String(error)
+			})
+			const textArea = document.createElement('textarea')
+			textArea.value = output
+			document.body.appendChild(textArea)
+			textArea.select()
+			document.execCommand('copy')
+			document.body.removeChild(textArea)
+		}
+	}
+
+	const actions: ToolAction[] = [
+		{ type: 'copy', label: 'Copy', onClick: copyToClipboard }
+	]
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			{/* Core */}
+			<div className="space-y-content">
+				<div>
+					<label
+						htmlFor={typeFieldId}
+						className="block text-sm font-medium text-foreground mb-subheading"
+					>
+						Business type
+					</label>
+					<select
+						id={typeFieldId}
+						value={type}
+						onChange={event => setType(event.target.value as LocalBusinessType)}
+						className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+					>
+						{BUSINESS_TYPES.map(option => (
+							<option key={option.value} value={option.value}>
+								{option.label}
+							</option>
+						))}
+					</select>
+				</div>
+
+				<CalculatorInput
+					id="schema-name"
+					label="Business name"
+					value={name}
+					onChange={event => setName(event.target.value)}
+					placeholder="Acme Plumbing Co."
+				/>
+				<CalculatorInput
+					id="schema-description"
+					label="Description"
+					value={description}
+					onChange={event => setDescription(event.target.value)}
+					placeholder="Licensed plumbers serving the Dallas area."
+				/>
+				<CalculatorInput
+					id="schema-url"
+					label="Website URL"
+					type="url"
+					value={url}
+					onChange={event => setUrl(event.target.value)}
+					placeholder="https://example.com"
+					helpText="Use the full URL including https://."
+				/>
+				<CalculatorInput
+					id="schema-phone"
+					label="Phone"
+					type="tel"
+					value={telephone}
+					onChange={event => setTelephone(event.target.value)}
+					placeholder="(555) 123-4567"
+				/>
+				<CalculatorInput
+					id="schema-email"
+					label="Email"
+					type="email"
+					value={email}
+					onChange={event => setEmail(event.target.value)}
+					placeholder="hello@example.com"
+				/>
+				<CalculatorInput
+					id="schema-image"
+					label="Logo / image URL"
+					type="url"
+					value={image}
+					onChange={event => setImage(event.target.value)}
+					placeholder="https://example.com/logo.png"
+					helpText="Use the full URL including https://."
+				/>
+				<CalculatorInput
+					id="schema-price"
+					label="Price range"
+					value={priceRange}
+					onChange={event => setPriceRange(event.target.value)}
+					placeholder="$$"
+					helpText="$ to $$$$, or a range like $50-$200."
+				/>
+			</div>
+
+			{/* Address */}
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Address
+				</legend>
+				<CalculatorInput
+					id="schema-street"
+					label="Street"
+					value={street}
+					onChange={event => setStreet(event.target.value)}
+					placeholder="123 Main St"
+				/>
+				<div className="grid grid-cols-2 gap-content">
+					<CalculatorInput
+						id="schema-city"
+						label="City"
+						value={city}
+						onChange={event => setCity(event.target.value)}
+						placeholder="Dallas"
+					/>
+					<CalculatorInput
+						id="schema-region"
+						label="State / region"
+						value={region}
+						onChange={event => setRegion(event.target.value)}
+						placeholder="TX"
+					/>
+				</div>
+				<div className="grid grid-cols-2 gap-content">
+					<CalculatorInput
+						id="schema-postal"
+						label="Postal code"
+						value={postalCode}
+						onChange={event => setPostalCode(event.target.value)}
+						placeholder="75201"
+					/>
+					<CalculatorInput
+						id="schema-country"
+						label="Country"
+						value={country}
+						onChange={event => setCountry(event.target.value)}
+						placeholder="US"
+					/>
+				</div>
+			</fieldset>
+
+			{/* Geo */}
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Map coordinates (optional)
+				</legend>
+				<div className="grid grid-cols-2 gap-content">
+					<CalculatorInput
+						id="schema-lat"
+						label="Latitude"
+						value={latitude}
+						onChange={event => setLatitude(event.target.value)}
+						placeholder="32.7767"
+						error={latError}
+					/>
+					<CalculatorInput
+						id="schema-lng"
+						label="Longitude"
+						value={longitude}
+						onChange={event => setLongitude(event.target.value)}
+						placeholder="-96.7970"
+						error={lngError}
+					/>
+				</div>
+			</fieldset>
+
+			{/* Hours */}
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Opening hours (optional)
+				</legend>
+				<p className="text-xs text-muted-foreground">
+					These hours apply to every selected day. For days with different
+					hours, leave them unchecked rather than entering the wrong times.
+				</p>
+				<div className="flex flex-wrap gap-2">
+					{DAYS.map(day => {
+						const checked = days.includes(day)
+						return (
+							<label
+								key={day}
+								className={`cursor-pointer rounded-md border px-2.5 py-1 text-xs transition-colors ${
+									checked
+										? 'border-accent bg-accent/10 text-accent'
+										: 'border-border text-muted-foreground hover:text-foreground'
+								}`}
+							>
+								<input
+									type="checkbox"
+									checked={checked}
+									onChange={() => toggleDay(day)}
+									className="sr-only"
+								/>
+								{day.slice(0, 3)}
+							</label>
+						)
+					})}
+				</div>
+				<div className="grid grid-cols-2 gap-content">
+					<CalculatorInput
+						id="schema-opens"
+						label="Opens"
+						type="time"
+						value={opens}
+						onChange={event => setOpens(event.target.value)}
+					/>
+					<CalculatorInput
+						id="schema-closes"
+						label="Closes"
+						type="time"
+						value={closes}
+						onChange={event => setCloses(event.target.value)}
+					/>
+				</div>
+			</fieldset>
+
+			{/* Social profiles */}
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Social profiles (optional)
+				</legend>
+				<textarea
+					value={socials}
+					onChange={event => setSocials(event.target.value)}
+					className="w-full rounded-md border border-border bg-background px-4 py-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-accent"
+					rows={4}
+					placeholder={
+						'https://facebook.com/yourbusiness\nhttps://instagram.com/yourbusiness'
+					}
+					spellCheck={false}
+				/>
+				<p className="text-xs text-muted-foreground">
+					One full profile URL per line (include https://). These become the
+					schema&apos;s sameAs links.
+				</p>
+			</fieldset>
+
+			<label
+				htmlFor={scriptTagFieldId}
+				className="flex items-center gap-tight text-sm text-muted-foreground"
+			>
+				<input
+					id={scriptTagFieldId}
+					type="checkbox"
+					checked={includeScriptTag}
+					onChange={event => setIncludeScriptTag(event.target.checked)}
+					className="rounded border-border text-accent focus:ring-accent"
+				/>
+				Wrap in a &lt;script&gt; tag (paste straight into your page head)
+			</label>
+		</div>
+	)
+
+	const resultSlot = hasResult ? (
+		<div>
+			<pre className="w-full rounded-md border border-border bg-background p-4 overflow-x-auto">
+				<code className="text-sm text-foreground whitespace-pre-wrap break-all font-mono">
+					{output}
+				</code>
+			</pre>
+			<p className="mt-2 text-xs text-muted-foreground">
+				Paste this into the &lt;head&gt; of your page, then validate it with
+				Google&apos;s Rich Results Test.
+			</p>
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="LocalBusiness Schema Generator"
+			description="Build schema.org LocalBusiness JSON-LD to help Google understand your business and show you in local results."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Enter your business name to generate the JSON-LD"
+			actions={actions}
+		/>
+	)
+}

--- a/src/app/(public)/tools/schema-generator/page.tsx
+++ b/src/app/(public)/tools/schema-generator/page.tsx
@@ -1,0 +1,17 @@
+/**
+ * LocalBusiness Schema Generator
+ * Generate schema.org LocalBusiness JSON-LD structured data for local SEO.
+ */
+
+import type { Metadata } from 'next'
+import SchemaGeneratorClient from './SchemaGeneratorClient'
+
+export const metadata: Metadata = {
+	title: 'LocalBusiness Schema Generator (JSON-LD) | Hudson Digital',
+	description:
+		'Free LocalBusiness schema markup generator. Build valid schema.org JSON-LD structured data for local SEO and Google rich results, then paste it into your site.'
+}
+
+export default function SchemaGeneratorPage() {
+	return <SchemaGeneratorClient />
+}

--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -8,6 +8,7 @@ import {
 	FileText,
 	Home,
 	List,
+	MapPin,
 	Receipt,
 	Tags,
 	TrendingUp,
@@ -117,6 +118,20 @@ export const TOOLS: readonly ToolEntry[] = [
 			'SEO meta tag preview'
 		],
 		cta: 'Generate Tags',
+		category: 'website'
+	},
+	{
+		title: 'LocalBusiness Schema Generator',
+		description:
+			'Build schema.org LocalBusiness JSON-LD structured data so Google understands your business and shows you in local results.',
+		href: TOOL_ROUTES.SCHEMA_GENERATOR,
+		Icon: MapPin,
+		benefits: [
+			'Valid schema.org JSON-LD',
+			'Address, hours, geo, and social links',
+			'Helps you rank in the local pack'
+		],
+		cta: 'Generate Schema',
 		category: 'website'
 	},
 	{

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -41,6 +41,7 @@ export const TOOL_ROUTES = {
 	PROPOSAL_GENERATOR: '/tools/proposal-generator',
 	JSON_FORMATTER: '/tools/json-formatter',
 	META_TAG_GENERATOR: '/tools/meta-tag-generator',
+	SCHEMA_GENERATOR: '/tools/schema-generator',
 	COMMA_SEPARATOR: '/tools/comma-separator',
 	TESTIMONIAL_COLLECTOR: '/tools/testimonial-collector'
 } as const

--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -1,0 +1,283 @@
+/**
+ * LocalBusiness JSON-LD schema generator.
+ *
+ * Builds a schema.org `LocalBusiness` (or subtype) structured-data object
+ * from form input and serializes it for pasting into a page <head>.
+ *
+ * Security: the serialized JSON is meant to live inside a
+ * `<script type="application/ld+json">` block, so any value containing
+ * `</script>` would otherwise break out of the tag (XSS). serializeSchema
+ * escapes `<`, `>`, `&`, U+2028 and U+2029 to their JSON unicode escapes —
+ * the same hardening the site's own JsonLd component
+ * (src/components/utilities/JsonLd.tsx) applies.
+ */
+
+export type LocalBusinessType =
+	| 'LocalBusiness'
+	| 'ProfessionalService'
+	| 'Store'
+	| 'Restaurant'
+	| 'FoodEstablishment'
+	| 'MedicalBusiness'
+	| 'HealthAndBeautyBusiness'
+	| 'HomeAndConstructionBusiness'
+	| 'AutomotiveBusiness'
+	| 'LegalService'
+	| 'FinancialService'
+	| 'EntertainmentBusiness'
+
+export interface SchemaAddressInput {
+	street?: string
+	city?: string
+	region?: string
+	postalCode?: string
+	country?: string
+}
+
+export interface SchemaGeoInput {
+	latitude?: string
+	longitude?: string
+}
+
+export interface OpeningHoursInput {
+	days: readonly string[]
+	opens: string
+	closes: string
+}
+
+export interface LocalBusinessInput {
+	type?: LocalBusinessType
+	name: string
+	description?: string
+	url?: string
+	telephone?: string
+	email?: string
+	image?: string
+	priceRange?: string
+	address?: SchemaAddressInput
+	geo?: SchemaGeoInput
+	openingHours?: readonly OpeningHoursInput[]
+	sameAs?: readonly string[]
+}
+
+/** Trim a value; return undefined when it is blank. */
+function clean(value: string | undefined | null): string | undefined {
+	if (typeof value !== 'string') {
+		return undefined
+	}
+	const trimmed = value.trim()
+	return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * Prepend https:// to a bare domain so URL-typed fields are absolute
+ * (Google rejects relative/scheme-less URLs in structured data). Values
+ * that already carry a scheme (http:, https:, mailto:, ...) or are
+ * protocol-relative (`//cdn...`) are left untouched.
+ */
+function normalizeUrl(value: string | undefined | null): string | undefined {
+	const v = clean(value)
+	if (v === undefined) {
+		return undefined
+	}
+	if (/^[a-z][a-z0-9+.-]*:/i.test(v) || v.startsWith('//')) {
+		return v
+	}
+	return `https://${v}`
+}
+
+// Decimal-only: a lone optionally-signed integer or decimal. Rejects the
+// JS numeric-literal forms Number() would otherwise coerce (hex 0x10,
+// binary 0b101, octal 0o17, exponential 1e1) into a plausible-but-wrong
+// coordinate.
+const COORDINATE_RE = /^[+-]?\d+(\.\d+)?$/
+
+/** Parse a latitude/longitude string into a valid in-range number, else undefined. */
+function parseCoordinate(
+	value: string | undefined,
+	limit: number
+): number | undefined {
+	const trimmed = clean(value)
+	if (trimmed === undefined || !COORDINATE_RE.test(trimmed)) {
+		return undefined
+	}
+	const num = Number(trimmed)
+	if (!Number.isFinite(num) || Math.abs(num) > limit) {
+		return undefined
+	}
+	return num
+}
+
+function buildAddress(
+	address: SchemaAddressInput | undefined
+): Record<string, unknown> | undefined {
+	if (!address) {
+		return undefined
+	}
+	const streetAddress = clean(address.street)
+	const addressLocality = clean(address.city)
+	const addressRegion = clean(address.region)
+	const postalCode = clean(address.postalCode)
+	const addressCountry = clean(address.country)
+	if (
+		!streetAddress &&
+		!addressLocality &&
+		!addressRegion &&
+		!postalCode &&
+		!addressCountry
+	) {
+		return undefined
+	}
+	return {
+		'@type': 'PostalAddress',
+		...(streetAddress ? { streetAddress } : {}),
+		...(addressLocality ? { addressLocality } : {}),
+		...(addressRegion ? { addressRegion } : {}),
+		...(postalCode ? { postalCode } : {}),
+		...(addressCountry ? { addressCountry } : {})
+	}
+}
+
+function buildGeo(
+	geo: SchemaGeoInput | undefined
+): Record<string, unknown> | undefined {
+	if (!geo) {
+		return undefined
+	}
+	const latitude = parseCoordinate(geo.latitude, 90)
+	const longitude = parseCoordinate(geo.longitude, 180)
+	// Both coordinates must be valid; a lone coordinate is meaningless.
+	if (latitude === undefined || longitude === undefined) {
+		return undefined
+	}
+	return { '@type': 'GeoCoordinates', latitude, longitude }
+}
+
+function buildOpeningHours(
+	hours: readonly OpeningHoursInput[] | undefined
+): Array<Record<string, unknown>> | undefined {
+	if (!hours || hours.length === 0) {
+		return undefined
+	}
+	const entries = hours
+		.map(entry => {
+			const days = entry.days.map(d => clean(d)).filter(Boolean) as string[]
+			const opens = clean(entry.opens)
+			const closes = clean(entry.closes)
+			if (days.length === 0 || !opens || !closes) {
+				return undefined
+			}
+			return {
+				'@type': 'OpeningHoursSpecification',
+				dayOfWeek: days,
+				opens,
+				closes
+			}
+		})
+		.filter(Boolean) as Array<Record<string, unknown>>
+	return entries.length > 0 ? entries : undefined
+}
+
+function buildSameAs(
+	sameAs: readonly string[] | undefined
+): string[] | undefined {
+	if (!sameAs) {
+		return undefined
+	}
+	const seen = new Set<string>()
+	const urls: string[] = []
+	for (const raw of sameAs) {
+		const url = clean(raw)
+		if (url && !seen.has(url)) {
+			seen.add(url)
+			urls.push(url)
+		}
+	}
+	return urls.length > 0 ? urls : undefined
+}
+
+/**
+ * Build the LocalBusiness JSON-LD object. Empty/blank fields are omitted
+ * so the output is always minimal and valid. `name` is the only field
+ * Google requires; callers should ensure it is present.
+ */
+export function buildLocalBusinessSchema(
+	input: LocalBusinessInput
+): Record<string, unknown> {
+	const name = clean(input.name)
+	const description = clean(input.description)
+	const url = normalizeUrl(input.url)
+	const telephone = clean(input.telephone)
+	const email = clean(input.email)
+	const image = normalizeUrl(input.image)
+	const priceRange = clean(input.priceRange)
+	const address = buildAddress(input.address)
+	const geo = buildGeo(input.geo)
+	const openingHoursSpecification = buildOpeningHours(input.openingHours)
+	const sameAs = buildSameAs(input.sameAs)
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': input.type || 'LocalBusiness',
+		...(name ? { name } : {}),
+		...(description ? { description } : {}),
+		...(url ? { url } : {}),
+		...(telephone ? { telephone } : {}),
+		...(email ? { email } : {}),
+		...(image ? { image } : {}),
+		...(priceRange ? { priceRange } : {}),
+		...(address ? { address } : {}),
+		...(geo ? { geo } : {}),
+		...(openingHoursSpecification ? { openingHoursSpecification } : {}),
+		...(sameAs ? { sameAs } : {})
+	}
+}
+
+// Escape characters that are unsafe inside an inline <script> block. Built
+// via RegExp() so the source stays ASCII (TS parses literal U+2028/U+2029
+// in a regex literal as line terminators).
+const SCRIPT_ESCAPE_RE = /[<>&\u2028\u2029]/g
+
+function escapeForScript(ch: string): string {
+	switch (ch.charCodeAt(0)) {
+		case 0x3c:
+			return '\\u003c'
+		case 0x3e:
+			return '\\u003e'
+		case 0x26:
+			return '\\u0026'
+		case 0x2028:
+			return '\\u2028'
+		case 0x2029:
+			return '\\u2029'
+		default:
+			return ch
+	}
+}
+
+export interface SerializeOptions {
+	/** Pretty-print with 2-space indentation. Default true. */
+	pretty?: boolean
+	/** Wrap the JSON in a `<script type="application/ld+json">` block. Default false. */
+	scriptTag?: boolean
+}
+
+/**
+ * Serialize a schema object to a string safe to paste into HTML. Always
+ * escapes `<`, `>`, `&`, U+2028 and U+2029 so a value containing
+ * `</script>` cannot break out of an inline script tag.
+ */
+export function serializeSchema(
+	schema: Record<string, unknown>,
+	options: SerializeOptions = {}
+): string {
+	const { pretty = true, scriptTag = false } = options
+	const json = JSON.stringify(schema, null, pretty ? 2 : undefined).replace(
+		SCRIPT_ESCAPE_RE,
+		escapeForScript
+	)
+	if (!scriptTag) {
+		return json
+	}
+	return `<script type="application/ld+json">\n${json}\n</script>`
+}

--- a/tests/unit/schema-generator.test.ts
+++ b/tests/unit/schema-generator.test.ts
@@ -1,0 +1,315 @@
+/**
+ * LocalBusiness JSON-LD generator — contract + security.
+ * Locks src/lib/schema-generator.ts.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import {
+	buildLocalBusinessSchema,
+	type LocalBusinessInput,
+	serializeSchema
+} from '@/lib/schema-generator'
+
+describe('buildLocalBusinessSchema', () => {
+	test('minimal input produces a valid LocalBusiness object', () => {
+		expect(buildLocalBusinessSchema({ name: 'Acme Co' })).toEqual({
+			'@context': 'https://schema.org',
+			'@type': 'LocalBusiness',
+			name: 'Acme Co'
+		})
+	})
+
+	test('honors the @type subtype', () => {
+		const out = buildLocalBusinessSchema({
+			name: 'Joe Law',
+			type: 'LegalService'
+		})
+		expect(out['@type']).toBe('LegalService')
+	})
+
+	test('omits every blank/whitespace field', () => {
+		const out = buildLocalBusinessSchema({
+			name: 'Acme',
+			description: '   ',
+			url: '',
+			telephone: undefined,
+			email: '\t'
+		})
+		expect(out).toEqual({
+			'@context': 'https://schema.org',
+			'@type': 'LocalBusiness',
+			name: 'Acme'
+		})
+	})
+
+	test('trims field values', () => {
+		const out = buildLocalBusinessSchema({
+			name: '  Acme  ',
+			telephone: '  555-1234 '
+		})
+		expect(out.name).toBe('Acme')
+		expect(out.telephone).toBe('555-1234')
+	})
+
+	describe('address', () => {
+		test('includes PostalAddress with only the present sub-fields', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				address: { city: 'Dallas', region: 'TX' }
+			})
+			expect(out.address).toEqual({
+				'@type': 'PostalAddress',
+				addressLocality: 'Dallas',
+				addressRegion: 'TX'
+			})
+		})
+
+		test('omits address entirely when all sub-fields are blank', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				address: { street: '', city: '   ' }
+			})
+			expect(out.address).toBeUndefined()
+		})
+	})
+
+	describe('url normalization', () => {
+		test('prepends https:// to a bare domain', () => {
+			expect(buildLocalBusinessSchema({ name: 'A', url: 'example.com' }).url).toBe(
+				'https://example.com'
+			)
+			expect(
+				buildLocalBusinessSchema({ name: 'A', url: 'www.acme.com' }).url
+			).toBe('https://www.acme.com')
+		})
+
+		test('leaves an explicit scheme or protocol-relative URL untouched', () => {
+			expect(
+				buildLocalBusinessSchema({ name: 'A', url: 'https://x.com' }).url
+			).toBe('https://x.com')
+			expect(
+				buildLocalBusinessSchema({ name: 'A', url: 'http://x.com' }).url
+			).toBe('http://x.com')
+			expect(
+				buildLocalBusinessSchema({ name: 'A', url: '//cdn.x.com' }).url
+			).toBe('//cdn.x.com')
+		})
+
+		test('normalizes the image field too, preserving blank omission', () => {
+			expect(
+				buildLocalBusinessSchema({
+					name: 'A',
+					image: 'cdn.example.com/logo.png'
+				}).image
+			).toBe('https://cdn.example.com/logo.png')
+			expect(
+				buildLocalBusinessSchema({ name: 'A', image: '   ' }).image
+			).toBeUndefined()
+		})
+	})
+
+	describe('geo', () => {
+		test('rejects JS numeric-literal forms Number() would coerce', () => {
+			for (const bad of ['0x10', '1e1', '0b101', '0o17']) {
+				expect(
+					buildLocalBusinessSchema({
+						name: 'A',
+						geo: { latitude: bad, longitude: '45' }
+					}).geo
+				).toBeUndefined()
+			}
+		})
+
+		test('still accepts signed, decimal, and whitespace-padded coordinates', () => {
+			expect(
+				buildLocalBusinessSchema({
+					name: 'A',
+					geo: { latitude: '+45.5', longitude: '-96.79' }
+				}).geo
+			).toEqual({ '@type': 'GeoCoordinates', latitude: 45.5, longitude: -96.79 })
+			expect(
+				buildLocalBusinessSchema({
+					name: 'A',
+					geo: { latitude: '  32.7767  ', longitude: '-96.797' }
+				}).geo
+			).toEqual({
+				'@type': 'GeoCoordinates',
+				latitude: 32.7767,
+				longitude: -96.797
+			})
+		})
+
+		test('omits geo for comma-format / European-decimal coordinates', () => {
+			expect(
+				buildLocalBusinessSchema({
+					name: 'A',
+					geo: { latitude: '32.7,96', longitude: '45' }
+				}).geo
+			).toBeUndefined()
+			expect(
+				buildLocalBusinessSchema({
+					name: 'A',
+					geo: { latitude: '32,7767', longitude: '-96,797' }
+				}).geo
+			).toBeUndefined()
+		})
+
+		test('includes GeoCoordinates when both are valid', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				geo: { latitude: '32.7767', longitude: '-96.797' }
+			})
+			expect(out.geo).toEqual({
+				'@type': 'GeoCoordinates',
+				latitude: 32.7767,
+				longitude: -96.797
+			})
+		})
+
+		test('omits geo when only one coordinate is provided', () => {
+			expect(
+				buildLocalBusinessSchema({ name: 'Acme', geo: { latitude: '32.7' } }).geo
+			).toBeUndefined()
+		})
+
+		test('omits geo for non-numeric coordinates', () => {
+			expect(
+				buildLocalBusinessSchema({
+					name: 'Acme',
+					geo: { latitude: 'abc', longitude: '5' }
+				}).geo
+			).toBeUndefined()
+		})
+
+		test('omits geo for out-of-range coordinates', () => {
+			expect(
+				buildLocalBusinessSchema({
+					name: 'Acme',
+					geo: { latitude: '120', longitude: '5' }
+				}).geo
+			).toBeUndefined()
+			expect(
+				buildLocalBusinessSchema({
+					name: 'Acme',
+					geo: { latitude: '45', longitude: '200' }
+				}).geo
+			).toBeUndefined()
+		})
+	})
+
+	describe('openingHours', () => {
+		test('maps a valid entry to OpeningHoursSpecification', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				openingHours: [
+					{ days: ['Monday', 'Tuesday'], opens: '09:00', closes: '17:00' }
+				]
+			})
+			expect(out.openingHoursSpecification).toEqual([
+				{
+					'@type': 'OpeningHoursSpecification',
+					dayOfWeek: ['Monday', 'Tuesday'],
+					opens: '09:00',
+					closes: '17:00'
+				}
+			])
+		})
+
+		test('drops entries with no days or missing times', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				openingHours: [
+					{ days: [], opens: '09:00', closes: '17:00' },
+					{ days: ['Monday'], opens: '', closes: '17:00' }
+				]
+			})
+			expect(out.openingHoursSpecification).toBeUndefined()
+		})
+	})
+
+	describe('sameAs', () => {
+		test('filters blanks and de-duplicates', () => {
+			const out = buildLocalBusinessSchema({
+				name: 'Acme',
+				sameAs: [
+					'https://x.com/acme',
+					'  ',
+					'https://x.com/acme',
+					'https://fb.com/acme'
+				]
+			})
+			expect(out.sameAs).toEqual(['https://x.com/acme', 'https://fb.com/acme'])
+		})
+
+		test('omits sameAs when empty', () => {
+			expect(
+				buildLocalBusinessSchema({ name: 'Acme', sameAs: ['', '  '] }).sameAs
+			).toBeUndefined()
+		})
+	})
+})
+
+describe('serializeSchema', () => {
+	const base: LocalBusinessInput = { name: 'Acme' }
+
+	test('pretty by default (2-space indent)', () => {
+		const out = serializeSchema(buildLocalBusinessSchema(base))
+		expect(out).toContain('\n  "@context"')
+	})
+
+	test('compact when pretty is false', () => {
+		const out = serializeSchema(buildLocalBusinessSchema(base), {
+			pretty: false
+		})
+		expect(out).not.toContain('\n')
+	})
+
+	test('wraps in a script tag when requested', () => {
+		const out = serializeSchema(buildLocalBusinessSchema(base), {
+			scriptTag: true
+		})
+		expect(out.startsWith('<script type="application/ld+json">')).toBe(true)
+		expect(out.trimEnd().endsWith('</script>')).toBe(true)
+	})
+
+	// Security: a value containing </script> must NOT be able to break out
+	// of the inline script block. < > & must be unicode-escaped.
+	test('escapes </script> to prevent script-tag breakout (XSS)', () => {
+		const schema = buildLocalBusinessSchema({
+			name: '</script><script>alert(1)</script>'
+		})
+		const out = serializeSchema(schema, { scriptTag: true })
+		// The raw closing tag must not appear except the legitimate wrapper.
+		expect(out.match(/<\/script>/g)?.length).toBe(1)
+		expect(out).toContain('\\u003c/script\\u003e')
+		expect(out).not.toContain('<script>alert')
+	})
+
+	test('escapes ampersand and angle brackets', () => {
+		const out = serializeSchema(
+			buildLocalBusinessSchema({ name: 'Tom & Jerry < >' })
+		)
+		expect(out).toContain('\\u0026')
+		expect(out).toContain('\\u003c')
+		expect(out).toContain('\\u003e')
+		expect(out).not.toContain('Tom & Jerry')
+	})
+
+	test('escapes U+2028 / U+2029 line separators', () => {
+		const ls = String.fromCharCode(0x2028)
+		const out = serializeSchema(
+			buildLocalBusinessSchema({ name: `a${ls}b` })
+		)
+		expect(out).toContain('\\u2028')
+	})
+
+	test('round-trips to valid JSON after escaping', () => {
+		const schema = buildLocalBusinessSchema({
+			name: 'Tom & Jerry </script>',
+			description: 'a < b > c'
+		})
+		const out = serializeSchema(schema)
+		// Escaped output must still parse as JSON and recover the original values.
+		expect(JSON.parse(out)).toEqual(schema)
+	})
+})


### PR DESCRIPTION
Build-next #1 from the tool-expansion research — highest lead-gen intent (a local owner with a Maps ranking problem is the exact ICP) and fills the portfolio's structured-data gap. Generates schema.org LocalBusiness JSON-LD to paste into a site `<head>` for local SEO / Google rich results.

## What's included
- **`src/lib/schema-generator.ts`** — pure builder + serializer. Omits blank fields; `address`/`geo`/`openingHours`/`sameAs` included only when valid. Serializer escapes `<`, `>`, `&`, U+2028, U+2029 (same hardening as the site's `JsonLd` component) so a value containing `</script>` cannot break out of the inline script block on the user's site.
- **Client tool + server page** (ToolPageLayout pattern): type subtype, name/description/url/phone/email/logo/price, address, geo, opening hours (day chips + times), social profiles, wrap-in-`<script>` toggle. Live output + copy.
- Registered in `tools-data.ts` (Website category) + `TOOL_ROUTES`; in the tools index, search, and cmdk palette.

## Battle-tested
6-lens adversarial workflow (security, schema.org validity, field/coordinate/locale handling) + per-finding verification. **Security confirmed solid** — script-tag escaping holds across pretty/compact/scriptTag modes, test-locked. Confirmed validity fixes applied:
- **URL normalization** — bare domains (`example.com`) get `https://` so `url`/`image` are absolute and pass Google's Rich Results Test.
- **Coordinate decimal-only guard** — rejects JS-coercible junk (`0x10`, `1e1`, `0b101`, `0o17`) before `Number()`, plus inline UI error when a coordinate isn't a single decimal (catches "lat, lng" pasted into one field).
- **Honesty copy** — absolute-URL hints; hours-apply-to-all-selected-days disclosure.

## Test plan
- [x] 27 unit tests (XSS/escaping, schema validity, URL normalization, coordinate guard, field omission)
- [x] `bun run typecheck` / `bun run lint`
- [x] `bun test tests/` — 851 pass
- [x] `bun run build` exit 0 (`/tools/schema-generator` prerendered static)

[hudsor01]