### PR TITLE
fix(blog): skeleton loaders mirror BlogPostCard shape (#275)

### DIFF
--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import { BlogPostCard } from '@/components/blog/BlogPostCard'
+import { BlogPostCardSkeleton } from '@/components/blog/BlogPostCardSkeleton'
 import { TagList } from '@/components/blog/TagList'
 import { Button } from '@/components/ui/button'
 import { getFeaturedPosts, getPosts, getTagsWithCounts } from '@/lib/blog'
@@ -113,10 +114,7 @@ function PostListSkeleton() {
 	return (
 		<div className="space-y-6" aria-hidden="true">
 			{[0, 1, 2].map(i => (
-				<div
-					key={i}
-					className="h-40 rounded-xl border border-border bg-muted/30 animate-pulse"
-				/>
+				<BlogPostCardSkeleton key={i} />
 			))}
 		</div>
 	)
@@ -131,10 +129,7 @@ function FeaturedSkeleton() {
 					aria-hidden="true"
 				>
 					{[0, 1, 2].map(i => (
-						<div
-							key={i}
-							className="aspect-video rounded-xl border border-border bg-muted/30 animate-pulse"
-						/>
+						<BlogPostCardSkeleton key={i} />
 					))}
 				</div>
 			</div>

--- a/src/components/blog/BlogPostCardSkeleton.tsx
+++ b/src/components/blog/BlogPostCardSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * Loading placeholder that mirrors the real BlogPostCard layout
+ * (aspect-video image + p-6 content with title, excerpt, and a meta
+ * row) so the skeleton occupies the same shape the content will, with
+ * no layout shift when posts resolve. Audit #275.
+ */
+export function BlogPostCardSkeleton() {
+	return (
+		<article
+			className="flex flex-col overflow-hidden rounded-xl border border-border bg-surface-raised"
+			aria-hidden="true"
+		>
+			{/* Image */}
+			<div className="aspect-video bg-muted/40 animate-pulse" />
+
+			{/* Content */}
+			<div className="flex flex-1 flex-col p-6">
+				{/* Title (two lines) */}
+				<div className="mb-3 space-y-2">
+					<div className="h-5 w-11/12 rounded bg-muted/40 animate-pulse" />
+					<div className="h-5 w-2/3 rounded bg-muted/40 animate-pulse" />
+				</div>
+				{/* Excerpt (three lines) */}
+				<div className="mb-4 space-y-2">
+					<div className="h-3 w-full rounded bg-muted/30 animate-pulse" />
+					<div className="h-3 w-full rounded bg-muted/30 animate-pulse" />
+					<div className="h-3 w-4/5 rounded bg-muted/30 animate-pulse" />
+				</div>
+				{/* Meta row (date + reading time) */}
+				<div className="mt-auto flex items-center gap-4">
+					<div className="h-3 w-20 rounded bg-muted/30 animate-pulse" />
+					<div className="h-3 w-14 rounded bg-muted/30 animate-pulse" />
+				</div>
+			</div>
+		</article>
+	)
+}


### PR DESCRIPTION
The last open audit issue. Blog loading skeletons were generic blocks (flat `h-40` bars for the post list, bare `aspect-video` tiles for featured) that didn't match the real `BlogPostCard` layout, so content visibly jumped when posts resolved.

New shared `BlogPostCardSkeleton` mirrors the actual card shape: `aspect-video` image placeholder + `p-6` content with title (2 lines), excerpt (3 lines), and a meta row (date + reading time). Both `PostListSkeleton` and `FeaturedSkeleton` now render it, so the placeholder occupies the same footprint the content will and there's no layout shift.

Closes #275.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test tests/` — 895 pass
- [x] `bun run build` exit 0

[hudsor01]