### PR TITLE
fix(leads): persist phone, company, and score on contact leads

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -48,6 +48,12 @@ async function handleContactPost(request: NextRequest) {
 		// Step 3: Security check (monitoring only)
 		checkForSecurityThreats(data, clientIP, logger)
 
+		// Lead score is computed up front: it drives both the persisted row
+		// and the follow-up email sequence below.
+		const leadScoring = scoreLeadFromContactData(data)
+		const leadScore = leadScoring.score
+		const sequenceId = leadScoring.sequenceType
+
 		// Step 3b: Save to leads table.
 		let leadId: string | undefined
 		try {
@@ -56,8 +62,11 @@ async function handleContactPost(request: NextRequest) {
 				.values({
 					email: data.email,
 					name: `${data.firstName} ${data.lastName}`.trim(),
+					phone: data.phone ?? null,
+					company: data.company ?? null,
 					source: 'contact-form',
 					status: 'new',
+					score: leadScore,
 					metadata: {
 						service: data.service,
 						budget: data.budget,
@@ -108,10 +117,7 @@ async function handleContactPost(request: NextRequest) {
 			}
 		}
 
-		// Step 4: Calculate lead score and prepare email data
-		const leadScoring = scoreLeadFromContactData(data)
-		const leadScore = leadScoring.score
-		const sequenceId = leadScoring.sequenceType
+		// Step 4: Prepare email data (lead score computed above).
 		const emailVariables = prepareEmailVariables(data)
 
 		// Step 5: Defer all email sends + lead notifications + follow-up

--- a/tests/unit/api-contact.test.ts
+++ b/tests/unit/api-contact.test.ts
@@ -202,6 +202,11 @@ describe('POST /api/contact', () => {
 		expect(meta.attribution.gclid).toBe('GCLID123')
 		expect(meta.attribution.utmSource).toBe('google')
 
+		// Lead fields that were previously dropped are now persisted.
+		expect(leadsValues.phone).toBe('555-123-4567')
+		expect(leadsValues.company).toBe('Riley Co')
+		expect(typeof leadsValues.score).toBe('number')
+
 		expect(touch.leadId).toBe('lead-uuid')
 		expect(touch.touchpoint).toBe('conversion')
 		expect(touch.channel).toBe('paid_search')


### PR DESCRIPTION
From the session-wide audit (should-fix).

The contact route saved the lead row with `email`/`name`/`metadata` but **never wrote `phone`, `company`, or the computed lead `score`** - so a lead's phone number was lost and `lead_score` stayed null despite being calculated for the email sequence.

- Compute `scoreLeadFromContactData` once up front (it was computed after the insert), and write `phone`/`company`/`score` onto the `leads` row.
- Extend the persistence test to assert the new fields.

`typecheck`/`lint` clean · `test:unit` 919 pass/0 · build passes.

[hudsor01]