### PR TITLE
chore(ui): remove the no-op Button trackConversion prop

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -461,12 +461,7 @@ export default function AboutPage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href="/contact">
 										Get My Free Website Plan
 										<ArrowRight className="w-5 h-5" />

--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -343,7 +343,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 								Let&apos;s map out what it needs, and build something that turns
 								your reputation into booked customers.
 							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">Get My Free Website Plan</Link>
 							</Button>
 						</div>

--- a/src/app/(public)/blog/page.tsx
+++ b/src/app/(public)/blog/page.tsx
@@ -201,7 +201,7 @@ export default function BlogPage() {
 								<p className="text-sm text-muted-foreground mb-6 leading-relaxed">
 									Let&apos;s build the one your business deserves.
 								</p>
-								<Button asChild variant="accent" trackConversion={true}>
+								<Button asChild variant="accent">
 									<Link href="/contact">
 										Get My Free Website Plan
 										<ArrowRight className="w-4 h-4" />

--- a/src/app/(public)/faq/FaqClient.tsx
+++ b/src/app/(public)/faq/FaqClient.tsx
@@ -239,7 +239,7 @@ export default function FaqClient() {
 								Get a free website plan. We&apos;ll map out what your site needs
 								and answer every question along the way.
 							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">
 									Get My Free Website Plan
 									<ArrowRight className="w-4 h-4" />

--- a/src/app/(public)/help/[category]/[slug]/page.tsx
+++ b/src/app/(public)/help/[category]/[slug]/page.tsx
@@ -271,7 +271,7 @@ export default async function HelpArticlePage({ params }: PageProps) {
 						<p className="text-sm text-muted-foreground mb-4">
 							Was this article helpful? Need more assistance?
 						</p>
-						<Button asChild variant="accent" trackConversion={true}>
+						<Button asChild variant="accent">
 							<Link href="/contact">
 								Contact Support
 								<ArrowRight className="size-4" />

--- a/src/app/(public)/help/[category]/page.tsx
+++ b/src/app/(public)/help/[category]/page.tsx
@@ -190,7 +190,7 @@ export default async function HelpCategoryPage({ params }: PageProps) {
 						<p className="text-sm text-muted-foreground mb-4">
 							Need more help with {categoryInfo.name.toLowerCase()}?
 						</p>
-						<Button asChild variant="accent" trackConversion={true}>
+						<Button asChild variant="accent">
 							<Link href="/contact">
 								Contact Support
 								<ArrowRight className="size-4" />

--- a/src/app/(public)/locations/[slug]/page.tsx
+++ b/src/app/(public)/locations/[slug]/page.tsx
@@ -224,7 +224,7 @@ export default async function LocationPage({ params }: LocationPageProps) {
 								Tell us about your business. We&apos;ll map out the website it
 								needs: pages, timeline, and cost.
 							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">
 									Get My Free Website Plan
 									<ArrowRight className="h-4 w-4" />

--- a/src/app/(public)/locations/page.tsx
+++ b/src/app/(public)/locations/page.tsx
@@ -100,7 +100,7 @@ export default function LocationsPage() {
 								We work with clients remotely across the entire US. Get in touch
 								to discuss your project.
 							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">
 									Contact Us
 									<ArrowRight className="w-4 h-4" />

--- a/src/app/(public)/not-found.tsx
+++ b/src/app/(public)/not-found.tsx
@@ -49,7 +49,7 @@ export default function NotFound() {
 
 				{/* Action Buttons */}
 				<div className="flex flex-wrap justify-center gap-4 mb-10">
-					<Button asChild variant="accent" size="xl" trackConversion={false}>
+					<Button asChild variant="accent" size="xl">
 						<Link href="/">
 							<Home className="w-5 h-5" />
 							Return Home

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -136,12 +136,7 @@ export default function HomePage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href={ROUTES.CONTACT}>
 										Get My Free Website Plan
 										<ArrowRight className="w-4 h-4" />
@@ -151,7 +146,6 @@ export default function HomePage() {
 									asChild
 									variant="outline"
 									size="xl"
-									trackConversion={true}
 									className="border-2 border-foreground/25 hover:border-accent dark:border-foreground/20"
 								>
 									<Link href={ROUTES.SHOWCASE}>See Recent Work</Link>
@@ -408,7 +402,7 @@ export default function HomePage() {
 					{/* Primary CTA card — visually contains the action + trust signals */}
 					<div className="mt-10 rounded-2xl border border-border bg-background p-6 sm:p-8 shadow-sm">
 						<div className="flex flex-col sm:flex-row gap-3 justify-center">
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href={ROUTES.CONTACT}>
 									Get My Free Website Plan
 									<ArrowRight className="w-4 h-4" />

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -78,7 +78,7 @@ export default function ServicesPage() {
 						follow-up when you&apos;re ready.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
-						<Button asChild variant="accent" size="xl" trackConversion={true}>
+						<Button asChild variant="accent" size="xl">
 							<Link href="/contact">
 								Get My Free Website Plan
 								<ArrowRight className="w-4 h-4" />
@@ -188,12 +188,7 @@ export default function ServicesPage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href="/contact">
 										Get My Free Website Plan
 										<ArrowRight className="w-5 h-5" />

--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -163,7 +163,7 @@ async function ShowcaseProjects() {
 								Free 30-minute call. We map out pages, timeline, and a clear
 								price for your website. No sales pitch.
 							</p>
-							<Button asChild variant="accent" size="xl" trackConversion={true}>
+							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">
 									Get My Free Website Plan
 									<Rocket className="w-5 h-5" aria-hidden="true" />
@@ -214,7 +214,7 @@ export default function ShowcasePage() {
 					</p>
 
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
-						<Button asChild variant="accent" size="xl" trackConversion={true}>
+						<Button asChild variant="accent" size="xl">
 							<Link href="/contact">
 								Get My Free Website Plan
 								<Rocket className="w-5 h-5" aria-hidden="true" />
@@ -274,12 +274,7 @@ export default function ShowcasePage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href="/contact">
 										Get My Free Website Plan
 										<Rocket className="w-5 h-5" aria-hidden="true" />

--- a/src/app/(public)/testimonials/page.tsx
+++ b/src/app/(public)/testimonials/page.tsx
@@ -247,12 +247,7 @@ export default function TestimonialsPage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href="/contact">
 										Get My Free Website Plan
 										<ArrowRight className="w-5 h-5" />

--- a/src/app/(public)/tools/page.tsx
+++ b/src/app/(public)/tools/page.tsx
@@ -107,12 +107,7 @@ export default function ToolsPage() {
 								reality. Schedule a free consultation to discuss your project.
 							</p>
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href="/contact">Get My Free Website Plan</Link>
 								</Button>
 								<Button

--- a/src/app/(public)/website-migration/page.tsx
+++ b/src/app/(public)/website-migration/page.tsx
@@ -189,7 +189,7 @@ export default function WebsiteMigrationPage() {
 						zero downtime and preserved SEO rankings.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
-						<Button asChild variant="accent" size="xl" trackConversion={true}>
+						<Button asChild variant="accent" size="xl">
 							<Link href={ROUTES.CONTACT}>
 								Free Migration Consultation
 								<ArrowRight className="w-4 h-4" />
@@ -432,12 +432,7 @@ export default function WebsiteMigrationPage() {
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
-								<Button
-									asChild
-									variant="accent"
-									size="xl"
-									trackConversion={true}
-								>
+								<Button asChild variant="accent" size="xl">
 									<Link href={ROUTES.CONTACT}>
 										Book Free Migration Audit
 										<ArrowRight className="w-5 h-5" />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -71,7 +71,7 @@ export default function NotFound() {
 					</div>
 
 					<div className="flex flex-wrap justify-center gap-4 mb-10">
-						<Button asChild variant="accent" size="xl" trackConversion={false}>
+						<Button asChild variant="accent" size="xl">
 							<Link href="/">
 								<Home className="w-5 h-5" />
 								Return Home

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -117,7 +117,6 @@ const Navbar = memo(function Navbar() {
 								asChild
 								variant="default"
 								size="sm"
-								trackConversion={true}
 								onClick={handleNavClick}
 							>
 								<Link href={ROUTES.CONTACT}>
@@ -175,7 +174,6 @@ const Navbar = memo(function Navbar() {
 								asChild
 								variant="default"
 								size="sm"
-								trackConversion={true}
 								className="w-full"
 								onClick={handleNavClick}
 							>

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -65,6 +65,4 @@ export interface ButtonProps
 	extends React.ComponentProps<'button'>,
 		VariantProps<typeof buttonVariants> {
 	asChild?: boolean
-	/** Track this button click as a conversion event (handled by Vercel Analytics) */
-	trackConversion?: boolean
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,8 +13,6 @@ function Button({
 	variant,
 	size,
 	asChild = false,
-	// trackConversion prop kept for API compatibility, tracking handled by Vercel Analytics
-	trackConversion: _trackConversion,
 	...props
 }: ButtonProps) {
 	const Comp = asChild ? Slot : 'button'

--- a/src/components/utilities/CTASection.tsx
+++ b/src/components/utilities/CTASection.tsx
@@ -42,7 +42,7 @@ export function CTASection({
 						<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
 							{description}
 						</p>
-						<Button asChild variant="accent" size="xl" trackConversion={true}>
+						<Button asChild variant="accent" size="xl">
 							<Link href={ctaHref}>
 								{ctaLabel}
 								<ArrowRight className="w-5 h-5" />

--- a/tests/unit/components.test.tsx
+++ b/tests/unit/components.test.tsx
@@ -291,7 +291,7 @@ describe('Card Component (Glass Variants)', () => {
 describe('Button Component (CTA Pattern)', () => {
 	it('should render as link with asChild', () => {
 		render(
-			<Button asChild variant="default" size="default" trackConversion={true}>
+			<Button asChild variant="default" size="default">
 				<Link href="/test">
 					Test CTA
 					<ArrowRight className="w-4 h-4" />
@@ -306,7 +306,7 @@ describe('Button Component (CTA Pattern)', () => {
 
 	it('should render different variants', () => {
 		const { rerender } = render(
-			<Button asChild variant="default" size="default" trackConversion={true}>
+			<Button asChild variant="default" size="default">
 				<Link href="/test">
 					Primary
 					<ArrowRight className="w-4 h-4" />
@@ -317,7 +317,7 @@ describe('Button Component (CTA Pattern)', () => {
 		expect(link).toHaveClass('bg-primary')
 
 		rerender(
-			<Button asChild variant="outline" size="default" trackConversion={true}>
+			<Button asChild variant="outline" size="default">
 				<Link href="/test">
 					Secondary
 					<ArrowRight className="w-4 h-4" />
@@ -330,7 +330,7 @@ describe('Button Component (CTA Pattern)', () => {
 
 	it('should show arrow by default', () => {
 		const { container } = render(
-			<Button asChild variant="default" size="default" trackConversion={true}>
+			<Button asChild variant="default" size="default">
 				<Link href="/test">
 					With Arrow
 					<ArrowRight className="w-4 h-4" />
@@ -344,7 +344,7 @@ describe('Button Component (CTA Pattern)', () => {
 
 	it('should hide arrow when not included', () => {
 		const { container } = render(
-			<Button asChild variant="default" size="default" trackConversion={true}>
+			<Button asChild variant="default" size="default">
 				<Link href="/test">No Arrow</Link>
 			</Button>
 		)
@@ -355,7 +355,7 @@ describe('Button Component (CTA Pattern)', () => {
 
 	it('should handle external links', () => {
 		render(
-			<Button asChild variant="default" size="default" trackConversion={true}>
+			<Button asChild variant="default" size="default">
 				<a
 					href="https://external.com"
 					target="_blank"


### PR DESCRIPTION
Closes out the last deferred item from the session: the `Button` `trackConversion` prop was accepted and immediately discarded (`trackConversion: _trackConversion`), so ~25 CTAs across 18 files passed `trackConversion={true}` that tracked **nothing**.

Conversions are now tracked centrally on contact-form submit (#321), so the per-CTA flag is dead and misleading. This removes it:
- `trackConversion?: boolean` from `ButtonProps` (`button-variants.ts`)
- the `_trackConversion` destructure + comment from `button.tsx`
- all 25 `trackConversion={...}` JSX usages (18 source files + 6 in the component test)

**Non-visual** - a discarded prop has no rendered output, so the Playwright snapshots are unaffected (no regeneration needed).

`typecheck`/`lint` clean · `test:unit` 924 pass/0 · build passes.

[hudsor01]