### PR TITLE
fix(contact): post lead as JSON so submissions stop 500ing

### DIFF
--- a/src/hooks/use-contact-form-submit.ts
+++ b/src/hooks/use-contact-form-submit.ts
@@ -16,18 +16,15 @@ export interface ContactFormResponse {
 export function useContactFormSubmit() {
 	return useMutation<ContactFormResponse, Error, ContactFormData>({
 		mutationFn: async formData => {
-			// Validation handled by TanStack Form + Zod
-			// Convert to FormData for the API
-			const form = new FormData()
-			Object.entries(formData).forEach(([key, value]) => {
-				if (value !== undefined && value !== null) {
-					form.append(key, String(value))
-				}
-			})
-
+			// Validation handled by TanStack Form + Zod. Send JSON, not
+			// multipart FormData: /api/contact parses request.json(), so a
+			// FormData body throws and falls to the generic 500 catch - every
+			// real submission was failing silently. csrfFetch only adds the
+			// X-CSRF-Token header and passes body/headers through untouched.
 			const response = await csrfFetch('/api/contact', {
 				method: 'POST',
-				body: form
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(formData)
 			})
 
 			const data = await response.json()

--- a/tests/unit/use-contact-form-submit.test.tsx
+++ b/tests/unit/use-contact-form-submit.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+/**
+ * Regression guard for the silent lead-loss bug: the submit hook used to
+ * POST multipart FormData while /api/contact only calls request.json(),
+ * which throws on a multipart body and falls to the generic 500 catch -
+ * so every real browser submission failed and no test caught it (the
+ * route test sent application/json directly). This locks the hook -> API
+ * content-type contract: the hook MUST send a JSON body.
+ */
+
+const csrfFetchMock = mock(
+	async () =>
+		new Response(JSON.stringify({ message: 'ok' }), {
+			status: 200,
+			headers: { 'Content-Type': 'application/json' }
+		})
+)
+mock.module('@/lib/api/csrf-fetch', () => ({ csrfFetch: csrfFetchMock }))
+
+const { useContactFormSubmit } = await import('@/hooks/use-contact-form-submit')
+
+function wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({
+		defaultOptions: { mutations: { retry: false } }
+	})
+	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('useContactFormSubmit', () => {
+	afterEach(() => csrfFetchMock.mockClear())
+
+	it('posts the lead as a JSON body, not multipart FormData', async () => {
+		const { result } = renderHook(() => useContactFormSubmit(), { wrapper })
+
+		result.current.mutate({
+			firstName: 'Jane',
+			lastName: 'Doe',
+			email: 'jane@example.com',
+			service: 'website-design',
+			budget: '5k-10k',
+			timeline: '1-month',
+			message: 'Hello, I need a website for my small business shop.'
+		} as never)
+
+		await waitFor(() => expect(csrfFetchMock).toHaveBeenCalledTimes(1))
+
+		const [url, init] = csrfFetchMock.mock.calls[0] as unknown as [
+			string,
+			RequestInit
+		]
+		expect(url).toBe('/api/contact')
+		expect(init.method).toBe('POST')
+		// A FormData body is the bug; a JSON string is the fix.
+		expect(init.body instanceof FormData).toBe(false)
+		expect(typeof init.body).toBe('string')
+		const headers = init.headers as Record<string, string>
+		expect(headers['Content-Type']).toBe('application/json')
+		const parsed = JSON.parse(init.body as string)
+		expect(parsed.email).toBe('jane@example.com')
+		// Native types survive (the old String() coercion broke timestamp:z.number()).
+		expect(parsed.firstName).toBe('Jane')
+	})
+})


### PR DESCRIPTION
## Critical: the contact form has been silently failing

The submit hook built a **multipart `FormData`** body (`use-contact-form-submit.ts:21-31`) while `/api/contact` only calls `await request.json()` (`route.ts:38`). `request.json()` throws on a multipart body, so the handler falls straight to the generic 500 catch (`route.ts:120-126`):

- no lead row written
- no admin notification / welcome email
- user sees "An unexpected error occurred"

The route's unit test passed only because it posts `application/json` directly, never exercising the hook's real body. The old `String(value)` coercion would also have broken `timestamp: z.number()` even if the body had parsed.

## Fix
- Hook now sends `JSON.stringify(formData)` with `Content-Type: application/json`. `csrfFetch` only adds the `X-CSRF-Token` header and passes the body/headers through untouched.
- Added a `renderHook` regression test asserting the hook posts a JSON body (not `FormData`) — the gap that let this ship was that **no test ever submitted the form**.

## Verification
- `bun run lint`, `bun run typecheck` clean
- `bun run test:unit` 901 pass / 0 fail (new hook test included; it fails on the old FormData path)
- `bun run build` passes

Recommend checking Vercel runtime logs for 500s on `POST /api/contact` to confirm how long this was live.

[hudsor01]