### PR TITLE
feat(seo): tool-page breadcrumbs + fix WebVitals client crash

### DIFF
--- a/src/components/layout/ToolPageLayout.tsx
+++ b/src/components/layout/ToolPageLayout.tsx
@@ -2,9 +2,21 @@
 
 import type { LucideIcon } from 'lucide-react'
 import { Copy, Download, Printer, RotateCcw } from 'lucide-react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import type { ReactElement, ReactNode } from 'react'
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator
+} from '@/components/ui/breadcrumb'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
+import { JsonLd } from '@/components/utilities/JsonLd'
+import { generateBreadcrumbSchema } from '@/lib/seo-utils'
 import { cn } from '@/lib/utils'
 
 // ---------------------------------------------------------------------------
@@ -41,6 +53,8 @@ const ICON_MAP: Record<ActionType, LucideIcon> = {
 	print: Printer,
 	reset: RotateCcw
 }
+
+const SITE_URL = 'https://hudsondigitalsolutions.com'
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -129,6 +143,13 @@ export function ToolPageLayout({
 	actions,
 	className
 }: ToolPageLayoutProps): ReactElement {
+	const pathname = usePathname()
+	const breadcrumbSchema = generateBreadcrumbSchema([
+		{ name: 'Home', url: SITE_URL },
+		{ name: 'Tools', url: `${SITE_URL}/tools` },
+		{ name: title, url: `${SITE_URL}${pathname}` }
+	])
+
 	return (
 		<main className="min-h-screen bg-background">
 			<div
@@ -137,6 +158,41 @@ export function ToolPageLayout({
 					className
 				)}
 			>
+				<JsonLd data={breadcrumbSchema} />
+
+				{/* Breadcrumb */}
+				<Breadcrumb className="mb-6">
+					<BreadcrumbList>
+						<BreadcrumbItem>
+							<BreadcrumbLink asChild>
+								<Link
+									href="/"
+									className="text-muted-foreground hover:text-foreground transition-colors"
+								>
+									Home
+								</Link>
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbLink asChild>
+								<Link
+									href="/tools"
+									className="text-muted-foreground hover:text-foreground transition-colors"
+								>
+									Tools
+								</Link>
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbPage className="text-foreground">
+								{title}
+							</BreadcrumbPage>
+						</BreadcrumbItem>
+					</BreadcrumbList>
+				</Breadcrumb>
+
 				{/* Header */}
 				<div className="mb-10">
 					<h1 className="mb-3 text-h1 text-foreground leading-tight">

--- a/src/components/utilities/WebVitalsReporting.tsx
+++ b/src/components/utilities/WebVitalsReporting.tsx
@@ -14,23 +14,25 @@ export function WebVitalsReporting() {
 		// Store in database for admin dashboard
 		storeWebVital(metric)
 
-		// Log in development at a level that matches the CWV rating so good
-		// metrics show as info and bad metrics surface in warn/error filters.
-		// The Phase 03 dashboard widget uses the same rating thresholds for
-		// its KPI cards (text-success-text / warning / destructive); align
-		// the log level here so dev-console filtering matches.
+		// Log in development so good metrics show as info and sub-par metrics
+		// surface in the warn filter. Call the logger methods directly rather
+		// than extracting one into a local: `const log = logger.error` detaches
+		// the method from `logger`, so `this` is undefined and `this.log(...)`
+		// throws on the client. Warn (not error) is used for poor metrics too,
+		// since a web vital is not an application error and should not write to
+		// the error_logs table that logger.error feeds.
 		if (env.NODE_ENV === 'development') {
-			const log =
-				metric.rating === 'poor'
-					? logger.error
-					: metric.rating === 'needs-improvement'
-						? logger.warn
-						: logger.info
-			log(`[WebVitals] ${metric.name}: ${metric.value} (${metric.rating})`, {
+			const message = `[WebVitals] ${metric.name}: ${metric.value} (${metric.rating})`
+			const data = {
 				name: metric.name,
 				value: metric.value,
 				rating: metric.rating
-			})
+			}
+			if (metric.rating === 'good') {
+				logger.info(message, data)
+			} else {
+				logger.warn(message, data)
+			}
 		}
 	})
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,15 +10,22 @@ import { z } from 'zod'
 
 export const env = createEnv({
 	/**
+	 * Shared environment variables
+	 * Available on both the server and the client. NODE_ENV lives here so
+	 * client components (e.g. WebVitalsReporting) can read it without
+	 * tripping the T3 "server-side variable on the client" guard.
+	 */
+	shared: {
+		NODE_ENV: z
+			.enum(['development', 'test', 'production'])
+			.default('development')
+	},
+
+	/**
 	 * Server-side environment variables
 	 * These are only available on the server and never sent to the client
 	 */
 	server: {
-		// Node environment
-		NODE_ENV: z
-			.enum(['development', 'test', 'production'])
-			.default('development'),
-
 		// Database - Neon/Drizzle (optional for CI/preview builds, required in production)
 		POSTGRES_URL: z
 			.string()

--- a/tests/unit/forms.test.tsx
+++ b/tests/unit/forms.test.tsx
@@ -27,12 +27,19 @@ process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test'
 
 describe('ContactForm Component', () => {
 	beforeEach(() => {
-		// Mock next/navigation
+		// Mock next/navigation. Include the full surface (usePathname,
+		// useSearchParams) even though this suite only uses useRouter: bun's
+		// mock.module is global and, on the CI bun version, is not cleared by
+		// mock.restore() between files, so an incomplete mock here leaks and
+		// breaks any later test that renders a usePathname consumer (Navbar,
+		// ToolPageLayout) with "usePathname not found in next/navigation".
 		mock.module('next/navigation', () => ({
 			useRouter: () => ({
 				push: mock(),
 				refresh: mock()
-			})
+			}),
+			usePathname: () => '/',
+			useSearchParams: () => new URLSearchParams()
 		}))
 
 		// Mock database client


### PR DESCRIPTION
Two follow-ups from the SEO batch.

## 1. Tool-page breadcrumbs (the deferred PR9)
All 18 tool detail pages render through the shared `ToolPageLayout`, so this is a single-file change. Adds:
- A visible `Home / Tools / [tool name]` breadcrumb above the page header.
- Matching `BreadcrumbList` JSON-LD via `generateBreadcrumbSchema` (added in the earlier SEO PR), for breadcrumb rich-result eligibility.

The tool name comes from the existing `title` prop; the current URL from `usePathname`. Tool pages aren't in the visual snapshot set, so no snapshot churn. Verified live: `/tools/word-counter` renders `Home > Tools > Word & Character Counter`.

## 2. Fix the WebVitals client-side crash
`WebVitalsReporting` (a client component) read `env.NODE_ENV`, which `@t3-oss/env-nextjs` declared **server-only**, so it threw `Attempted to access a server-side environment variable on the client` on every page.

- Moved `NODE_ENV` from the T3 `server` block to a `shared` block (its canonical place) so it's valid on both client and server. Server callers keep working; no `NEXT_PUBLIC_` leak; still validated through `env.ts`.
- Fixing the env access exposed a latent bug: the dev-logging did `const log = logger.error` then `log(...)`, which **detaches the method from `logger`** (`this` undefined -> `this.log()` throws `reading 'log'`). Now calls `logger.info`/`logger.warn` directly (bound), and uses `warn` (not `error`) for poor metrics so a web vital doesn't write to the `error_logs` DB table.

Verified with a headless browser: a tool page now loads with **0 console errors** (was 2: the env error + the `reading 'log'` crash).

## Checks
- `bun run lint`, `bun run typecheck` clean
- `bun run test:unit` 900 pass / 0 fail
- `bun run build` passes

[hudsor01]