### PR TITLE
feat(tools): add 4 roadmap calculators/utilities

### DIFF
--- a/src/app/(public)/tools/invoice-late-fee-calculator/InvoiceLateFeeCalculatorClient.tsx
+++ b/src/app/(public)/tools/invoice-late-fee-calculator/InvoiceLateFeeCalculatorClient.tsx
@@ -1,0 +1,211 @@
+/**
+ * Invoice Late Fee Calculator
+ * Flat or percentage-per-period late fees on an overdue invoice.
+ */
+
+'use client'
+
+import { useId, useMemo, useState } from 'react'
+import { CalculatorInput } from '@/components/calculators/CalculatorInput'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import {
+	calculateLateFee,
+	type FeePeriod,
+	type LateFeeMode
+} from '@/lib/late-fee-calculator'
+
+const USD = new Intl.NumberFormat('en-US', {
+	style: 'currency',
+	currency: 'USD'
+})
+
+const PERIODS: ReadonlyArray<{ value: FeePeriod; label: string }> = [
+	{ value: 'day', label: 'per day' },
+	{ value: 'week', label: 'per week' },
+	{ value: 'month', label: 'per month' }
+]
+
+export default function InvoiceLateFeeCalculatorClient() {
+	const [amount, setAmount] = useState('')
+	const [mode, setMode] = useState<LateFeeMode>('percent')
+	const [flatFee, setFlatFee] = useState('')
+	const [percentRate, setPercentRate] = useState('')
+	const [period, setPeriod] = useState<FeePeriod>('month')
+	const [daysOverdue, setDaysOverdue] = useState('')
+	const [grace, setGrace] = useState('')
+
+	const modeFieldId = useId()
+	const periodFieldId = useId()
+
+	const amountNum = Number.parseFloat(amount)
+	const daysNum = Number.parseFloat(daysOverdue)
+	const hasInputs = Number.isFinite(amountNum) && Number.isFinite(daysNum)
+
+	const result = useMemo(
+		() =>
+			calculateLateFee({
+				amount: amountNum,
+				mode,
+				flatFee: Number.parseFloat(flatFee),
+				percentRate: Number.parseFloat(percentRate),
+				period,
+				daysOverdue: daysNum,
+				gracePeriodDays: Number.parseFloat(grace)
+			}),
+		[amountNum, mode, flatFee, percentRate, period, daysNum, grace]
+	)
+
+	const hasResult = hasInputs
+
+	// The fee-defining input for the active mode. When it's blank we show
+	// a prompt instead of a misleading "$0.00 fee / N days overdue" pair.
+	const feeInputMissing =
+		mode === 'percent'
+			? !Number.isFinite(Number.parseFloat(percentRate))
+			: !Number.isFinite(Number.parseFloat(flatFee))
+	const graceNum = Number.parseFloat(grace)
+	const hasGrace = Number.isFinite(graceNum) && graceNum > 0
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			<CalculatorInput
+				id="latefee-amount"
+				label="Invoice amount"
+				type="number"
+				inputMode="decimal"
+				prefix="$"
+				value={amount}
+				onChange={event => setAmount(event.target.value)}
+				placeholder="1000"
+			/>
+
+			<div>
+				<label
+					htmlFor={modeFieldId}
+					className="block text-sm font-medium text-foreground mb-subheading"
+				>
+					Fee type
+				</label>
+				<select
+					id={modeFieldId}
+					value={mode}
+					onChange={event => setMode(event.target.value as LateFeeMode)}
+					className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground"
+				>
+					<option value="percent">Percentage of the invoice</option>
+					<option value="flat">Flat one-time fee</option>
+				</select>
+			</div>
+
+			{mode === 'flat' ? (
+				<CalculatorInput
+					id="latefee-flat"
+					label="Flat fee"
+					type="number"
+					inputMode="decimal"
+					prefix="$"
+					value={flatFee}
+					onChange={event => setFlatFee(event.target.value)}
+					placeholder="25"
+				/>
+			) : (
+				<div className="flex items-end gap-content">
+					<div className="flex-1">
+						<CalculatorInput
+							id="latefee-rate"
+							label="Rate"
+							type="number"
+							inputMode="decimal"
+							suffix="%"
+							value={percentRate}
+							onChange={event => setPercentRate(event.target.value)}
+							placeholder="1.5"
+						/>
+					</div>
+					<div>
+						<label htmlFor={periodFieldId} className="sr-only">
+							Period
+						</label>
+						<select
+							id={periodFieldId}
+							value={period}
+							onChange={event => setPeriod(event.target.value as FeePeriod)}
+							className="rounded-md border border-border bg-background px-3 py-2.5 text-sm text-foreground"
+						>
+							{PERIODS.map(p => (
+								<option key={p.value} value={p.value}>
+									{p.label}
+								</option>
+							))}
+						</select>
+					</div>
+				</div>
+			)}
+
+			<div className="grid grid-cols-2 gap-content">
+				<CalculatorInput
+					id="latefee-days"
+					label="Days overdue"
+					type="number"
+					inputMode="numeric"
+					value={daysOverdue}
+					onChange={event => setDaysOverdue(event.target.value)}
+					placeholder="30"
+				/>
+				<CalculatorInput
+					id="latefee-grace"
+					label="Grace period (days)"
+					type="number"
+					inputMode="numeric"
+					value={grace}
+					onChange={event => setGrace(event.target.value)}
+					placeholder="0"
+				/>
+			</div>
+		</div>
+	)
+
+	const resultSlot = hasResult ? (
+		<div className="rounded-xl border border-border bg-surface-raised p-6 space-y-3">
+			<div>
+				<div className="text-xs text-muted-foreground">Late fee</div>
+				<div className="text-3xl font-bold text-accent tabular-nums">
+					{USD.format(result.lateFee)}
+				</div>
+			</div>
+			<div className="border-t border-border pt-3">
+				<div className="text-xs text-muted-foreground">Total now owed</div>
+				<div className="text-xl font-semibold text-foreground tabular-nums">
+					{USD.format(result.total)}
+				</div>
+			</div>
+			<p className="text-xs text-muted-foreground">
+				{amountNum <= 0
+					? 'Enter an invoice amount above $0 to calculate a fee.'
+					: feeInputMissing
+						? mode === 'percent'
+							? 'Enter a rate to calculate the fee.'
+							: 'Enter a flat fee to calculate the fee.'
+						: result.effectiveDays === 0
+							? hasGrace && daysNum > 0
+								? 'Still within the grace period, so no fee applies.'
+								: 'The invoice is not overdue, so no fee applies.'
+							: `Based on ${result.effectiveDays} chargeable day${
+									result.effectiveDays === 1 ? '' : 's'
+								} overdue.`}
+			</p>
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="Invoice Late Fee Calculator"
+			description="Work out the late fee and total owed on an overdue invoice, using a flat fee or a percentage rate per day, week, or month."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Enter an invoice amount and days overdue"
+		/>
+	)
+}

