### PR TITLE
feat(analytics): track contact-form leads as a conversion

### DIFF
--- a/src/hooks/use-contact-form-submit.ts
+++ b/src/hooks/use-contact-form-submit.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { trackConversion } from '@/lib/analytics'
 import { csrfFetch } from '@/lib/api/csrf-fetch'
 import { logger } from '@/lib/logger'
 import type { ContactFormData } from '@/lib/schemas/contact'
@@ -49,6 +50,11 @@ export function useContactFormSubmit() {
 					userFlow: 'lead_generation',
 					conversionEvent: 'contact_form_completed',
 					businessValue: 'high'
+				})
+				// Real lead conversion: Vercel Analytics today + a GA4/GTM
+				// generate_lead dataLayer event for ad-platform attribution.
+				trackConversion('generate_lead', undefined, undefined, {
+					source: 'contact-form'
 				})
 			} else {
 				toast.error(data.error || 'An error occurred. Please try again.', {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -29,11 +29,11 @@ const PII_KEYS = new Set([
 	'address'
 ])
 
-function stripPii(
-	properties?: Record<string, AnalyticsValue>
-): Record<string, AnalyticsValue> {
+export function stripPii<T extends Record<string, AnalyticsValue>>(
+	properties?: T
+): T {
 	if (!properties) {
-		return {}
+		return {} as T
 	}
 	const out: Record<string, AnalyticsValue> = {}
 	for (const [key, val] of Object.entries(properties)) {
@@ -41,7 +41,7 @@ function stripPii(
 			out[key] = val
 		}
 	}
-	return out
+	return out as T
 }
 
 /**
@@ -57,7 +57,9 @@ export function trackEvent(
 	}
 
 	try {
-		vercelTrack(eventName, properties)
+		// Strip PII before the analytics sink: callers like the newsletter
+		// signup pass an email, which must not be forwarded to Vercel.
+		vercelTrack(eventName, stripPii(properties))
 	} catch (error) {
 		logger.warn('Failed to track event:', error)
 	}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -7,6 +7,12 @@ import { track as vercelTrack } from '@vercel/analytics'
 import { logger } from '@/lib/logger'
 import type { EventProperties } from '@/types/analytics'
 
+declare global {
+	interface Window {
+		dataLayer?: Record<string, unknown>[]
+	}
+}
+
 type AnalyticsValue = string | number | boolean | null | undefined
 
 /**
@@ -52,4 +58,26 @@ export function trackConversion(
 	} catch (error) {
 		logger.warn('Failed to track conversion:', error)
 	}
+
+	// Also push a GA4/GTM-standard event to the dataLayer, so a Google Ads /
+	// Meta pixel added later via a tag manager fires with zero code change.
+	pushToDataLayer(conversionType, value, currency, properties)
+}
+
+function pushToDataLayer(
+	event: string,
+	value?: number,
+	currency = 'USD',
+	properties?: Record<string, AnalyticsValue>
+): void {
+	if (typeof window === 'undefined') {
+		return
+	}
+
+	window.dataLayer = window.dataLayer ?? []
+	window.dataLayer.push({
+		event,
+		...(value !== undefined ? { value, currency } : {}),
+		...properties
+	})
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -15,6 +15,35 @@ declare global {
 
 type AnalyticsValue = string | number | boolean | null | undefined
 
+// Property keys never forwarded to an analytics sink. The dataLayer is read
+// by third-party tag managers / ad pixels, and Vercel Analytics is not a PII
+// store either, so these are stripped centrally before any send.
+const PII_KEYS = new Set([
+	'email',
+	'phone',
+	'telephone',
+	'name',
+	'firstname',
+	'lastname',
+	'fullname',
+	'address'
+])
+
+function stripPii(
+	properties?: Record<string, AnalyticsValue>
+): Record<string, AnalyticsValue> {
+	if (!properties) {
+		return {}
+	}
+	const out: Record<string, AnalyticsValue> = {}
+	for (const [key, val] of Object.entries(properties)) {
+		if (!PII_KEYS.has(key.toLowerCase())) {
+			out[key] = val
+		}
+	}
+	return out
+}
+
 /**
  * Track custom event
  * Used for general event tracking (page views, user actions, etc.)
@@ -48,12 +77,14 @@ export function trackConversion(
 		return
 	}
 
+	const safeProperties = stripPii(properties)
+
 	try {
 		vercelTrack('conversion', {
 			conversionType,
 			value,
 			currency,
-			...properties
+			...safeProperties
 		})
 	} catch (error) {
 		logger.warn('Failed to track conversion:', error)
@@ -61,7 +92,7 @@ export function trackConversion(
 
 	// Also push a GA4/GTM-standard event to the dataLayer, so a Google Ads /
 	// Meta pixel added later via a tag manager fires with zero code change.
-	pushToDataLayer(conversionType, value, currency, properties)
+	pushToDataLayer(conversionType, value, currency, safeProperties)
 }
 
 function pushToDataLayer(

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,5 +1,28 @@
 import { beforeEach, describe, expect, it } from 'bun:test'
-import { trackConversion } from '@/lib/analytics'
+import { stripPii, trackConversion } from '@/lib/analytics'
+
+describe('stripPii', () => {
+	it('drops PII keys (case-insensitive) and keeps everything else', () => {
+		const out = stripPii({
+			email: 'jane@example.com',
+			Phone: '555-0100',
+			firstName: 'Jane',
+			address: '1 Main St',
+			source: 'newsletter',
+			count: 3
+		})
+		expect(out.email).toBeUndefined()
+		expect(out.Phone).toBeUndefined()
+		expect(out.firstName).toBeUndefined()
+		expect(out.address).toBeUndefined()
+		expect(out.source).toBe('newsletter')
+		expect(out.count).toBe(3)
+	})
+
+	it('returns an empty object for undefined input', () => {
+		expect(stripPii(undefined)).toEqual({})
+	})
+})
 
 // No module mock: trackConversion's Vercel Analytics call is wrapped in
 // try/catch and inert outside a Vercel-instrumented page, and we assert only

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -29,4 +29,18 @@ describe('trackConversion -> dataLayer', () => {
 		expect('value' in last).toBe(false)
 		expect('currency' in last).toBe(false)
 	})
+
+	it('strips PII before pushing to the dataLayer (3rd-party sink)', () => {
+		trackConversion('generate_lead', undefined, undefined, {
+			email: 'jane@example.com',
+			phone: '555-0100',
+			name: 'Jane Doe',
+			source: 'contact-form'
+		})
+		const last = (window.dataLayer ?? []).at(-1) as Record<string, unknown>
+		expect(last.email).toBeUndefined()
+		expect(last.phone).toBeUndefined()
+		expect(last.name).toBeUndefined()
+		expect(last.source).toBe('contact-form')
+	})
 })

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { trackConversion } from '@/lib/analytics'
+
+// No module mock: trackConversion's Vercel Analytics call is wrapped in
+// try/catch and inert outside a Vercel-instrumented page, and we assert only
+// the platform-agnostic dataLayer push. Mocking @vercel/analytics here would
+// leak globally and break other suites.
+
+describe('trackConversion -> dataLayer', () => {
+	beforeEach(() => {
+		window.dataLayer = []
+	})
+
+	it('pushes a GA4/GTM-standard event a tag manager can consume', () => {
+		trackConversion('generate_lead', 1500, 'USD', { source: 'contact-form' })
+		const last = (window.dataLayer ?? []).at(-1) as Record<string, unknown>
+		expect(last.event).toBe('generate_lead')
+		expect(last.value).toBe(1500)
+		expect(last.currency).toBe('USD')
+		expect(last.source).toBe('contact-form')
+	})
+
+	it('omits value/currency when no value is provided', () => {
+		trackConversion('generate_lead', undefined, undefined, {
+			source: 'contact-form'
+		})
+		const last = (window.dataLayer ?? []).at(-1) as Record<string, unknown>
+		expect(last.event).toBe('generate_lead')
+		expect('value' in last).toBe(false)
+		expect('currency' in last).toBe(false)
+	})
+})


### PR DESCRIPTION
Wires the contact form into conversion tracking and makes conversions platform-agnostic, so paid campaigns have a lead signal to optimize toward.

## Gap
`trackConversion` (in `src/lib/analytics.ts`) was already used by the calculators (`CalculatorResults.tsx`), but the **contact form fired no conversion** on submit, and there was no ad-platform mechanism (no GA4/GTM/pixel hook).

## Change
- `trackConversion` now also pushes a **GA4/GTM-standard event to `window.dataLayer`** alongside the existing Vercel Analytics event. The moment a Google Ads / Meta pixel is added via a tag manager (or gtag), the conversion fires with **zero code change** - no platform decision needed now.
- The contact submit hook fires `trackConversion('generate_lead', ...)` on success.
- Adds a test for the dataLayer contract (no module mock, so no cross-suite leakage).

Together with the merged attribution PR (#320), a paid lead is now both **measurable** (gclid/fbclid + campaign on the lead) and **trackable** (a `generate_lead` event ready for the ad platform).

## Verification
- `typecheck` clean · `lint` clean · `test:unit` 921 pass/0 · `build` passes

## Deferred
The `Button` `trackConversion` no-op prop (discarded across ~23 CTAs) is a separate mechanical cleanup.

[hudsor01]