### PR TITLE
fix(seo): stop pages canonicalizing to the homepage

### DIFF
--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/contact' },
 	title: 'Get a Free Website Plan | Hudson Digital Solutions',
 	description:
 		"Tell us about your business and we'll map out the website it needs (pages, timeline, and cost) on a free 30-minute call. No sales pitch.",

--- a/src/app/(public)/help/[category]/[slug]/page.tsx
+++ b/src/app/(public)/help/[category]/[slug]/page.tsx
@@ -37,7 +37,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({
 	params
 }: PageProps): Promise<Metadata> {
-	const { slug } = await params
+	const { category, slug } = await params
 	const article = await getArticleBySlug(slug)
 
 	if (!article) {
@@ -49,7 +49,8 @@ export async function generateMetadata({
 	return {
 		title: `${article.title} | Help Center | Hudson Digital Solutions`,
 		description:
-			article.excerpt || `Read about ${article.title} in our help center.`
+			article.excerpt || `Read about ${article.title} in our help center.`,
+		alternates: { canonical: `/help/${category}/${slug}` }
 	}
 }
 

--- a/src/app/(public)/help/[category]/page.tsx
+++ b/src/app/(public)/help/[category]/page.tsx
@@ -69,7 +69,8 @@ export async function generateMetadata({
 
 	return {
 		title: `${categoryInfo.name} | Help Center | Hudson Digital Solutions`,
-		description: categoryInfo.description
+		description: categoryInfo.description,
+		alternates: { canonical: `/help/${category}` }
 	}
 }
 

--- a/src/app/(public)/help/page.tsx
+++ b/src/app/(public)/help/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link'
 import { getCategoriesWithCounts } from '@/lib/help-articles'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/help' },
 	title: 'Help Center | Hudson Digital Solutions',
 	description:
 		'Find answers to common questions, learn how to use our tools, and get support from Hudson Digital Solutions.'

--- a/src/app/(public)/locations/page.tsx
+++ b/src/app/(public)/locations/page.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button'
 import { getLocationsByState } from '@/lib/locations'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/locations' },
 	title: 'Service Locations | Hudson Digital Solutions',
 	description:
 		'Hudson Digital Solutions builds websites for small businesses across the US. Find professional web design in your city: Texas, Florida, Georgia, and more.',

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { formatDate } from '@/lib/utils'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/privacy' },
 	title: 'Privacy Policy | Hudson Digital Solutions',
 	description:
 		'Learn how Hudson Digital Solutions collects, uses, and protects your personal information. Our commitment to your privacy and data security.',

--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -10,6 +10,7 @@ import { getShowcaseItems } from '@/lib/showcase'
 // Caching handled at data-layer level (src/lib/showcase.ts uses 'use cache'
 // + cacheLife). Page-level revalidate is incompatible with cacheComponents.
 export const metadata: Metadata = {
+	alternates: { canonical: '/showcase' },
 	title: 'Showcase | Hudson Digital Solutions',
 	description:
 		'Real websites delivering measurable results for small businesses. See how we help local businesses get found online, win customers, and grow.',

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { formatDate } from '@/lib/utils'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/terms' },
 	title: 'Terms of Service | Hudson Digital Solutions',
 	description:
 		'Read the Terms of Service for Hudson Digital Solutions. Understand your rights and obligations when using our website and services.',

--- a/src/app/(public)/testimonials/page.tsx
+++ b/src/app/(public)/testimonials/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/testimonials' },
 	title: 'Client Testimonials | Hudson Digital Solutions',
 	description:
 		'Real results from the small businesses we have built websites for. See how a professional website turned local reputations into booked customers.'

--- a/src/app/(public)/tools/comma-separator/page.tsx
+++ b/src/app/(public)/tools/comma-separator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import CommaSeparatorClient from './CommaSeparatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/comma-separator' },
 	title: 'Comma Separator - Column to Comma Separated List | Hudson Digital',
 	description:
 		'Free tool to convert a column of values into a comma-separated list. Paste a spreadsheet column or space-separated list and get a clean comma-separated series, with optional quotes.'

--- a/src/app/(public)/tools/contract-generator/page.tsx
+++ b/src/app/(public)/tools/contract-generator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import ContractGeneratorClient from './ContractGeneratorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/contract-generator' },
 	title: 'Contract Generator | Hudson Digital Solutions',
 	description:
 		'Create professional contracts with PDF download. Free contract generator with customizable clauses, terms, and legal templates.',

--- a/src/app/(public)/tools/cost-estimator/page.tsx
+++ b/src/app/(public)/tools/cost-estimator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import { CostEstimatorClient } from './CostEstimatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/cost-estimator' },
 	title: 'Website Cost Estimator | Hudson Digital Solutions',
 	description:
 		'Get an instant estimate for your website project based on your specific requirements, features, and design complexity.',

--- a/src/app/(public)/tools/invoice-generator/page.tsx
+++ b/src/app/(public)/tools/invoice-generator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import InvoiceGeneratorClient from './InvoiceGeneratorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/invoice-generator' },
 	title: 'Invoice Generator | Hudson Digital Solutions',
 	description:
 		'Create professional invoices with PDF download. Free invoice generator with customizable line items, tax calculations, and branding.',

--- a/src/app/(public)/tools/invoice-late-fee-calculator/page.tsx
+++ b/src/app/(public)/tools/invoice-late-fee-calculator/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next'
 import InvoiceLateFeeCalculatorClient from './InvoiceLateFeeCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/invoice-late-fee-calculator' },
 	title: 'Invoice Late Fee Calculator | Hudson Digital Solutions',
 	description:
 		'Free invoice late fee calculator. Work out the late fee and total owed on an overdue invoice using a flat fee or a percentage rate per day, week, or month.'