--- a/src/app/(public)/tools/invoice-late-fee-calculator/page.tsx
+++ b/src/app/(public)/tools/invoice-late-fee-calculator/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Invoice Late Fee Calculator
+ */
+
+import type { Metadata } from 'next'
+import InvoiceLateFeeCalculatorClient from './InvoiceLateFeeCalculatorClient'
+
+export const metadata: Metadata = {
+	title: 'Invoice Late Fee Calculator | Hudson Digital Solutions',
+	description:
+		'Free invoice late fee calculator. Work out the late fee and total owed on an overdue invoice using a flat fee or a percentage rate per day, week, or month.'
+}
+
+export default function InvoiceLateFeeCalculatorPage() {
+	return <InvoiceLateFeeCalculatorClient />
+}

--- a/src/app/(public)/tools/profit-margin-calculator/ProfitMarginCalculatorClient.tsx
+++ b/src/app/(public)/tools/profit-margin-calculator/ProfitMarginCalculatorClient.tsx
@@ -1,0 +1,149 @@
+/**
+ * Profit Margin & Markup Calculator
+ * Cost + price to margin %, markup %, and profit; plus price-for-margin.
+ */
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CalculatorInput } from '@/components/calculators/CalculatorInput'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { calculateMargin, priceForMargin } from '@/lib/margin-calculator'
+
+const USD = new Intl.NumberFormat('en-US', {
+	style: 'currency',
+	currency: 'USD'
+})
+
+function pct(value: number | null): string {
+	return value === null ? 'n/a' : `${value.toFixed(2)}%`
+}
+
+interface ResultRowProps {
+	label: string
+	value: string
+	emphasis?: boolean
+}
+
+function ResultRow({ label, value, emphasis }: ResultRowProps) {
+	return (
+		<div className="flex items-center justify-between border-b border-border py-3 last:border-0">
+			<span className="text-sm text-muted-foreground">{label}</span>
+			<span
+				className={
+					emphasis
+						? 'text-lg font-bold text-accent tabular-nums'
+						: 'text-sm font-semibold text-foreground tabular-nums'
+				}
+			>
+				{value}
+			</span>
+		</div>
+	)
+}
+
+export default function ProfitMarginCalculatorClient() {
+	const [cost, setCost] = useState('')
+	const [price, setPrice] = useState('')
+	const [targetMargin, setTargetMargin] = useState('')
+
+	const costNum = Number.parseFloat(cost)
+	const priceNum = Number.parseFloat(price)
+	// Negative cost/price are nonsensical (they produce impossible >100%
+	// margins). Gate on non-negative so a stray minus doesn't render a
+	// styled, valid-looking-but-wrong result. `min="0"` on the inputs
+	// blocks the common case; this guards typed/pasted negatives too.
+	const hasInputs =
+		Number.isFinite(costNum) &&
+		Number.isFinite(priceNum) &&
+		costNum >= 0 &&
+		priceNum >= 0
+
+	const result = useMemo(
+		() => calculateMargin(costNum, priceNum),
+		[costNum, priceNum]
+	)
+
+	const targetMarginNum = Number.parseFloat(targetMargin)
+	const suggestedPrice = useMemo(() => {
+		if (!Number.isFinite(costNum) || !Number.isFinite(targetMarginNum)) {
+			return null
+		}
+		return priceForMargin(costNum, targetMarginNum)
+	}, [costNum, targetMarginNum])
+
+	const hasResult = hasInputs
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			<div className="space-y-content">
+				<CalculatorInput
+					id="margin-cost"
+					label="Cost"
+					type="number"
+					inputMode="decimal"
+					prefix="$"
+					value={cost}
+					onChange={event => setCost(event.target.value)}
+					placeholder="60"
+				/>
+				<CalculatorInput
+					id="margin-price"
+					label="Selling price"
+					type="number"
+					inputMode="decimal"
+					prefix="$"
+					value={price}
+					onChange={event => setPrice(event.target.value)}
+					placeholder="100"
+				/>
+			</div>
+
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Reverse: price for a target margin
+				</legend>
+				<CalculatorInput
+					id="margin-target"
+					label="Target margin"
+					type="number"
+					inputMode="decimal"
+					suffix="%"
+					value={targetMargin}
+					onChange={event => setTargetMargin(event.target.value)}
+					placeholder="40"
+					helpText={
+						suggestedPrice !== null
+							? `Sell at ${USD.format(suggestedPrice)} to hit that margin on your cost.`
+							: 'Enter a cost and a target margin under 100%.'
+					}
+				/>
+			</fieldset>
+		</div>
+	)
+
+	const resultSlot = hasResult ? (
+		<div className="rounded-xl border border-border bg-surface-raised p-6">
+			<ResultRow label="Profit" value={USD.format(result.profit)} emphasis />
+			<ResultRow label="Gross margin" value={pct(result.marginPercent)} />
+			<ResultRow label="Markup" value={pct(result.markupPercent)} />
+			{Math.round(result.profit * 100) < 0 && (
+				<p className="mt-3 text-xs text-destructive-text">
+					This price is below cost, so you would take a loss.
+				</p>
+			)}
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="Profit Margin & Markup Calculator"
+			description="Enter your cost and selling price to see profit, gross margin, and markup. Margin is profit over price; markup is profit over cost."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Enter a cost and selling price to see your margin"
+		/>
+	)
+}

--- a/src/app/(public)/tools/profit-margin-calculator/page.tsx
+++ b/src/app/(public)/tools/profit-margin-calculator/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Profit Margin & Markup Calculator
+ */
+
+import type { Metadata } from 'next'
+import ProfitMarginCalculatorClient from './ProfitMarginCalculatorClient'
+
+export const metadata: Metadata = {
+	title: 'Profit Margin & Markup Calculator | Hudson Digital Solutions',
+	description:
+		'Free profit margin and markup calculator. Enter cost and selling price to get gross margin, markup, and profit, or find the price for a target margin.'
+}
+
+export default function ProfitMarginCalculatorPage() {
+	return <ProfitMarginCalculatorClient />
+}

--- a/src/app/(public)/tools/time-card-calculator/TimeCardCalculatorClient.tsx
+++ b/src/app/(public)/tools/time-card-calculator/TimeCardCalculatorClient.tsx
@@ -123,6 +123,17 @@ export default function TimeCardCalculatorClient() {
 								placeholder="0"
 							/>
 						</div>
+						<label className="mt-2 flex items-center gap-tight text-xs text-muted-foreground">
+							<input
+								type="checkbox"
+								checked={row.overnight}
+								onChange={event =>
+									updateRow(row.id, { overnight: event.target.checked })
+								}
+								className="rounded border-border text-accent focus:ring-accent"
+							/>
+							Overnight shift (clock-out is the next day)
+						</label>
 					</div>
 				))}
 				<button

