### PR TITLE
fix(cron): process the email queue on GET (critical) + audit cleanup

### DIFF
--- a/e2e/api/email-queue-processing.spec.ts
+++ b/e2e/api/email-queue-processing.spec.ts
@@ -142,15 +142,18 @@ test.describe('Email Queue Processing - Response Format', () => {
   })
 })
 
-test.describe('Email Queue Processing - GET Endpoint (Stats)', () => {
-  test('should get queue stats without authorization', async ({ request }) => {
+test.describe('Email Queue Processing - GET Endpoint (Cron)', () => {
+  // Vercel native cron invokes the route with GET, so GET must process the
+  // queue exactly like POST. The old GET stats endpoint was removed; these
+  // assertions track the processing contract: { success, processed, errors }.
+  test('GET without authorization is rejected', async ({ request }) => {
     const response = await request.get(API_ENDPOINT)
 
-    // Should require authentication
-    expect(response.status()).toBe(401)
+    // 401 when CRON_SECRET is configured, 503 when it is not.
+    expect([401, 503]).toContain(response.status())
   })
 
-  test('should get queue stats with valid authorization', async ({ request }) => {
+  test('GET with valid authorization processes the queue', async ({ request }) => {
     const cronSecret = process.env.CRON_SECRET || 'test-cron-secret'
 
     const response = await request.get(API_ENDPOINT, {
@@ -159,34 +162,15 @@ test.describe('Email Queue Processing - GET Endpoint (Stats)', () => {
       }
     })
 
-    if (response.ok()) {
-      const data = await response.json()
-
-      expect(data).toHaveProperty('stats')
-      expect(data).toHaveProperty('timestamp')
-
-      // Stats should contain queue information
-      expect(typeof data.stats).toBe('object')
-    }
-  })
-
-  test('should return current timestamp in stats', async ({ request }) => {
-    const cronSecret = process.env.CRON_SECRET || 'test-cron-secret'
-
-    const response = await request.get(API_ENDPOINT, {
-      headers: {
-        'Authorization': `Bearer ${cronSecret}`
-      }
-    })
+    // 200/500 when the secret matches, 401/503 when it is absent or wrong here.
+    expect([200, 500, 401, 503]).toContain(response.status())
 
     if (response.ok()) {
       const data = await response.json()
 
-      const timestamp = new Date(data.timestamp)
-      const now = new Date()
-
-      // Timestamp should be within last 10 seconds
-      expect(now.getTime() - timestamp.getTime()).toBeLessThan(10000)
+      expect(data).toHaveProperty('success')
+      expect(data).toHaveProperty('processed')
+      expect(data).toHaveProperty('errors')
     }
   })
 })

--- a/e2e/api/rate-limiting-security.spec.ts
+++ b/e2e/api/rate-limiting-security.spec.ts
@@ -386,10 +386,12 @@ test.describe('Authentication & Authorization', () => {
     expect(response.status()).toBe(401)
   })
 
-  test('should protect email queue stats from unauthorized access', async ({ request }) => {
+  test('should protect the email queue endpoint from unauthorized access', async ({ request }) => {
     const response = await request.get('/api/process-emails')
 
-    expect(response.status()).toBe(401)
+    // 401 when CRON_SECRET is configured, 503 when it is not - either way
+    // the unauthenticated request never reaches the processing logic.
+    expect([401, 503]).toContain(response.status())
   })
 
   test('should validate Bearer token format', async ({ request }) => {

--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { Suspense } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
-import { Analytics } from '@/components/utilities/Analytics'
 import { getShowcaseItems } from '@/lib/showcase'
 
 // Caching handled at data-layer level (src/lib/showcase.ts uses 'use cache'
@@ -183,129 +182,126 @@ async function ShowcaseProjects() {
 
 export default function ShowcasePage() {
 	return (
-		<>
-			<Analytics />
-			<div className="min-h-screen bg-background">
-				{/* Hero Section */}
-				<section className="relative overflow-hidden bg-background">
-					<div
-						className="absolute inset-0 grid-pattern-subtle dark:grid-pattern-dark pointer-events-none"
-						aria-hidden="true"
-					/>
-					<div
-						className="hero-spotlight absolute inset-0 pointer-events-none"
-						aria-hidden="true"
-					/>
+		<div className="min-h-screen bg-background">
+			{/* Hero Section */}
+			<section className="relative overflow-hidden bg-background">
+				<div
+					className="absolute inset-0 grid-pattern-subtle dark:grid-pattern-dark pointer-events-none"
+					aria-hidden="true"
+				/>
+				<div
+					className="hero-spotlight absolute inset-0 pointer-events-none"
+					aria-hidden="true"
+				/>
 
-					<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
-						<p className="text-xs font-semibold uppercase tracking-widest text-accent-text mb-3">
-							Showcase
-						</p>
-						{/* The visible heading used to be driven by a looping
+				<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
+					<p className="text-xs font-semibold uppercase tracking-widest text-accent-text mb-3">
+						Showcase
+					</p>
+					{/* The visible heading used to be driven by a looping
 						    typewriter animation (~30 chars, 80ms per char, 2s pause)
 						    that left the H1 mid-state for several seconds — users
 						    landing on the wrong frame read it as truncated or broken
 						    and one early audit even misread it as a missing logo
 						    (audit #243). Static now; the brand "personality" was
 						    costing us comprehension. */}
-						<h1 className="text-page-title text-foreground leading-tight">
-							Real Projects. Real Results.
-						</h1>
-						<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
-							Real websites for small businesses. See how we help local
-							businesses get found online, win customers, and grow.
-						</p>
+					<h1 className="text-page-title text-foreground leading-tight">
+						Real Projects. Real Results.
+					</h1>
+					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
+						Real websites for small businesses. See how we help local businesses
+						get found online, win customers, and grow.
+					</p>
 
-						<div className="flex flex-col sm:flex-row gap-3 justify-center">
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
-								<Link href="/contact">
-									Get My Free Website Plan
-									<Rocket className="w-5 h-5" aria-hidden="true" />
-								</Link>
-							</Button>
+					<div className="flex flex-col sm:flex-row gap-3 justify-center">
+						<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Link href="/contact">
+								Get My Free Website Plan
+								<Rocket className="w-5 h-5" aria-hidden="true" />
+							</Link>
+						</Button>
 
-							<Button
-								asChild
-								variant="outline"
-								size="xl"
-								className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
-							>
-								<Link href="/services">
-									View Services
-									<ArrowRight className="w-5 h-5" aria-hidden="true" />
-								</Link>
-							</Button>
-						</div>
+						<Button
+							asChild
+							variant="outline"
+							size="xl"
+							className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
+						>
+							<Link href="/services">
+								View Services
+								<ArrowRight className="w-5 h-5" aria-hidden="true" />
+							</Link>
+						</Button>
 					</div>
-				</section>
+				</div>
+			</section>
 
-				{/* Dynamic content with Suspense */}
-				<Suspense
-					fallback={
-						<div className="container-wide py-section-sm px-4 text-center">
-							<div className="inline-block animate-spin rounded-full h-12 w-12 border-4 border-border border-t-accent" />
-							<p className="text-sm text-muted-foreground mt-4 leading-relaxed">
-								Loading projects...
-							</p>
-						</div>
-					}
-				>
-					<ShowcaseProjects />
-				</Suspense>
+			{/* Dynamic content with Suspense */}
+			<Suspense
+				fallback={
+					<div className="container-wide py-section-sm px-4 text-center">
+						<div className="inline-block animate-spin rounded-full h-12 w-12 border-4 border-border border-t-accent" />
+						<p className="text-sm text-muted-foreground mt-4 leading-relaxed">
+							Loading projects...
+						</p>
+					</div>
+				}
+			>
+				<ShowcaseProjects />
+			</Suspense>
 
-				{/* CTA Section */}
-				<section className="py-section px-4 sm:px-6">
-					<div className="container-wide">
-						<div className="relative overflow-hidden rounded-2xl border border-border bg-surface-raised p-10 md:p-16 text-center">
-							<div
-								className="hero-spotlight absolute inset-0 opacity-60 pointer-events-none"
-								aria-hidden="true"
-							/>
-							<div className="relative z-10">
-								{/* Demoted to h3 so heading order across showcase is
+			{/* CTA Section */}
+			<section className="py-section px-4 sm:px-6">
+				<div className="container-wide">
+					<div className="relative overflow-hidden rounded-2xl border border-border bg-surface-raised p-10 md:p-16 text-center">
+						<div
+							className="hero-spotlight absolute inset-0 opacity-60 pointer-events-none"
+							aria-hidden="true"
+						/>
+						<div className="relative z-10">
+							{/* Demoted to h3 so heading order across showcase is
 								    h1 (hero) > h2 (section header) > h2 (inline CTA) > h3
 								    (closing CTA). The inline CTA precedes this one in DOM
 								    order. */}
-								<h3 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-									Ready to create your{' '}
-									<span className="text-accent">success story?</span>
-								</h3>
+							<h3 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
+								Ready to create your{' '}
+								<span className="text-accent">success story?</span>
+							</h3>
 
-								<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-									Join these businesses with a website that does justice to what
-									they&apos;ve built. Let&apos;s build yours.
-								</p>
+							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
+								Join these businesses with a website that does justice to what
+								they&apos;ve built. Let&apos;s build yours.
+							</p>
 
-								<div className="flex flex-col sm:flex-row gap-3 justify-center">
-									<Button
-										asChild
-										variant="accent"
-										size="xl"
-										trackConversion={true}
-									>
-										<Link href="/contact">
-											Get My Free Website Plan
-											<Rocket className="w-5 h-5" aria-hidden="true" />
-										</Link>
-									</Button>
+							<div className="flex flex-col sm:flex-row gap-3 justify-center">
+								<Button
+									asChild
+									variant="accent"
+									size="xl"
+									trackConversion={true}
+								>
+									<Link href="/contact">
+										Get My Free Website Plan
+										<Rocket className="w-5 h-5" aria-hidden="true" />
+									</Link>
+								</Button>
 
-									<Button
-										asChild
-										variant="outline"
-										size="xl"
-										className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
-									>
-										<Link href="/services">
-											View Services
-											<ArrowRight className="w-5 h-5" aria-hidden="true" />
-										</Link>
-									</Button>
-								</div>
+								<Button
+									asChild
+									variant="outline"
+									size="xl"
+									className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
+								>
+									<Link href="/services">
+										View Services
+										<ArrowRight className="w-5 h-5" aria-hidden="true" />
+									</Link>
+								</Button>
 							</div>
 						</div>
 					</div>
-				</section>
-			</div>
-		</>
+				</div>
+			</section>
+		</div>
 	)
 }

--- a/src/app/api/process-emails/route.ts
+++ b/src/app/api/process-emails/route.ts
@@ -1,7 +1,15 @@
 /**
  * Process Emails API Route
- * Called by Vercel Cron to process the scheduled email queue.
- * Authenticated via Bearer token (CRON_SECRET).
+ * Drains the scheduled-email queue (contact-form follow-ups, calculator
+ * lead-nurture) via Resend. Authenticated with Bearer CRON_SECRET.
+ *
+ * Exposes BOTH GET and POST. Vercel native cron always invokes the route
+ * with an HTTP GET (the vercel.json `crons` schema has no method field, so
+ * a method override would be ignored), so a POST-only route returned 405
+ * on every scheduled run and the queue never drained in production. POST is
+ * kept for n8n / manual invocation. Vercel injects
+ * `Authorization: Bearer ${CRON_SECRET}` on cron GETs when the secret is
+ * set, so the same guard covers both verbs.
  */
 
 import { type NextRequest, NextResponse } from 'next/server'
@@ -9,7 +17,7 @@ import { validateCronAuth } from '@/lib/auth/admin'
 import { logger } from '@/lib/logger'
 import { processEmailsEndpoint } from '@/lib/scheduled-emails'
 
-export async function POST(request: NextRequest) {
+async function handleProcessEmails(request: NextRequest) {
 	const authError = validateCronAuth(request)
 	if (authError) {
 		return authError
@@ -23,4 +31,12 @@ export async function POST(request: NextRequest) {
 		logger.error('Email queue processing failed', error)
 		return NextResponse.json({ error: 'Processing failed' }, { status: 500 })
 	}
+}
+
+export async function GET(request: NextRequest) {
+	return handleProcessEmails(request)
+}
+
+export async function POST(request: NextRequest) {
+	return handleProcessEmails(request)
 }

--- a/src/lib/schema-generator.ts
+++ b/src/lib/schema-generator.ts
@@ -26,7 +26,7 @@ export type LocalBusinessType =
 	| 'FinancialService'
 	| 'EntertainmentBusiness'
 
-export interface SchemaAddressInput {
+interface SchemaAddressInput {
 	street?: string
 	city?: string
 	region?: string
@@ -34,12 +34,12 @@ export interface SchemaAddressInput {
 	country?: string
 }
 
-export interface SchemaGeoInput {
+interface SchemaGeoInput {
 	latitude?: string
 	longitude?: string
 }
 
-export interface OpeningHoursInput {
+interface OpeningHoursInput {
 	days: readonly string[]
 	opens: string
 	closes: string


### PR DESCRIPTION
Resolves the one **critical** finding from the repo-wide no-op audit, plus two safe cleanups.

## 🔴 Critical: scheduled emails never sent in production
Vercel native cron always invokes routes with **HTTP GET** (the `vercel.json` `crons` schema has no `method` field), but `/api/process-emails` exported **only `POST`** — so every scheduled run hit a 405 before the handler ran. The scheduled-email queue never drained: contact-form follow-ups and calculator lead-nurture sequences sat `pending` forever, and the admin "retry" action (which only flips DB rows for this cron to pick up) never sent either.

**Fix:** add a `GET` handler that runs `validateCronAuth` then `processEmailsEndpoint`, sharing one helper with `POST`. Vercel injects `Authorization: Bearer ${CRON_SECRET}` on cron GETs, so the existing guard covers both verbs. `POST` stays for n8n / manual runs. **Did not** add a `method` to `vercel.json` (the schema ignores it).

Pairs with the just-merged contact-form fix (#318): leads now save *and* their queued follow-ups will actually send.

## Cleanup (from the audit)
- **Duplicate `<Analytics/>`**: `/showcase` mounted Vercel Analytics directly while the root layout already mounts it site-wide — removed the page-level mount (Analytics renders no visible markup, so the `/showcase` snapshot is unchanged).
- **Unexported 3 internal types** in `schema-generator.ts` (knip flagged them as unused exports; they're only used within the module).

## Intentionally left (flagged for your call)
- `getLimitInfo()` — unused by any route but has dedicated test suites; deleting it would delete working tested code, not dead code.
- `STIRLING_PDF_URL` env — declared-but-unused, but documented as an optional feature-gate; removal would also need a CLAUDE.md edit.
- DB schema drops (`lead_attribution`, orphaned analytics/logging tables, unused columns, `trackConversion` wiring) — left for the ad-readiness work since they're attribution/conversion features, not pure dead weight.

## Tests
- e2e GET assertions updated: the removed GET "stats" endpoint is replaced with the processing contract (`{ success, processed, errors }`), tolerant of 401/503 when `CRON_SECRET` is unset.
- `bun run lint`, `typecheck` clean · `test:unit` 901 pass/0 fail · `build` passes

[hudsor01]