### PR TITLE
feat(leads): capture marketing attribution on every lead

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -26,11 +26,13 @@ import { Suspense } from 'react'
 import CommandPaletteData from '@/components/cmdk/CommandPaletteData'
 import Footer from '@/components/layout/Footer'
 import NavbarLight from '@/components/layout/Navbar'
+import { AttributionTracker } from '@/components/utilities/AttributionTracker'
 import ScrollToTop from '@/components/utilities/ScrollToTop'
 
 export default function PublicLayout({ children }: { children: ReactNode }) {
 	return (
 		<>
+			<AttributionTracker />
 			<NavbarLight />
 			{/* Global command palette (audit #263). Singleton mount across
 			    the public route group — admin/auth layouts intentionally

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -93,8 +93,17 @@ export default function PrivacyPage() {
 									<li>Measure the effectiveness of our marketing campaigns</li>
 								</ul>
 								<p>
-									You can control cookie settings through our cookie consent
-									banner or your browser settings.
+									For marketing attribution we store the source of your visit
+									(such as the campaign, referrer, or ad click ID) in your
+									browser's local storage for up to 90 days and attach it to a
+									contact form submission. We do not sell or share it with third
+									parties.
+								</p>
+								<p>
+									You can clear or block this data at any time through your
+									browser settings, for example by clearing site data or
+									disabling cookies and local storage. We do not currently use a
+									cookie consent banner.
 								</p>
 							</div>
 						</section>

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -48,7 +48,8 @@ async function handleContactPost(request: NextRequest) {
 		// Step 3: Security check (monitoring only)
 		checkForSecurityThreats(data, clientIP, logger)
 
-		// Step 3b: Save to leads table + record the marketing touchpoint.
+		// Step 3b: Save to leads table.
+		let leadId: string | undefined
 		try {
 			const [inserted] = await db
 				.insert(leads)
@@ -68,12 +69,22 @@ async function handleContactPost(request: NextRequest) {
 					}
 				})
 				.returning({ id: leads.id })
+			leadId = inserted?.id
+		} catch (dbError) {
+			// Log but do not fail the request if DB insert fails
+			logger.error('Failed to save contact lead to database', dbError)
+		}
 
-			// Normalized touchpoint for the admin Touchpoints view + reporting.
-			if (inserted?.id && data.attribution) {
-				const attr = data.attribution
+		// Step 3c: Record the normalized marketing touchpoint for the admin
+		// Touchpoints view + reporting. Its own try/catch: neon-http commits
+		// each insert independently, so a touchpoint-write failure must not be
+		// logged as "lead not saved" - the lead row above already exists, and
+		// the full attribution is also stored on leads.metadata.
+		if (leadId && data.attribution) {
+			const attr = data.attribution
+			try {
 				await db.insert(leadAttribution).values({
-					leadId: inserted.id,
+					leadId,
 					touchpoint: 'conversion',
 					channel: deriveChannel(attr),
 					source: attr.utmSource ?? null,
@@ -88,10 +99,13 @@ async function handleContactPost(request: NextRequest) {
 					isLastTouch: true,
 					attributionWeight: '1'
 				})
+			} catch (dbError) {
+				logger.error(
+					'Failed to write lead_attribution row; lead was saved',
+					dbError,
+					{ metadata: { leadId } }
+				)
 			}
-		} catch (dbError) {
-			// Log but do not fail the request if DB insert fails
-			logger.error('Failed to save contact lead to database', dbError)
 		}
 
 		// Step 4: Calculate lead score and prepare email data

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -6,6 +6,7 @@ import {
 	successResponse,
 	validationErrorResponse
 } from '@/lib/api/responses'
+import { deriveChannel } from '@/lib/attribution'
 import {
 	checkForSecurityThreats,
 	prepareEmailVariables,
@@ -22,7 +23,7 @@ import {
 	contactFormSchema,
 	scoreLeadFromContactData
 } from '@/lib/schemas/contact'
-import { leads } from '@/lib/schemas/leads'
+import { leadAttribution, leads } from '@/lib/schemas/leads'
 
 async function handleContactPost(request: NextRequest) {
 	const logContext = { component: 'contact-form', timestamp: Date.now() }
@@ -47,20 +48,47 @@ async function handleContactPost(request: NextRequest) {
 		// Step 3: Security check (monitoring only)
 		checkForSecurityThreats(data, clientIP, logger)
 
-		// Step 3b: Save to leads table
+		// Step 3b: Save to leads table + record the marketing touchpoint.
 		try {
-			await db.insert(leads).values({
-				email: data.email,
-				name: `${data.firstName} ${data.lastName}`.trim(),
-				source: 'contact-form',
-				status: 'new',
-				metadata: {
-					service: data.service,
-					budget: data.budget,
-					timeline: data.timeline,
-					message: data.message
-				}
-			})
+			const [inserted] = await db
+				.insert(leads)
+				.values({
+					email: data.email,
+					name: `${data.firstName} ${data.lastName}`.trim(),
+					source: 'contact-form',
+					status: 'new',
+					metadata: {
+						service: data.service,
+						budget: data.budget,
+						timeline: data.timeline,
+						message: data.message,
+						// Full attribution (incl. gclid/fbclid) for offline
+						// conversion export back to the ad platform.
+						attribution: data.attribution ?? null
+					}
+				})
+				.returning({ id: leads.id })
+
+			// Normalized touchpoint for the admin Touchpoints view + reporting.
+			if (inserted?.id && data.attribution) {
+				const attr = data.attribution
+				await db.insert(leadAttribution).values({
+					leadId: inserted.id,
+					touchpoint: 'conversion',
+					channel: deriveChannel(attr),
+					source: attr.utmSource ?? null,
+					medium: attr.utmMedium ?? null,
+					campaign: attr.utmCampaign ?? null,
+					content: attr.utmContent ?? null,
+					term: attr.utmTerm ?? null,
+					referrer: attr.referrer ?? null,
+					landingPage: attr.landingPage ?? null,
+					touchpointOrder: 1,
+					isFirstTouch: true,
+					isLastTouch: true,
+					attributionWeight: '1'
+				})
+			}
 		} catch (dbError) {
 			// Log but do not fail the request if DB insert fails
 			logger.error('Failed to save contact lead to database', dbError)

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -6,6 +6,7 @@ import { FieldGroup } from '@/components/ui/field'
 import formOptions from '@/data/form-options.json'
 import { useAppForm } from '@/hooks/form-hook'
 import { useContactFormSubmit } from '@/hooks/use-contact-form-submit'
+import { getAttribution } from '@/lib/attribution'
 import type { ContactFormData } from '@/lib/schemas/contact'
 import QueryProvider from '@/providers/QueryProvider'
 
@@ -45,7 +46,12 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 			message: ''
 		},
 		onSubmit: async ({ value }) => {
-			await mutation.mutateAsync(value as ContactFormData)
+			// Attach the persisted marketing attribution so the lead is
+			// traceable to the campaign/click that produced it.
+			await mutation.mutateAsync({
+				...value,
+				attribution: getAttribution()
+			} as ContactFormData)
 			setShowSuccess(true)
 		}
 	})

--- a/src/components/utilities/AttributionTracker.tsx
+++ b/src/components/utilities/AttributionTracker.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect } from 'react'
+import { captureAttribution } from '@/lib/attribution'
+
+/**
+ * Records marketing attribution (UTM + ad click IDs + referrer + landing
+ * page) into localStorage on first paint of every public page, so a lead's
+ * converting submission carries the campaign that acquired them. Renders
+ * nothing. Mounted once in the public route-group layout.
+ */
+export function AttributionTracker() {
+	useEffect(() => {
+		captureAttribution()
+	}, [])
+
+	return null
+}

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -1,0 +1,208 @@
+/**
+ * First-party marketing attribution.
+ *
+ * Captures the acquisition touch (UTM params + ad click IDs + referrer +
+ * landing page) on page load and persists it in localStorage for 90 days,
+ * so a lead who clicks an ad, lands on one page, and converts on another
+ * still carries the original campaign + gclid/fbclid. The lead write path
+ * reads getAttribution() and stores it on the lead, which is what makes
+ * paid-ad spend measurable (offline conversion import keys on gclid/fbclid
+ * + the persisted source).
+ *
+ * Storage is localStorage rather than a cookie on purpose: the server
+ * never auto-reads this value (it is injected into the contact POST body
+ * explicitly), so a cookie's request-attachment is unused. localStorage is
+ * synchronous - so getAttribution() can run inline at form submit - and
+ * universally supported, unlike the async, recent-only Cookie Store API.
+ *
+ * No platform decision required: every common click ID is captured
+ * (Google gclid/wbraid/gbraid, Meta fbclid) so the same module works for
+ * Google Ads, Meta, or both.
+ *
+ * Import-safe on the server (the schema + deriveChannel are pure; the
+ * capture/get helpers no-op when window is absent).
+ */
+
+import { z } from 'zod'
+
+const STR = z.string().trim().max(512).optional()
+
+export const attributionSchema = z.object({
+	utmSource: STR,
+	utmMedium: STR,
+	utmCampaign: STR,
+	utmTerm: STR,
+	utmContent: STR,
+	gclid: STR,
+	fbclid: STR,
+	wbraid: STR,
+	gbraid: STR,
+	referrer: STR,
+	landingPage: STR,
+	firstTouchAt: STR,
+	lastTouchAt: STR
+})
+
+export type Attribution = z.infer<typeof attributionSchema>
+
+const STORAGE_KEY = 'hds_attr'
+const TTL_MS = 1000 * 60 * 60 * 24 * 90 // 90 days
+
+// URL params that mark a meaningful (paid/campaign) touch. Their presence
+// means this visit should overwrite a previously-stored touch (last-click).
+const AD_PARAM_KEYS = [
+	'utm_source',
+	'utm_medium',
+	'utm_campaign',
+	'utm_term',
+	'utm_content',
+	'gclid',
+	'fbclid',
+	'wbraid',
+	'gbraid'
+] as const
+
+/** Drop empty/undefined entries so the stored object stays compact. */
+function compact(input: Record<string, string | undefined>): Attribution {
+	const out: Record<string, string> = {}
+	for (const [key, value] of Object.entries(input)) {
+		if (value && value.length > 0) {
+			out[key] = value.slice(0, 512)
+		}
+	}
+	return out as Attribution
+}
+
+function externalReferrer(): string | undefined {
+	if (typeof document === 'undefined' || !document.referrer) {
+		return undefined
+	}
+	try {
+		const ref = new URL(document.referrer)
+		return ref.host === window.location.host ? undefined : document.referrer
+	} catch {
+		return undefined
+	}
+}
+
+function readStore(): Attribution | undefined {
+	if (typeof window === 'undefined') {
+		return undefined
+	}
+	try {
+		const raw = window.localStorage.getItem(STORAGE_KEY)
+		if (!raw) {
+			return undefined
+		}
+		const result = attributionSchema.safeParse(JSON.parse(raw))
+		if (!result.success) {
+			return undefined
+		}
+		// Expire after the TTL, matching what a 90-day cookie would do.
+		const last = result.data.lastTouchAt
+		if (last && Date.now() - Date.parse(last) > TTL_MS) {
+			window.localStorage.removeItem(STORAGE_KEY)
+			return undefined
+		}
+		return result.data
+	} catch {
+		return undefined
+	}
+}
+
+function writeStore(attribution: Attribution): void {
+	if (typeof window === 'undefined') {
+		return
+	}
+	try {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify(attribution))
+	} catch {
+		// Storage can be unavailable (private mode / quota exceeded).
+		// Attribution is best-effort, so swallow rather than break the page.
+	}
+}
+
+/**
+ * Pure attribution resolution. Given the current visit's params, referrer,
+ * and path plus any previously-stored touch, return the touch to persist -
+ * or null when a stored paid/campaign touch should be preserved (a later
+ * organic or internal visit must not overwrite it). Exported for testing.
+ */
+export function buildAttributionTouch(
+	params: URLSearchParams,
+	referrer: string | undefined,
+	pathname: string,
+	existing: Attribution | undefined,
+	now: string
+): Attribution | null {
+	const hasAdParams = AD_PARAM_KEYS.some(key => params.get(key))
+
+	// Preserve a prior attributed touch on paramless later visits.
+	if (existing && !hasAdParams) {
+		return null
+	}
+
+	return compact({
+		utmSource: params.get('utm_source') ?? undefined,
+		utmMedium: params.get('utm_medium') ?? undefined,
+		utmCampaign: params.get('utm_campaign') ?? undefined,
+		utmTerm: params.get('utm_term') ?? undefined,
+		utmContent: params.get('utm_content') ?? undefined,
+		gclid: params.get('gclid') ?? undefined,
+		fbclid: params.get('fbclid') ?? undefined,
+		wbraid: params.get('wbraid') ?? undefined,
+		gbraid: params.get('gbraid') ?? undefined,
+		referrer,
+		landingPage: pathname,
+		firstTouchAt: existing?.firstTouchAt ?? now,
+		lastTouchAt: now
+	})
+}
+
+/**
+ * Capture the current visit's attribution and persist it. Last meaningful
+ * (UTM / ad-click) touch wins; a later organic or internal visit never
+ * overwrites a stored paid touch. The first visit records a baseline
+ * (referrer + landing page) so direct entries still have a first-touch
+ * timestamp. Safe to call on every page mount.
+ */
+export function captureAttribution(): void {
+	if (typeof window === 'undefined') {
+		return
+	}
+	const touch = buildAttributionTouch(
+		new URLSearchParams(window.location.search),
+		externalReferrer(),
+		window.location.pathname,
+		readStore(),
+		new Date().toISOString()
+	)
+	if (touch) {
+		writeStore(touch)
+	}
+}
+
+/** Read the persisted attribution to attach to a lead submission. */
+export function getAttribution(): Attribution | undefined {
+	return readStore()
+}
+
+/**
+ * Map an attribution touch to a coarse channel for the admin Touchpoints
+ * view / reporting. A click ID is the strongest paid signal.
+ */
+export function deriveChannel(attribution: Attribution): string {
+	if (attribution.gclid || attribution.wbraid || attribution.gbraid) {
+		return 'paid_search'
+	}
+	if (attribution.fbclid) {
+		return 'paid_social'
+	}
+	if (attribution.utmMedium) {
+		return attribution.utmMedium
+	}
+	if (attribution.referrer) {
+		return 'referral'
+	}
+	return 'direct'
+}

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -39,8 +39,10 @@ export const attributionSchema = z.object({
 	gbraid: STR,
 	referrer: STR,
 	landingPage: STR,
-	firstTouchAt: STR,
-	lastTouchAt: STR
+	// ISO 8601 so a corrupt/non-date value fails validation (and is evicted)
+	// rather than silently defeating the TTL via a NaN comparison.
+	firstTouchAt: z.iso.datetime().optional(),
+	lastTouchAt: z.iso.datetime().optional()
 })
 
 export type Attribution = z.infer<typeof attributionSchema>
@@ -79,7 +81,9 @@ function externalReferrer(): string | undefined {
 	}
 	try {
 		const ref = new URL(document.referrer)
-		return ref.host === window.location.host ? undefined : document.referrer
+		// Origin only: the host is the marketing signal; the path/query can
+		// carry PII (inbox search strings, CRM deal URLs) we must not store.
+		return ref.host === window.location.host ? undefined : ref.origin
 	} catch {
 		return undefined
 	}
@@ -96,6 +100,8 @@ function readStore(): Attribution | undefined {
 		}
 		const result = attributionSchema.safeParse(JSON.parse(raw))
 		if (!result.success) {
+			// Corrupt/old-shape record: evict so the next visit recaptures.
+			window.localStorage.removeItem(STORAGE_KEY)
 			return undefined
 		}
 		// Expire after the TTL, matching what a 90-day cookie would do.
@@ -187,6 +193,25 @@ export function getAttribution(): Attribution | undefined {
 	return readStore()
 }
 
+// Allowlist of recognized utm_medium values. An arbitrary client-supplied
+// medium is collapsed to 'other' so a crafted or misconfigured campaign
+// cannot fragment the channel grouping that feeds the admin reporting.
+const KNOWN_MEDIUMS = new Set([
+	'cpc',
+	'ppc',
+	'paid',
+	'cpm',
+	'email',
+	'social',
+	'paid-social',
+	'affiliate',
+	'referral',
+	'organic',
+	'display',
+	'video',
+	'sms'
+])
+
 /**
  * Map an attribution touch to a coarse channel for the admin Touchpoints
  * view / reporting. A click ID is the strongest paid signal.
@@ -199,7 +224,9 @@ export function deriveChannel(attribution: Attribution): string {
 		return 'paid_social'
 	}
 	if (attribution.utmMedium) {
-		return attribution.utmMedium
+		return KNOWN_MEDIUMS.has(attribution.utmMedium)
+			? attribution.utmMedium
+			: 'other'
 	}
 	if (attribution.referrer) {
 		return 'referral'

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -104,9 +104,11 @@ function readStore(): Attribution | undefined {
 			window.localStorage.removeItem(STORAGE_KEY)
 			return undefined
 		}
-		// Expire after the TTL, matching what a 90-day cookie would do.
+		// Expire after the TTL, matching what a 90-day cookie would do. A
+		// missing timestamp is treated as expired too (compact() always writes
+		// one, so this only sheds tampered / old-shape records).
 		const last = result.data.lastTouchAt
-		if (last && Date.now() - Date.parse(last) > TTL_MS) {
+		if (!last || Date.now() - Date.parse(last) > TTL_MS) {
 			window.localStorage.removeItem(STORAGE_KEY)
 			return undefined
 		}

--- a/src/lib/schemas/contact.ts
+++ b/src/lib/schemas/contact.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { attributionSchema } from '@/lib/attribution'
 import {
 	LEAD_CATEGORY_THRESHOLDS,
 	LEAD_SCORE_POINTS,
@@ -29,7 +30,10 @@ export const contactFormSchema = z.object({
 	message: messageSchema,
 	// Anti-spam fields
 	honeypot: z.string().max(0, 'Invalid submission').optional(),
-	timestamp: z.number().optional()
+	timestamp: z.number().optional(),
+	// Marketing attribution captured client-side (UTM + ad click IDs +
+	// referrer + landing page); persisted on the lead for ad measurement.
+	attribution: attributionSchema.optional()
 })
 
 // Type inference

--- a/tests/unit/api-contact.test.ts
+++ b/tests/unit/api-contact.test.ts
@@ -63,7 +63,9 @@ function mockContactService(opts: MockOpts) {
 		mock.module('@/lib/db', () => ({
 			db: {
 				insert: mock().mockReturnValue({
-					values: mock().mockRejectedValue(new Error('pg connection lost'))
+					values: mock().mockReturnValue({
+						returning: mock().mockRejectedValue(new Error('pg connection lost'))
+					})
 				}),
 				select: mock().mockReturnValue({
 					from: mock().mockReturnValue({

--- a/tests/unit/api-contact.test.ts
+++ b/tests/unit/api-contact.test.ts
@@ -151,4 +151,116 @@ describe('POST /api/contact', () => {
 		const res = await POST(makeRequest(VALID_BODY))
 		expect(res.status).toBe(200)
 	})
+
+	const ATTRIBUTION = {
+		utmSource: 'google',
+		utmMedium: 'cpc',
+		utmCampaign: 'dfw-web-design',
+		gclid: 'GCLID123',
+		landingPage: '/services',
+		firstTouchAt: '2026-01-01T00:00:00.000Z',
+		lastTouchAt: '2026-01-01T00:00:00.000Z'
+	}
+
+	const selectStub = () =>
+		mock().mockReturnValue({
+			from: mock().mockReturnValue({
+				where: mock().mockReturnValue({
+					limit: mock().mockResolvedValue([])
+				})
+			})
+		})
+
+	it('persists attribution to leads.metadata and writes a lead_attribution row', async () => {
+		mockContactService({ resendConfigured: true })
+		const valuesCalls: Record<string, unknown>[] = []
+		mock.module('@/lib/db', () => ({
+			db: {
+				insert: mock(() => ({
+					values: mock((v: Record<string, unknown>) => {
+						valuesCalls.push(v)
+						return { returning: mock().mockResolvedValue([{ id: 'lead-uuid' }]) }
+					})
+				})),
+				select: selectStub()
+			}
+		}))
+
+		const { POST } = await import('@/app/api/contact/route')
+		const res = await POST(
+			makeRequest({ ...VALID_BODY, attribution: ATTRIBUTION })
+		)
+
+		expect(res.status).toBe(200)
+		expect(valuesCalls).toHaveLength(2)
+
+		const leadsValues = valuesCalls[0] as Record<string, unknown>
+		const touch = valuesCalls[1] as Record<string, unknown>
+		const meta = leadsValues.metadata as {
+			attribution: { gclid: string; utmSource: string }
+		}
+		expect(meta.attribution.gclid).toBe('GCLID123')
+		expect(meta.attribution.utmSource).toBe('google')
+
+		expect(touch.leadId).toBe('lead-uuid')
+		expect(touch.touchpoint).toBe('conversion')
+		expect(touch.channel).toBe('paid_search')
+		expect(touch.source).toBe('google')
+		expect(touch.campaign).toBe('dfw-web-design')
+	})
+
+	it('skips the lead_attribution insert when no lead id is returned', async () => {
+		mockContactService({ resendConfigured: true })
+		const valuesCalls: unknown[] = []
+		mock.module('@/lib/db', () => ({
+			db: {
+				insert: mock(() => ({
+					values: mock((v: unknown) => {
+						valuesCalls.push(v)
+						return { returning: mock().mockResolvedValue([]) }
+					})
+				})),
+				select: selectStub()
+			}
+		}))
+
+		const { POST } = await import('@/app/api/contact/route')
+		const res = await POST(
+			makeRequest({ ...VALID_BODY, attribution: ATTRIBUTION })
+		)
+
+		expect(res.status).toBe(200)
+		// Only the leads insert ran; no touchpoint row without a lead id.
+		expect(valuesCalls).toHaveLength(1)
+	})
+
+	it('still returns 200 when the lead_attribution insert throws (lead already saved)', async () => {
+		mockContactService({ resendConfigured: true })
+		let insertCall = 0
+		mock.module('@/lib/db', () => ({
+			db: {
+				insert: mock(() => {
+					insertCall++
+					if (insertCall === 1) {
+						return {
+							values: mock().mockReturnValue({
+								returning: mock().mockResolvedValue([{ id: 'lead-uuid' }])
+							})
+						}
+					}
+					return {
+						values: mock().mockRejectedValue(new Error('touchpoint write failed'))
+					}
+				}),
+				select: selectStub()
+			}
+		}))
+
+		const { POST } = await import('@/app/api/contact/route')
+		const res = await POST(
+			makeRequest({ ...VALID_BODY, attribution: ATTRIBUTION })
+		)
+
+		expect(res.status).toBe(200)
+	})
 })

--- a/tests/unit/attribution.test.ts
+++ b/tests/unit/attribution.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import {
 	buildAttributionTouch,
-	deriveChannel
+	deriveChannel,
+	getAttribution
 } from '@/lib/attribution'
 
 const NOW = '2026-01-01T00:00:00.000Z'
+const STORAGE_KEY = 'hds_attr'
 
 describe('deriveChannel', () => {
 	it('classifies Google click IDs as paid_search', () => {
@@ -15,6 +17,13 @@ describe('deriveChannel', () => {
 
 	it('classifies fbclid as paid_social', () => {
 		expect(deriveChannel({ fbclid: 'abc' })).toBe('paid_social')
+	})
+
+	it('collapses an unrecognized utm medium to "other" but keeps known ones', () => {
+		expect(deriveChannel({ utmMedium: 'cpc' })).toBe('cpc')
+		expect(deriveChannel({ utmMedium: 'email' })).toBe('email')
+		// Crafted / misconfigured medium must not fragment channel reporting.
+		expect(deriveChannel({ utmMedium: 'totally-made-up-value' })).toBe('other')
 	})
 
 	it('falls back to utm medium, then referral, then direct', () => {
@@ -85,5 +94,54 @@ describe('buildAttributionTouch', () => {
 		expect(touch?.gclid).toBe('SECONDCLICK')
 		expect(touch?.firstTouchAt).toBe(NOW)
 		expect(touch?.lastTouchAt).toBe(later)
+	})
+})
+
+// The write glue (captureAttribution reading window.location) is verified in
+// the browser; here we cover the localStorage read path + TTL/eviction, which
+// happy-dom (registered in tests/setup.ts) supports.
+describe('getAttribution (localStorage read + TTL)', () => {
+	beforeEach(() => {
+		window.localStorage.clear()
+	})
+
+	it('returns undefined when nothing is stored', () => {
+		expect(getAttribution()).toBeUndefined()
+	})
+
+	it('reads back a stored, in-window record', () => {
+		// Recent timestamp so it is inside the 90-day TTL regardless of run date.
+		const recent = new Date().toISOString()
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ utmSource: 'google', gclid: 'X', lastTouchAt: recent })
+		)
+		const attr = getAttribution()
+		expect(attr?.utmSource).toBe('google')
+		expect(attr?.gclid).toBe('X')
+	})
+
+	it('evicts and returns undefined past the 90-day TTL', () => {
+		const old = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString()
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ gclid: 'X', lastTouchAt: old })
+		)
+		expect(getAttribution()).toBeUndefined()
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+	})
+
+	it('evicts a record with a non-ISO timestamp (schema rejects it)', () => {
+		window.localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify({ gclid: 'X', lastTouchAt: 'not-a-date' })
+		)
+		expect(getAttribution()).toBeUndefined()
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+	})
+
+	it('returns undefined for a corrupt (non-JSON) record without throwing', () => {
+		window.localStorage.setItem(STORAGE_KEY, 'not-json{{{')
+		expect(getAttribution()).toBeUndefined()
 	})
 })

--- a/tests/unit/attribution.test.ts
+++ b/tests/unit/attribution.test.ts
@@ -19,6 +19,14 @@ describe('deriveChannel', () => {
 		expect(deriveChannel({ fbclid: 'abc' })).toBe('paid_social')
 	})
 
+	it('resolves priority when multiple signals co-occur', () => {
+		expect(deriveChannel({ gclid: 'G', fbclid: 'F' })).toBe('paid_search')
+		expect(deriveChannel({ gclid: 'G', utmMedium: 'email' })).toBe(
+			'paid_search'
+		)
+		expect(deriveChannel({ fbclid: 'F', utmMedium: 'cpc' })).toBe('paid_social')
+	})
+
 	it('collapses an unrecognized utm medium to "other" but keeps known ones', () => {
 		expect(deriveChannel({ utmMedium: 'cpc' })).toBe('cpc')
 		expect(deriveChannel({ utmMedium: 'email' })).toBe('email')
@@ -143,5 +151,11 @@ describe('getAttribution (localStorage read + TTL)', () => {
 	it('returns undefined for a corrupt (non-JSON) record without throwing', () => {
 		window.localStorage.setItem(STORAGE_KEY, 'not-json{{{')
 		expect(getAttribution()).toBeUndefined()
+	})
+
+	it('evicts a record with no lastTouchAt (treated as expired)', () => {
+		window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ gclid: 'X' }))
+		expect(getAttribution()).toBeUndefined()
+		expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
 	})
 })

--- a/tests/unit/attribution.test.ts
+++ b/tests/unit/attribution.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'bun:test'
+import {
+	buildAttributionTouch,
+	deriveChannel
+} from '@/lib/attribution'
+
+const NOW = '2026-01-01T00:00:00.000Z'
+
+describe('deriveChannel', () => {
+	it('classifies Google click IDs as paid_search', () => {
+		expect(deriveChannel({ gclid: 'abc' })).toBe('paid_search')
+		expect(deriveChannel({ wbraid: 'abc' })).toBe('paid_search')
+		expect(deriveChannel({ gbraid: 'abc' })).toBe('paid_search')
+	})
+
+	it('classifies fbclid as paid_social', () => {
+		expect(deriveChannel({ fbclid: 'abc' })).toBe('paid_social')
+	})
+
+	it('falls back to utm medium, then referral, then direct', () => {
+		expect(deriveChannel({ utmMedium: 'email' })).toBe('email')
+		expect(deriveChannel({ referrer: 'https://news.ycombinator.com' })).toBe(
+			'referral'
+		)
+		expect(deriveChannel({})).toBe('direct')
+	})
+})
+
+describe('buildAttributionTouch', () => {
+	it('captures utm params + gclid from the URL', () => {
+		const touch = buildAttributionTouch(
+			new URLSearchParams(
+				'utm_source=google&utm_medium=cpc&utm_campaign=dfw-web-design&gclid=XYZ123'
+			),
+			undefined,
+			'/services',
+			undefined,
+			NOW
+		)
+
+		expect(touch?.utmSource).toBe('google')
+		expect(touch?.utmMedium).toBe('cpc')
+		expect(touch?.utmCampaign).toBe('dfw-web-design')
+		expect(touch?.gclid).toBe('XYZ123')
+		expect(touch?.landingPage).toBe('/services')
+		expect(touch?.firstTouchAt).toBe(NOW)
+		expect(touch?.lastTouchAt).toBe(NOW)
+	})
+
+	it('records a first-touch baseline on a direct visit', () => {
+		const touch = buildAttributionTouch(
+			new URLSearchParams(''),
+			undefined,
+			'/',
+			undefined,
+			NOW
+		)
+		expect(touch).not.toBeNull()
+		expect(touch?.landingPage).toBe('/')
+		expect(touch?.utmSource).toBeUndefined()
+	})
+
+	it('preserves a stored paid touch on a later paramless visit (returns null)', () => {
+		const existing = { gclid: 'FIRSTCLICK', firstTouchAt: NOW }
+		const touch = buildAttributionTouch(
+			new URLSearchParams(''),
+			undefined,
+			'/about',
+			existing,
+			'2026-02-02T00:00:00.000Z'
+		)
+		expect(touch).toBeNull()
+	})
+
+	it('overwrites with a newer ad click but keeps the first-touch timestamp', () => {
+		const existing = { gclid: 'FIRSTCLICK', firstTouchAt: NOW }
+		const later = '2026-02-02T00:00:00.000Z'
+		const touch = buildAttributionTouch(
+			new URLSearchParams('gclid=SECONDCLICK'),
+			undefined,
+			'/landing',
+			existing,
+			later
+		)
+		expect(touch?.gclid).toBe('SECONDCLICK')
+		expect(touch?.firstTouchAt).toBe(NOW)
+		expect(touch?.lastTouchAt).toBe(later)
+	})
+})


### PR DESCRIPTION
First piece of ad-readiness, and the highest-leverage one: **make ad spend measurable** by capturing which campaign/click produced each lead. Platform-agnostic (captures every common click ID), no DB migration, no platform decision required.

## What was missing
The DB was *designed* for attribution — `calculator_leads` has 9 UTM/referrer columns, there's a `lead_attribution` table, and the admin lead view renders source/medium/campaign/Touchpoints — but **nothing ever wrote any of it**. So every lead looked "direct" and ad ROAS was unknowable. (No-op audit finding.)

## What this adds
- **`src/lib/attribution.ts`** — on each public page load, capture UTM params + ad click IDs (`gclid`/`wbraid`/`gbraid` for Google, `fbclid` for Meta) + external referrer + landing page. Persist 90 days with a **last-meaningful-touch** rule: a later organic/internal visit never wipes a stored paid touch, so an ad click that lands on one page and converts on another keeps its source.
- **`AttributionTracker`** mounts the capture once in the public layout.
- **`ContactForm`** attaches `getAttribution()` to the submission; `contactFormSchema` gains an optional `attribution` object.
- **`/api/contact`** stores the full attribution (incl. `gclid`/`fbclid` for offline conversion import) on `leads.metadata`, **and** writes a normalized `lead_attribution` row — un-orphaning that table and lighting up the admin Touchpoints view.

## On storage choice (localStorage, not a cookie)
The server never auto-reads this value (it's injected into the POST body), and `getAttribution()` must read **synchronously** at submit. `document.cookie` triggers biome's `noDocumentCookie`, whose suggested fix (Cookie Store API) is **async + Baseline-2025-only** per MDN — that would silently drop attribution on older browsers. `localStorage` is the correct primitive here: sync, universal, not flagged. No `biome-ignore` suppression.

## Verification
- Pure resolver + channel mapping covered by `tests/unit/attribution.test.ts`.
- **Browser-verified**: loading `/?utm_source=google&gclid=ABC123` persists `{utmSource:"google", gclid:"ABC123", ...}`; navigating to `/contact` (no params) **preserves** it.
- `lint` clean (0 warnings) · `typecheck` clean · `test:unit` 908 pass/0 fail · `build` passes.

## Next (needs your call)
Emit a real conversion event on submit (replaces the `trackConversion` no-op) — that one needs the ad platform (Google/Meta/both) + what counts as a conversion + where conversions export (your n8n vs direct).

[hudsor01]