--- a/src/app/(public)/tools/json-formatter/page.tsx
+++ b/src/app/(public)/tools/json-formatter/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import JsonFormatterClient from './JsonFormatterClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/json-formatter' },
 	title: 'JSON Formatter | Hudson Digital Solutions',
 	description:
 		'Format, validate, and minify JSON data online. Free JSON formatter with syntax highlighting and error detection.',

--- a/src/app/(public)/tools/meta-tag-generator/page.tsx
+++ b/src/app/(public)/tools/meta-tag-generator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import MetaTagGeneratorClient from './MetaTagGeneratorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/meta-tag-generator' },
 	title: 'Meta Tag Generator | Hudson Digital Solutions',
 	description:
 		'Generate SEO-optimized meta tags, Open Graph, and Twitter Card markup for your web pages. Free meta tag generator with live preview.',

--- a/src/app/(public)/tools/mortgage-calculator/page.tsx
+++ b/src/app/(public)/tools/mortgage-calculator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import { MortgageCalculatorClient } from './MortgageCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/mortgage-calculator' },
 	title: 'Mortgage Calculator | Hudson Digital Solutions',
 	description:
 		'Calculate your monthly mortgage payment including principal, interest, taxes, insurance, and PMI. Free mortgage calculator.',

--- a/src/app/(public)/tools/page.tsx
+++ b/src/app/(public)/tools/page.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button'
 import ToolsCatalog from './ToolsCatalog'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools' },
 	title: 'Free Business Tools & Calculators | Hudson Digital Solutions',
 	description:
 		'Free interactive tools for business owners and freelancers. Calculate ROI, generate invoices and contracts, format JSON, analyze performance, and more.',

--- a/src/app/(public)/tools/paystub-calculator/page.tsx
+++ b/src/app/(public)/tools/paystub-calculator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import PaystubCalculatorClient from './PaystubCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/paystub-calculator' },
 	title: 'Paystub Calculator | Hudson Digital Solutions',
 	description:
 		'Generate detailed payroll breakdowns with federal and state tax calculations. Free paystub calculator for employers and employees.',

--- a/src/app/(public)/tools/performance-calculator/page.tsx
+++ b/src/app/(public)/tools/performance-calculator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import PerformanceCalculatorClient from './PerformanceCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/performance-calculator' },
 	title: 'Performance Savings Calculator | Hudson Digital Solutions',
 	description:
 		'Analyze how website load times affect your revenue. Calculate potential savings from performance optimization with our free calculator.',

--- a/src/app/(public)/tools/profit-margin-calculator/page.tsx
+++ b/src/app/(public)/tools/profit-margin-calculator/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next'
 import ProfitMarginCalculatorClient from './ProfitMarginCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/profit-margin-calculator' },
 	title: 'Profit Margin & Markup Calculator | Hudson Digital Solutions',
 	description:
 		'Free profit margin and markup calculator. Enter cost and selling price to get gross margin, markup, and profit, or find the price for a target margin.'

--- a/src/app/(public)/tools/proposal-generator/page.tsx
+++ b/src/app/(public)/tools/proposal-generator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import ProposalGeneratorClient from './ProposalGeneratorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/proposal-generator' },
 	title: 'Proposal Generator | Hudson Digital Solutions',
 	description:
 		'Create professional project proposals with PDF download. Free proposal generator with customizable templates for freelancers and agencies.',

--- a/src/app/(public)/tools/roi-calculator/page.tsx
+++ b/src/app/(public)/tools/roi-calculator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import { ROICalculatorClient } from './ROICalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/roi-calculator' },
 	title: 'ROI Calculator | Hudson Digital Solutions',
 	description:
 		'Calculate how much additional revenue you could generate by improving your website conversion rate. Free ROI calculator for businesses.',

--- a/src/app/(public)/tools/schema-generator/page.tsx
+++ b/src/app/(public)/tools/schema-generator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import SchemaGeneratorClient from './SchemaGeneratorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/schema-generator' },
 	title: 'LocalBusiness Schema Generator (JSON-LD) | Hudson Digital',
 	description:
 		'Free LocalBusiness schema markup generator. Build valid schema.org JSON-LD structured data for local SEO and Google rich results, then paste it into your site.'