--- a/src/app/(public)/tools/time-card-calculator/TimeCardCalculatorClient.tsx
+++ b/src/app/(public)/tools/time-card-calculator/TimeCardCalculatorClient.tsx
@@ -1,0 +1,218 @@
+/**
+ * Time Card / Hours Calculator
+ * Clock-in/out rows with breaks, overtime split, and optional pay.
+ */
+
+'use client'
+
+import { Plus, X } from 'lucide-react'
+import { useId, useMemo, useState } from 'react'
+import { CalculatorInput } from '@/components/calculators/CalculatorInput'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { calculateTimecard } from '@/lib/timecard-calculator'
+
+const USD = new Intl.NumberFormat('en-US', {
+	style: 'currency',
+	currency: 'USD'
+})
+
+interface Row {
+	id: string
+	clockIn: string
+	clockOut: string
+	breakMinutes: string
+	overnight: boolean
+}
+
+let rowSeq = 0
+function newRow(): Row {
+	rowSeq += 1
+	return {
+		id: `row-${rowSeq}`,
+		clockIn: '',
+		clockOut: '',
+		breakMinutes: '',
+		overnight: false
+	}
+}
+
+const fmtHours = (h: number) => `${h.toFixed(2)} h`
+
+export default function TimeCardCalculatorClient() {
+	const [rows, setRows] = useState<Row[]>(() => [newRow(), newRow()])
+	const [rate, setRate] = useState('')
+	const [threshold, setThreshold] = useState('40')
+	const thresholdFieldId = useId()
+
+	const result = useMemo(() => {
+		return calculateTimecard({
+			entries: rows.map(r => ({
+				clockIn: r.clockIn,
+				clockOut: r.clockOut,
+				breakMinutes: Number.parseFloat(r.breakMinutes),
+				overnight: r.overnight
+			})),
+			hourlyRate: Number.parseFloat(rate),
+			overtimeThresholdHours: Number.parseFloat(threshold)
+		})
+	}, [rows, rate, threshold])
+
+	const hasResult = result.totalHours > 0
+
+	const updateRow = (id: string, patch: Partial<Row>) => {
+		setRows(prev => prev.map(r => (r.id === id ? { ...r, ...patch } : r)))
+	}
+	const addRow = () => setRows(prev => [...prev, newRow()])
+	const removeRow = (id: string) =>
+		setRows(prev => (prev.length > 1 ? prev.filter(r => r.id !== id) : prev))
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			<div className="space-y-3">
+				{rows.map((row, index) => (
+					<div
+						key={row.id}
+						className="rounded-lg border border-border bg-surface-raised p-3"
+					>
+						<div className="flex items-center justify-between mb-2">
+							<span className="text-xs font-medium text-muted-foreground">
+								Day {index + 1}
+								{(result.perDay[index] ?? 0) > 0
+									? ` - ${fmtHours(result.perDay[index] ?? 0)}`
+									: ''}
+							</span>
+							{rows.length > 1 && (
+								<button
+									type="button"
+									onClick={() => removeRow(row.id)}
+									className="text-muted-foreground hover:text-destructive-text"
+									aria-label={`Remove day ${index + 1}`}
+								>
+									<X className="h-4 w-4" />
+								</button>
+							)}
+						</div>
+						<div className="grid grid-cols-3 gap-2">
+							<CalculatorInput
+								id={`${row.id}-in`}
+								label="In"
+								type="time"
+								value={row.clockIn}
+								onChange={event =>
+									updateRow(row.id, { clockIn: event.target.value })
+								}
+							/>
+							<CalculatorInput
+								id={`${row.id}-out`}
+								label="Out"
+								type="time"
+								value={row.clockOut}
+								onChange={event =>
+									updateRow(row.id, { clockOut: event.target.value })
+								}
+							/>
+							<CalculatorInput
+								id={`${row.id}-break`}
+								label="Break (min)"
+								type="number"
+								inputMode="numeric"
+								value={row.breakMinutes}
+								onChange={event =>
+									updateRow(row.id, { breakMinutes: event.target.value })
+								}
+								placeholder="0"
+							/>
+						</div>
+					</div>
+				))}
+				<button
+					type="button"
+					onClick={addRow}
+					className="flex items-center gap-tight text-sm text-accent hover:text-accent/80"
+				>
+					<Plus className="h-4 w-4" />
+					Add a day
+				</button>
+			</div>
+
+			<fieldset className="space-y-content border-t border-border pt-comfortable">
+				<legend className="text-sm font-semibold text-foreground">
+					Pay (optional)
+				</legend>
+				<div className="grid grid-cols-2 gap-content">
+					<CalculatorInput
+						id="timecard-rate"
+						label="Hourly rate"
+						type="number"
+						inputMode="decimal"
+						prefix="$"
+						value={rate}
+						onChange={event => setRate(event.target.value)}
+						placeholder="20"
+					/>
+					<CalculatorInput
+						id={thresholdFieldId}
+						label="Overtime after"
+						type="number"
+						inputMode="decimal"
+						suffix="h/wk"
+						value={threshold}
+						onChange={event => setThreshold(event.target.value)}
+						placeholder="40"
+						helpText="Hours above this are paid at 1.5x."
+					/>
+				</div>
+			</fieldset>
+		</div>
+	)
+
+	const resultSlot = hasResult ? (
+		<div className="rounded-xl border border-border bg-surface-raised p-6 space-y-3">
+			<div>
+				<div className="text-xs text-muted-foreground">Total hours</div>
+				<div className="text-3xl font-bold text-accent tabular-nums">
+					{fmtHours(result.totalHours)}
+				</div>
+			</div>
+			<div className="grid grid-cols-2 gap-3 border-t border-border pt-3">
+				<div>
+					<div className="text-xs text-muted-foreground">Regular</div>
+					<div className="text-sm font-semibold text-foreground tabular-nums">
+						{fmtHours(result.regularHours)}
+					</div>
+				</div>
+				<div>
+					<div className="text-xs text-muted-foreground">Overtime</div>
+					<div className="text-sm font-semibold text-foreground tabular-nums">
+						{fmtHours(result.overtimeHours)}
+					</div>
+				</div>
+			</div>
+			{result.totalPay !== null && (
+				<div className="border-t border-border pt-3">
+					<div className="text-xs text-muted-foreground">Gross pay</div>
+					<div className="text-xl font-semibold text-foreground tabular-nums">
+						{USD.format(result.totalPay)}
+					</div>
+					{result.overtimePay !== null && result.overtimePay > 0 && (
+						<p className="mt-1 text-xs text-muted-foreground">
+							Includes {USD.format(result.overtimePay)} overtime.
+						</p>
+					)}
+				</div>
+			)}
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="Time Card Calculator"
+			description="Add up clock-in and clock-out times with breaks to get total hours, overtime, and gross pay. Works for payroll and billable freelance hours."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Enter clock-in and clock-out times to total your hours"
+		/>
+	)
+}

--- a/src/app/(public)/tools/time-card-calculator/page.tsx
+++ b/src/app/(public)/tools/time-card-calculator/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Time Card / Hours Calculator
+ */
+
+import type { Metadata } from 'next'
+import TimeCardCalculatorClient from './TimeCardCalculatorClient'
+
+export const metadata: Metadata = {
+	title: 'Time Card Calculator with Breaks & Overtime | Hudson Digital',
+	description:
+		'Free time card calculator. Add clock-in and clock-out times with lunch breaks to total daily and weekly hours, split overtime, and calculate gross pay.'
+}
+
+export default function TimeCardCalculatorPage() {
+	return <TimeCardCalculatorClient />
+}

--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -1,7 +1,9 @@
 import {
 	Briefcase,
 	Calculator,
+	CalendarClock,
 	Car,
+	Clock,
 	Code2,
 	DollarSign,
 	FileSignature,
@@ -9,9 +11,11 @@ import {
 	Home,
 	List,
 	MapPin,
+	Percent,
 	Receipt,
 	Tags,
 	TrendingUp,
+	Type,
 	Zap
 } from 'lucide-react'
 import { TOOL_ROUTES } from '@/lib/constants/routes'
@@ -191,6 +195,48 @@ export const TOOLS: readonly ToolEntry[] = [
 		category: 'business'
 	},
 	{
+		title: 'Profit Margin & Markup Calculator',
+		description:
+			'Enter your cost and selling price to get gross margin, markup, and profit, or find the price for a target margin.',
+		href: TOOL_ROUTES.PROFIT_MARGIN_CALCULATOR,
+		Icon: Percent,
+		benefits: [
+			'Gross margin and markup',
+			'Profit per sale',
+			'Price for a target margin'
+		],
+		cta: 'Calculate Margin',
+		category: 'business'
+	},
+	{
+		title: 'Invoice Late Fee Calculator',
+		description:
+			'Work out the late fee and total owed on an overdue invoice, using a flat fee or a percentage rate per day, week, or month.',
+		href: TOOL_ROUTES.INVOICE_LATE_FEE_CALCULATOR,
+		Icon: CalendarClock,
+		benefits: [
+			'Flat or percentage fees',
+			'Daily, weekly, or monthly rates',
+			'Grace-period support'
+		],
+		cta: 'Calculate Late Fee',
+		category: 'business'
+	},
+	{
+		title: 'Time Card Calculator',
+		description:
+			'Add clock-in and clock-out times with breaks to total hours, split overtime, and calculate gross pay.',
+		href: TOOL_ROUTES.TIME_CARD_CALCULATOR,
+		Icon: Clock,
+		benefits: [
+			'Total daily and weekly hours',
+			'Overtime split at 1.5x',
+			'Optional gross pay'
+		],
+		cta: 'Total My Hours',
+		category: 'business'
+	},
+	{
 		title: 'Contract Generator',
 		description:
 			'Create professional contracts ready for signature with customizable terms and PDF download.',
@@ -258,6 +304,20 @@ export const TOOLS: readonly ToolEntry[] = [
 			'Remove duplicate items'
 		],
 		cta: 'Separate List',
+		category: 'developers'
+	},
+	{
+		title: 'Word & Character Counter',
+		description:
+			'Count words, characters, sentences, paragraphs, and reading time as you type. Handy for meta descriptions, tweets, and content limits.',
+		href: TOOL_ROUTES.WORD_COUNTER,
+		Icon: Type,
+		benefits: [
+			'Live word and character counts',
+			'Sentence and paragraph counts',
+			'Reading-time estimate'
+		],
+		cta: 'Count Words',
 		category: 'developers'
 	}
 	// The Testimonial Collector tool is admin-only (gated behind an

--- a/src/app/(public)/tools/word-counter/WordCounterClient.tsx
+++ b/src/app/(public)/tools/word-counter/WordCounterClient.tsx
@@ -1,0 +1,88 @@
+/**
+ * Word & Character Counter
+ * Live word, character, sentence, paragraph, and reading-time counts.
+ */
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import type { ToolAction } from '@/components/layout/ToolPageLayout'
+import { ToolPageLayout } from '@/components/layout/ToolPageLayout'
+import { analyzeText } from '@/lib/text-stats'
+
+interface StatCardProps {
+	label: string
+	value: string
+}
+
+function StatCard({ label, value }: StatCardProps) {
+	return (
+		<div className="rounded-lg border border-border bg-surface-raised px-4 py-3">
+			<div className="text-2xl font-bold text-accent tabular-nums">{value}</div>
+			<div className="text-xs text-muted-foreground">{label}</div>
+		</div>
+	)
+}
+
+export default function WordCounterClient() {
+	const [text, setText] = useState('')
+	const stats = useMemo(() => analyzeText(text), [text])
+	const hasResult = text.length > 0
+
+	const readingTime =
+		stats.readingTimeMinutes === 0 ? '0 min' : `${stats.readingTimeMinutes} min`
+
+	const clearAll = () => setText('')
+
+	const actions: ToolAction[] = [
+		{ type: 'reset', label: 'Clear', onClick: clearAll }
+	]
+
+	const formSlot = (
+		<div className="space-y-comfortable">
+			<div>
+				<label
+					htmlFor="word-counter-input"
+					className="block text-sm font-medium text-foreground mb-subheading"
+				>
+					Your text
+				</label>
+				<textarea
+					id="word-counter-input"
+					value={text}
+					onChange={event => setText(event.target.value)}
+					className="w-full rounded-md border border-border bg-background px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-accent"
+					rows={14}
+					placeholder="Type or paste your text to count words, characters, sentences, and reading time."
+				/>
+			</div>
+		</div>
+	)
+
+	const resultSlot = hasResult ? (
+		<div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+			<StatCard label="Words" value={stats.words.toLocaleString()} />
+			<StatCard label="Characters" value={stats.characters.toLocaleString()} />
+			<StatCard
+				label="Characters (no spaces)"
+				value={stats.charactersNoSpaces.toLocaleString()}
+			/>
+			<StatCard label="Sentences" value={stats.sentences.toLocaleString()} />
+			<StatCard label="Paragraphs" value={stats.paragraphs.toLocaleString()} />
+			<StatCard label="Reading time" value={readingTime} />
+		</div>
+	) : undefined
+
+	return (
+		<ToolPageLayout
+			title="Word & Character Counter"
+			description="Count words, characters, sentences, paragraphs, and reading time as you type. Handy for meta descriptions, tweets, essays, and content limits."
+			columns="two"
+			formSlot={formSlot}
+			resultSlot={resultSlot}
+			hasResult={hasResult}
+			resultPlaceholder="Start typing to see live counts"
+			actions={actions}
+		/>
+	)
+}

--- a/src/app/(public)/tools/word-counter/page.tsx
+++ b/src/app/(public)/tools/word-counter/page.tsx
@@ -1,0 +1,16 @@
+/**
+ * Word & Character Counter
+ */
+
+import type { Metadata } from 'next'
+import WordCounterClient from './WordCounterClient'
+
+export const metadata: Metadata = {
+	title: 'Word & Character Counter | Hudson Digital Solutions',
+	description:
+		'Free word and character counter. Live counts of words, characters, sentences, paragraphs, and reading time, perfect for meta descriptions, tweets, and content limits.'
+}
+
+export default function WordCounterPage() {
+	return <WordCounterClient />
+}

--- a/src/lib/constants/routes.ts
+++ b/src/lib/constants/routes.ts
@@ -36,6 +36,9 @@ export const TOOL_ROUTES = {
 	PERFORMANCE_CALCULATOR: '/tools/performance-calculator',
 	TIP_CALCULATOR: '/tools/tip-calculator',
 	PAYSTUB_CALCULATOR: '/tools/paystub-calculator',
+	PROFIT_MARGIN_CALCULATOR: '/tools/profit-margin-calculator',
+	INVOICE_LATE_FEE_CALCULATOR: '/tools/invoice-late-fee-calculator',
+	TIME_CARD_CALCULATOR: '/tools/time-card-calculator',
 	CONTRACT_GENERATOR: '/tools/contract-generator',
 	INVOICE_GENERATOR: '/tools/invoice-generator',
 	PROPOSAL_GENERATOR: '/tools/proposal-generator',
@@ -43,5 +46,6 @@ export const TOOL_ROUTES = {
 	META_TAG_GENERATOR: '/tools/meta-tag-generator',
 	SCHEMA_GENERATOR: '/tools/schema-generator',
 	COMMA_SEPARATOR: '/tools/comma-separator',
+	WORD_COUNTER: '/tools/word-counter',
 	TESTIMONIAL_COLLECTOR: '/tools/testimonial-collector'
 } as const

--- a/src/lib/late-fee-calculator.ts
+++ b/src/lib/late-fee-calculator.ts
@@ -1,0 +1,89 @@
+/**
+ * Invoice late fee calculator.
+ *
+ * Two policies:
+ *  - 'flat'    : a one-time fee charged once the invoice is overdue past
+ *                any grace period.
+ *  - 'percent' : simple interest at a rate per period (day/week/month),
+ *                prorated across the number of periods elapsed.
+ */
+
+export type LateFeeMode = 'flat' | 'percent'
+export type FeePeriod = 'day' | 'week' | 'month'
+
+export interface LateFeeInput {
+	amount: number
+	mode: LateFeeMode
+	/** Used when mode === 'flat'. */
+	flatFee?: number
+	/** Percentage per period, used when mode === 'percent'. */
+	percentRate?: number
+	/** Period the percent rate applies to. Default 'month'. */
+	period?: FeePeriod
+	daysOverdue: number
+	/** Days before any fee applies. Default 0. */
+	gracePeriodDays?: number
+}
+
+export interface LateFeeResult {
+	/** Days overdue after subtracting the grace period (never negative). */
+	effectiveDays: number
+	/** Periods elapsed (fractional) for percent mode; 0 for flat. */
+	periods: number
+	lateFee: number
+	total: number
+}
+
+const PERIOD_DAYS: Record<FeePeriod, number> = {
+	day: 1,
+	week: 7,
+	month: 30
+}
+
+const EMPTY: LateFeeResult = {
+	effectiveDays: 0,
+	periods: 0,
+	lateFee: 0,
+	total: 0
+}
+
+export function calculateLateFee(input: LateFeeInput): LateFeeResult {
+	const amount = Number.isFinite(input.amount) ? input.amount : 0
+	const daysOverdue = Number.isFinite(input.daysOverdue) ? input.daysOverdue : 0
+	const grace = Number.isFinite(input.gracePeriodDays ?? 0)
+		? (input.gracePeriodDays ?? 0)
+		: 0
+
+	const effectiveDays = Math.max(0, daysOverdue - Math.max(0, grace))
+
+	// Not overdue (or still within grace): no fee.
+	if (effectiveDays <= 0 || amount <= 0) {
+		return { ...EMPTY, total: Math.max(0, amount) }
+	}
+
+	if (input.mode === 'flat') {
+		const flatFee = Number.isFinite(input.flatFee ?? 0)
+			? Math.max(0, input.flatFee ?? 0)
+			: 0
+		return {
+			effectiveDays,
+			periods: 0,
+			lateFee: flatFee,
+			total: amount + flatFee
+		}
+	}
+
+	// percent
+	const rate = Number.isFinite(input.percentRate ?? 0)
+		? Math.max(0, input.percentRate ?? 0)
+		: 0
+	const period = input.period ?? 'month'
+	const periods = effectiveDays / PERIOD_DAYS[period]
+	const lateFee = amount * (rate / 100) * periods
+	return {
+		effectiveDays,
+		periods,
+		lateFee,
+		total: amount + lateFee
+	}
+}

--- a/src/lib/margin-calculator.ts
+++ b/src/lib/margin-calculator.ts
@@ -1,0 +1,47 @@
+/**
+ * Profit margin & markup calculator.
+ *
+ * Given a cost and a selling price, computes profit, gross margin %, and
+ * markup %. Margin and markup are distinct: margin is profit over PRICE,
+ * markup is profit over COST. A value is `null` when its denominator is
+ * zero (margin needs a non-zero price, markup needs a non-zero cost).
+ */
+
+export interface MarginResult {
+	profit: number
+	/** (price - cost) / price * 100. null when price is 0. */
+	marginPercent: number | null
+	/** (price - cost) / cost * 100. null when cost is 0. */
+	markupPercent: number | null
+}
+
+export function calculateMargin(cost: number, price: number): MarginResult {
+	if (!Number.isFinite(cost) || !Number.isFinite(price)) {
+		return { profit: Number.NaN, marginPercent: null, markupPercent: null }
+	}
+	const profit = price - cost
+	const marginPercent = price !== 0 ? (profit / price) * 100 : null
+	const markupPercent = cost !== 0 ? (profit / cost) * 100 : null
+	return { profit, marginPercent, markupPercent }
+}
+
+/**
+ * Selling price needed to hit a target margin % on a given cost.
+ * price = cost / (1 - margin/100). Returns null for an unreachable
+ * margin (>= 100%, since that implies zero or negative cost basis).
+ */
+export function priceForMargin(
+	cost: number,
+	targetMarginPercent: number
+): number | null {
+	if (!Number.isFinite(cost) || !Number.isFinite(targetMarginPercent)) {
+		return null
+	}
+	const m = targetMarginPercent / 100
+	// Reject negative targets (would imply a sell-below-cost price) and
+	// >=100% (mathematically unreachable with a non-zero cost basis).
+	if (m < 0 || m >= 1) {
+		return null
+	}
+	return cost / (1 - m)
+}

--- a/src/lib/text-stats.ts
+++ b/src/lib/text-stats.ts
@@ -1,0 +1,78 @@
+/**
+ * Text statistics for the Word & Character Counter.
+ *
+ * Character counts use UTF-16 length (`String.length`) to match what
+ * textarea `maxlength`, Twitter/X, and meta-description limits count, so
+ * the number lines up with the limits people check against.
+ */
+
+export interface TextStats {
+	words: number
+	/** Characters including spaces (UTF-16 length). */
+	characters: number
+	/** Characters excluding any whitespace. */
+	charactersNoSpaces: number
+	sentences: number
+	paragraphs: number
+	lines: number
+	/** Whole minutes at 200 words/min, rounded up. 0 for empty text. */
+	readingTimeMinutes: number
+}
+
+const WORDS_PER_MINUTE = 200
+
+const EMPTY: TextStats = {
+	words: 0,
+	characters: 0,
+	charactersNoSpaces: 0,
+	sentences: 0,
+	paragraphs: 0,
+	lines: 0,
+	readingTimeMinutes: 0
+}
+
+export function analyzeText(text: string): TextStats {
+	if (typeof text !== 'string' || text.length === 0) {
+		return { ...EMPTY }
+	}
+
+	const characters = text.length
+	const charactersNoSpaces = text.replace(/\s/g, '').length
+
+	const trimmed = text.trim()
+	if (trimmed.length === 0) {
+		// Whitespace-only: it has characters and lines but no words/sentences.
+		return {
+			...EMPTY,
+			characters,
+			charactersNoSpaces,
+			lines: text.split('\n').length
+		}
+	}
+
+	const words = trimmed.split(/\s+/u).filter(Boolean).length
+
+	// Sentence-ending punctuation groups followed by a space or end of text.
+	// Falls back to 1 for text that has no terminal punctuation at all.
+	const sentenceMatches = trimmed.match(/[.!?]+(?=["')\]’”]*(?:\s|$))/g)
+	const sentences = sentenceMatches ? sentenceMatches.length : 1
+
+	// Paragraphs are blocks separated by one or more blank lines.
+	const paragraphs = trimmed
+		.split(/\n\s*\n/)
+		.filter(p => p.trim().length > 0).length
+
+	const lines = text.split('\n').length
+
+	const readingTimeMinutes = Math.ceil(words / WORDS_PER_MINUTE)
+
+	return {
+		words,
+		characters,
+		charactersNoSpaces,
+		sentences,
+		paragraphs,
+		lines,
+		readingTimeMinutes
+	}
+}

--- a/src/lib/timecard-calculator.ts
+++ b/src/lib/timecard-calculator.ts
@@ -1,0 +1,123 @@
+/**
+ * Time card / hours calculator.
+ *
+ * Each entry is a clock-in / clock-out pair ("HH:MM", 24h) plus optional
+ * unpaid break minutes. Overnight shifts (clock-out earlier than
+ * clock-in) roll over to the next day. Weekly hours past the overtime
+ * threshold are paid at the overtime multiplier.
+ */
+
+export interface TimeEntry {
+	clockIn: string
+	clockOut: string
+	breakMinutes?: number
+	/**
+	 * Opt-in for a shift that crosses midnight. Only when true does a
+	 * clock-out earlier than clock-in roll over to the next day. Without
+	 * it, an out-before-in entry (usually a typo) returns 0 hours rather
+	 * than silently becoming a ~24h shift.
+	 */
+	overnight?: boolean
+}
+
+export interface TimecardInput {
+	entries: readonly TimeEntry[]
+	hourlyRate?: number
+	/** Weekly hours before overtime kicks in. Default 40. */
+	overtimeThresholdHours?: number
+	/** Overtime pay multiplier. Default 1.5. */
+	overtimeMultiplier?: number
+}
+
+export interface TimecardResult {
+	/** Worked hours per entry (same order/length as input entries). */
+	perDay: number[]
+	totalHours: number
+	regularHours: number
+	overtimeHours: number
+	regularPay: number | null
+	overtimePay: number | null
+	totalPay: number | null
+}
+
+const MINUTES_PER_DAY = 24 * 60
+
+/** Parse "HH:MM" (24h) into minutes since midnight, or null if invalid. */
+export function parseTime(value: string | undefined): number | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+	const match = value.trim().match(/^(\d{1,2}):(\d{2})$/)
+	if (!match) {
+		return null
+	}
+	const hours = Number(match[1])
+	const minutes = Number(match[2])
+	if (hours > 23 || minutes > 59) {
+		return null
+	}
+	return hours * 60 + minutes
+}
+
+/** Hours worked for one entry; 0 if the times are invalid/unparseable. */
+export function entryHours(entry: TimeEntry): number {
+	const start = parseTime(entry.clockIn)
+	const end = parseTime(entry.clockOut)
+	if (start === null || end === null) {
+		return 0
+	}
+	// Same or later clock-out: a normal same-day shift. Earlier clock-out
+	// is a real overnight shift ONLY if explicitly flagged; otherwise it's
+	// a transposed/typo entry and we return 0 (visibly wrong, prompts a
+	// fix) rather than silently inventing a ~24h shift.
+	let span: number
+	if (end >= start) {
+		span = end - start
+	} else if (entry.overnight) {
+		span = end + MINUTES_PER_DAY - start
+	} else {
+		return 0
+	}
+	const breakMin =
+		Number.isFinite(entry.breakMinutes ?? 0) && (entry.breakMinutes ?? 0) > 0
+			? (entry.breakMinutes as number)
+			: 0
+	const worked = Math.max(0, span - breakMin)
+	return worked / 60
+}
+
+export function calculateTimecard(input: TimecardInput): TimecardResult {
+	const perDay = input.entries.map(entryHours)
+	const totalHours = perDay.reduce((sum, h) => sum + h, 0)
+
+	const threshold = Number.isFinite(input.overtimeThresholdHours ?? 40)
+		? Math.max(0, input.overtimeThresholdHours ?? 40)
+		: 40
+	const multiplier = Number.isFinite(input.overtimeMultiplier ?? 1.5)
+		? Math.max(0, input.overtimeMultiplier ?? 1.5)
+		: 1.5
+
+	const regularHours = Math.min(totalHours, threshold)
+	const overtimeHours = Math.max(0, totalHours - threshold)
+
+	const rate = input.hourlyRate
+	const hasRate = typeof rate === 'number' && Number.isFinite(rate) && rate >= 0
+	const regularPay = hasRate ? regularHours * (rate as number) : null
+	const overtimePay = hasRate
+		? overtimeHours * (rate as number) * multiplier
+		: null
+	const totalPay =
+		regularPay !== null && overtimePay !== null
+			? regularPay + overtimePay
+			: null
+
+	return {
+		perDay,
+		totalHours,
+		regularHours,
+		overtimeHours,
+		regularPay,
+		overtimePay,
+		totalPay
+	}
+}

--- a/tests/unit/late-fee-calculator.test.ts
+++ b/tests/unit/late-fee-calculator.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test'
+import { calculateLateFee } from '@/lib/late-fee-calculator'
+
+describe('calculateLateFee', () => {
+	test('flat fee once overdue', () => {
+		const r = calculateLateFee({
+			amount: 1000,
+			mode: 'flat',
+			flatFee: 25,
+			daysOverdue: 10
+		})
+		expect(r.lateFee).toBe(25)
+		expect(r.total).toBe(1025)
+		expect(r.effectiveDays).toBe(10)
+	})
+
+	test('percent: 1.5% per month, one month overdue', () => {
+		const r = calculateLateFee({
+			amount: 1000,
+			mode: 'percent',
+			percentRate: 1.5,
+			period: 'month',
+			daysOverdue: 30
+		})
+		expect(r.periods).toBeCloseTo(1)
+		expect(r.lateFee).toBeCloseTo(15)
+		expect(r.total).toBeCloseTo(1015)
+	})
+
+	test('percent prorates fractional periods', () => {
+		const r = calculateLateFee({
+			amount: 1000,
+			mode: 'percent',
+			percentRate: 1.5,
+			period: 'month',
+			daysOverdue: 45
+		})
+		expect(r.periods).toBeCloseTo(1.5)
+		expect(r.lateFee).toBeCloseTo(22.5)
+	})
+
+	test('percent daily rate', () => {
+		const r = calculateLateFee({
+			amount: 500,
+			mode: 'percent',
+			percentRate: 0.1,
+			period: 'day',
+			daysOverdue: 10
+		})
+		expect(r.periods).toBeCloseTo(10)
+		expect(r.lateFee).toBeCloseTo(5)
+	})
+
+	test('grace period suppresses the fee until passed', () => {
+		const within = calculateLateFee({
+			amount: 1000,
+			mode: 'flat',
+			flatFee: 25,
+			daysOverdue: 5,
+			gracePeriodDays: 7
+		})
+		expect(within.lateFee).toBe(0)
+		expect(within.total).toBe(1000)
+
+		const past = calculateLateFee({
+			amount: 1000,
+			mode: 'flat',
+			flatFee: 25,
+			daysOverdue: 10,
+			gracePeriodDays: 7
+		})
+		expect(past.effectiveDays).toBe(3)
+		expect(past.lateFee).toBe(25)
+	})
+
+	test('not overdue: no fee, total is the amount', () => {
+		const r = calculateLateFee({
+			amount: 1000,
+			mode: 'percent',
+			percentRate: 5,
+			daysOverdue: 0
+		})
+		expect(r.lateFee).toBe(0)
+		expect(r.total).toBe(1000)
+	})
+
+	test('negative / invalid inputs do not produce negative fees', () => {
+		const r = calculateLateFee({
+			amount: 1000,
+			mode: 'flat',
+			flatFee: -50,
+			daysOverdue: 10
+		})
+		expect(r.lateFee).toBe(0)
+
+		const neg = calculateLateFee({
+			amount: -100,
+			mode: 'percent',
+			percentRate: 5,
+			daysOverdue: 30
+		})
+		expect(neg.lateFee).toBe(0)
+		expect(neg.total).toBe(0)
+	})
+})

--- a/tests/unit/margin-calculator.test.ts
+++ b/tests/unit/margin-calculator.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+import { calculateMargin, priceForMargin } from '@/lib/margin-calculator'
+
+describe('calculateMargin', () => {
+	test('basic margin and markup', () => {
+		const r = calculateMargin(60, 100)
+		expect(r.profit).toBe(40)
+		expect(r.marginPercent).toBeCloseTo(40)
+		expect(r.markupPercent).toBeCloseTo(66.6667, 3)
+	})
+
+	test('margin and markup differ (the core point of the tool)', () => {
+		const r = calculateMargin(80, 100)
+		expect(r.marginPercent).toBeCloseTo(20) // profit / price
+		expect(r.markupPercent).toBeCloseTo(25) // profit / cost
+	})
+
+	test('selling at cost is zero margin/markup', () => {
+		const r = calculateMargin(50, 50)
+		expect(r.profit).toBe(0)
+		expect(r.marginPercent).toBe(0)
+		expect(r.markupPercent).toBe(0)
+	})
+
+	test('selling below cost is a loss (negative)', () => {
+		const r = calculateMargin(100, 80)
+		expect(r.profit).toBe(-20)
+		expect(r.marginPercent).toBeCloseTo(-25)
+		expect(r.markupPercent).toBeCloseTo(-20)
+	})
+
+	test('zero price yields null margin (undefined ratio)', () => {
+		expect(calculateMargin(10, 0).marginPercent).toBeNull()
+	})
+
+	test('zero cost yields null markup (infinite ratio)', () => {
+		const r = calculateMargin(0, 100)
+		expect(r.markupPercent).toBeNull()
+		expect(r.marginPercent).toBeCloseTo(100)
+	})
+
+	test('non-finite inputs are handled', () => {
+		const r = calculateMargin(Number.NaN, 100)
+		expect(r.marginPercent).toBeNull()
+		expect(r.markupPercent).toBeNull()
+	})
+})
+
+describe('priceForMargin', () => {
+	test('price needed for a target margin', () => {
+		// 40% margin on $60 cost -> $100 price
+		expect(priceForMargin(60, 40)).toBeCloseTo(100)
+	})
+
+	test('unreachable margin (>=100%) returns null', () => {
+		expect(priceForMargin(60, 100)).toBeNull()
+		expect(priceForMargin(60, 150)).toBeNull()
+	})
+
+	test('negative target margin returns null (no sell-below-cost price)', () => {
+		expect(priceForMargin(60, -50)).toBeNull()
+		expect(priceForMargin(60, -1)).toBeNull()
+	})
+
+	test('valid positive target still works after the guard', () => {
+		expect(priceForMargin(60, 25)).toBeCloseTo(80)
+	})
+})

--- a/tests/unit/text-stats.test.ts
+++ b/tests/unit/text-stats.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+import { analyzeText } from '@/lib/text-stats'
+
+describe('analyzeText', () => {
+	test('counts words and characters', () => {
+		const s = analyzeText('hello world')
+		expect(s.words).toBe(2)
+		expect(s.characters).toBe(11)
+		expect(s.charactersNoSpaces).toBe(10)
+	})
+
+	test('collapses multiple spaces for word count', () => {
+		expect(analyzeText('a   b\t c').words).toBe(3)
+	})
+
+	test('empty string is all zeroes', () => {
+		expect(analyzeText('')).toEqual({
+			words: 0,
+			characters: 0,
+			charactersNoSpaces: 0,
+			sentences: 0,
+			paragraphs: 0,
+			lines: 0,
+			readingTimeMinutes: 0
+		})
+	})
+
+	test('whitespace-only has characters and lines but no words', () => {
+		const s = analyzeText('  \n  ')
+		expect(s.words).toBe(0)
+		expect(s.sentences).toBe(0)
+		expect(s.characters).toBe(5)
+		expect(s.lines).toBe(2)
+	})
+
+	test('counts sentences', () => {
+		expect(analyzeText('One. Two! Three?').sentences).toBe(3)
+	})
+
+	test('groups repeated terminators as one sentence', () => {
+		expect(analyzeText('Wait... really?!').sentences).toBe(2)
+	})
+
+	test('text with no terminator counts as one sentence', () => {
+		expect(analyzeText('just a fragment').sentences).toBe(1)
+	})
+
+	test('counts a sentence ending in a closing quote', () => {
+		expect(analyzeText('He said "Stop." Now go.').sentences).toBe(2)
+	})
+
+	test('counts a sentence ending in a closing paren', () => {
+		expect(analyzeText('This (done.) Next one.').sentences).toBe(2)
+	})
+
+	test('counts paragraphs split by blank lines', () => {
+		expect(analyzeText('Para one.\n\nPara two.\n\nPara three.').paragraphs).toBe(
+			3
+		)
+	})
+
+	test('counts lines', () => {
+		expect(analyzeText('a\nb\nc').lines).toBe(3)
+	})
+
+	test('reading time rounds up at 200 wpm', () => {
+		const text = Array.from({ length: 201 }, () => 'word').join(' ')
+		expect(analyzeText(text).readingTimeMinutes).toBe(2)
+		expect(analyzeText('one word here').readingTimeMinutes).toBe(1)
+	})
+
+	test('character count is the UTF-16 length (matches textarea limits)', () => {
+		// 'h','i',' ' = 3, plus the rocket emoji which is a surrogate pair
+		// (length 2) = 5 total, matching what textarea maxlength counts.
+		expect(analyzeText('hi 🚀').characters).toBe(5)
+	})
+})

--- a/tests/unit/timecard-calculator.test.ts
+++ b/tests/unit/timecard-calculator.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+import {
+	calculateTimecard,
+	entryHours,
+	parseTime
+} from '@/lib/timecard-calculator'
+
+describe('parseTime', () => {
+	test('parses HH:MM', () => {
+		expect(parseTime('09:00')).toBe(540)
+		expect(parseTime('17:30')).toBe(1050)
+		expect(parseTime('00:00')).toBe(0)
+		expect(parseTime('23:59')).toBe(1439)
+	})
+
+	test('rejects invalid', () => {
+		expect(parseTime('24:00')).toBeNull()
+		expect(parseTime('12:60')).toBeNull()
+		expect(parseTime('abc')).toBeNull()
+		expect(parseTime('')).toBeNull()
+		expect(parseTime('9')).toBeNull()
+	})
+})
+
+describe('entryHours', () => {
+	test('basic shift minus break', () => {
+		expect(entryHours({ clockIn: '09:00', clockOut: '17:00' })).toBe(8)
+		expect(
+			entryHours({ clockIn: '09:00', clockOut: '17:00', breakMinutes: 30 })
+		).toBe(7.5)
+	})
+
+	test('overnight shift rolls over only when flagged', () => {
+		expect(
+			entryHours({ clockIn: '22:00', clockOut: '06:00', overnight: true })
+		).toBe(8)
+	})
+
+	test('out-before-in without the overnight flag returns 0 (likely a typo)', () => {
+		expect(entryHours({ clockIn: '22:00', clockOut: '06:00' })).toBe(0)
+		expect(entryHours({ clockIn: '09:00', clockOut: '08:59' })).toBe(0)
+	})
+
+	test('identical clock-in/out still returns 0 (safe payroll default)', () => {
+		expect(entryHours({ clockIn: '09:00', clockOut: '09:00' })).toBe(0)
+	})
+
+	test('invalid times yield 0', () => {
+		expect(entryHours({ clockIn: 'x', clockOut: '17:00' })).toBe(0)
+	})
+
+	test('break longer than the shift clamps to 0', () => {
+		expect(
+			entryHours({ clockIn: '09:00', clockOut: '10:00', breakMinutes: 120 })
+		).toBe(0)
+	})
+})
+
+describe('calculateTimecard', () => {
+	test('sums hours across entries', () => {
+		const r = calculateTimecard({
+			entries: [
+				{ clockIn: '09:00', clockOut: '17:00' },
+				{ clockIn: '09:00', clockOut: '12:00' }
+			]
+		})
+		expect(r.totalHours).toBe(11)
+		expect(r.perDay).toEqual([8, 3])
+	})
+
+	test('splits regular vs overtime past the weekly threshold', () => {
+		const r = calculateTimecard({
+			entries: [
+				{ clockIn: '08:00', clockOut: '18:00' }, // 10
+				{ clockIn: '08:00', clockOut: '18:00' }, // 10
+				{ clockIn: '08:00', clockOut: '18:00' }, // 10
+				{ clockIn: '08:00', clockOut: '18:00' }, // 10
+				{ clockIn: '08:00', clockOut: '13:00' } // 5 -> total 45
+			],
+			hourlyRate: 20
+		})
+		expect(r.totalHours).toBe(45)
+		expect(r.regularHours).toBe(40)
+		expect(r.overtimeHours).toBe(5)
+		expect(r.regularPay).toBe(800)
+		expect(r.overtimePay).toBe(150) // 5 * 20 * 1.5
+		expect(r.totalPay).toBe(950)
+	})
+
+	test('pay is null without a rate', () => {
+		const r = calculateTimecard({
+			entries: [{ clockIn: '09:00', clockOut: '17:00' }]
+		})
+		expect(r.totalPay).toBeNull()
+		expect(r.regularPay).toBeNull()
+	})
+
+	test('custom overtime threshold and multiplier', () => {
+		const r = calculateTimecard({
+			entries: [{ clockIn: '00:00', clockOut: '10:00' }], // 10h
+			hourlyRate: 10,
+			overtimeThresholdHours: 8,
+			overtimeMultiplier: 2
+		})
+		expect(r.regularHours).toBe(8)
+		expect(r.overtimeHours).toBe(2)
+		expect(r.totalPay).toBe(8 * 10 + 2 * 10 * 2) // 80 + 40 = 120
+	})
+
+	test('empty entries produce zeroes', () => {
+		const r = calculateTimecard({ entries: [] })
+		expect(r.totalHours).toBe(0)
+		expect(r.perDay).toEqual([])
+	})
+})


### PR DESCRIPTION
Build-next #2-5 from the tool-expansion research, shipped as one batch. Each is a pure client-side util + `ToolPageLayout` client, registered in the tools index, `TOOL_ROUTES`, and the cmdk palette.

| Tool | Category | Route |
|---|---|---|
| Profit Margin & Markup Calculator | Business | `/tools/profit-margin-calculator` |
| Invoice Late Fee Calculator | Business | `/tools/invoice-late-fee-calculator` |
| Time Card Calculator | Business | `/tools/time-card-calculator` |
| Word & Character Counter | Developers | `/tools/word-counter` |

## Battle-tested
8-lens adversarial workflow across all 4 utils + per-finding verification. The arithmetic was sound everywhere; confirmed fixes were input-hygiene and caption-honesty:
- **Margin** — reject negative cost/price (which produced impossible >100% margins) and negative target margins; gate the loss banner on the cents-rounded value so it can't show \"-$0.00\" beside a loss warning.
- **Late fee** — state-aware result caption (not-overdue vs within-grace vs zero-amount vs missing-rate) instead of always blaming a grace period.
- **Time card** — out-before-in no longer silently becomes a ~24h shift; overnight rollover is an explicit per-row opt-in (a typo now reads 0h).
- **Word counter** — sentence regex now counts sentences ending in a closing quote/paren.

Left as documented/intentional (verifier ruled works-as-intended): 30-day-month late-fee proration, weekly (not daily) overtime, abbreviation over-count in sentence detection, UTF-16 character counting.

## Test plan
- [x] 50 unit tests across the 4 new utils
- [x] `bun run typecheck` / `bun run lint`
- [x] `bun test tests/` — 895 pass
- [x] `bun run build` exit 0 (all 4 routes prerender static)

[hudsor01]