--- a/src/app/(public)/tools/time-card-calculator/page.tsx
+++ b/src/app/(public)/tools/time-card-calculator/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next'
 import TimeCardCalculatorClient from './TimeCardCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/time-card-calculator' },
 	title: 'Time Card Calculator with Breaks & Overtime | Hudson Digital',
 	description:
 		'Free time card calculator. Add clock-in and clock-out times with lunch breaks to total daily and weekly hours, split overtime, and calculate gross pay.'

--- a/src/app/(public)/tools/tip-calculator/page.tsx
+++ b/src/app/(public)/tools/tip-calculator/page.tsx
@@ -7,6 +7,7 @@ import type { Metadata } from 'next'
 import TipCalculatorClient from './TipCalculatorClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/tip-calculator' },
 	title: 'Tip Calculator | Hudson Digital Solutions',
 	description:
 		'Calculate tip amounts and split bills among multiple people. Free tip calculator with customizable percentages and per-person breakdown.',

--- a/src/app/(public)/tools/ttl-calculator/page.tsx
+++ b/src/app/(public)/tools/ttl-calculator/page.tsx
@@ -12,6 +12,7 @@ import { Calculator } from '@/components/calculators/Calculator'
 import { JsonLd } from '@/components/utilities/JsonLd'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/ttl-calculator' },
 	title: 'Texas TTL Calculator | Hudson Digital Solutions',
 	description:
 		'Calculate tax, title, license fees and monthly payments for vehicles in Texas. Free online calculator for car buyers and dealers.',

--- a/src/app/(public)/tools/word-counter/page.tsx
+++ b/src/app/(public)/tools/word-counter/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next'
 import WordCounterClient from './WordCounterClient'
 
 export const metadata: Metadata = {
+	alternates: { canonical: '/tools/word-counter' },
 	title: 'Word & Character Counter | Hudson Digital Solutions',
 	description:
 		'Free word and character counter. Live counts of words, characters, sentences, paragraphs, and reading time, perfect for meta descriptions, tweets, and content limits.'

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,12 +93,15 @@ export const metadata: Metadata = {
 	verification: {
 		google: env.GOOGLE_SITE_VERIFICATION
 	},
-	alternates: {
-		canonical: 'https://hudsondigitalsolutions.com',
-		languages: {
-			'en-US': 'https://hudsondigitalsolutions.com'
-		}
-	},
+	// No `alternates.canonical` here: Next.js inherits non-title metadata
+	// fields (alternates included) into every child page that does not set
+	// its own. A canonical declared on the root layout therefore cascades
+	// to /showcase, /contact, all /tools/*, /locations, /help/* etc. as a
+	// self-defeating "duplicate of the homepage" signal that drops them
+	// from the index. The homepage sets its own self-canonical in
+	// src/app/(public)/page.tsx; every other indexable route declares its
+	// own. Pages that set none simply emit no canonical and Google
+	// self-canonicalizes to the page URL, which is correct.
 	applicationName: 'Hudson Digital Solutions',
 	authors: [
 		{


### PR DESCRIPTION
## Problem

Next.js merges metadata down the route tree and **inherits non-title fields (including `alternates`) into any child page that doesn't set its own**. The root layout hard-coded `alternates.canonical = https://hudsondigitalsolutions.com`, so that value cascaded into every page without its own canonical.

Verified against a local build before the fix:

| Route | Canonical emitted (before) |
|---|---|
| `/about` (sets own) | `.../about` ✓ |
| `/contact` | `.../` ✗ |
| `/terms` | `.../` ✗ |
| `/showcase` | `.../` ✗ |
| `/tools/word-counter` | `.../` ✗ |
| `/locations` | `.../` ✗ |
| `/help` | `.../` ✗ |

~30 indexable pages were telling Google "I am a duplicate of the homepage," which removes them from the index and suppresses the linking domain's overall authority. Critically, `/showcase` is the crawl path to the showcased **richardwhudsonjr.com** backlink, so the defect also starved that page of internal discovery.

## Fix

- Remove the inherited `alternates.canonical` from `src/app/layout.tsx`. The homepage keeps its own self-canonical; pages that set none now emit no canonical and Google self-assigns the page URL (correct).
- Add explicit self-canonicals to every indexable route that lacked one: the tools index + all 18 public tool pages, `/showcase`, `/contact`, `/terms`, `/privacy`, `/testimonials`, `/locations`, the `/help` index, `/help/[category]`, and `/help/[category]/[slug]`. `testimonial-collector` (admin-only) is intentionally excluded.

## Verification (after fix, local build)

`/contact`, `/terms`, `/showcase`, `/tools/word-counter`, `/locations`, `/help` now each self-canonicalize to their own URL; `/about` (control) unchanged.

- `bun run lint` clean
- `bun run typecheck` clean
- `bun run test:unit` 895 pass / 0 fail
- `bun run build` passes (lefthook pre-push)

No visual changes (metadata only).

[hudsor01]