### PR TITLE
Fix: make client-side form validation actually fire (noValidate + submit mode)

### DIFF
--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -60,7 +60,7 @@ test.describe('Contact Form', () => {
     // Select service option
     const serviceSelect = page.locator('#service')
     await serviceSelect.click()
-    await page.locator('[role="option"]').filter({ hasText: 'Web Development' }).click()
+    await page.locator('[role="option"]').filter({ hasText: 'Website Design' }).click()
 
     // Select best time to contact
     const timeSelect = page.locator('#bestTimeToContact')
@@ -109,7 +109,7 @@ test.describe('Contact Form', () => {
 
     // Select service (Radix Select)
     await page.locator('#service').click()
-    await page.locator('[role="option"]').filter({ hasText: 'Web Development' }).click()
+    await page.locator('[role="option"]').filter({ hasText: 'Website Design' }).click()
 
     // Select best time to contact
     await page.locator('#bestTimeToContact').click()

--- a/e2e/free-mockup.spec.ts
+++ b/e2e/free-mockup.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Free Mockup Landing Page E2E Tests
+ * =============================================================================
+ *
+ * Covers the /free-mockup conversion flow: the distraction-free landing page
+ * (new `(landing)` route group) and its minimal lead form, which reuses the
+ * contact pipeline via buildFreeMockupPayload.
+ *
+ * The success path mocks POST /api/contact so the test never creates a real
+ * lead or sends a real email on each run. The validation tests exercise the
+ * client-side "reward early, punish late" behaviour: a submit attempt surfaces
+ * errors, then they clear on change as the user fixes them.
+ */
+
+import { expect, type Route, test } from '@playwright/test'
+
+test.describe('Free Mockup Landing', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/free-mockup')
+		// Wait for the dynamically imported form to load.
+		await page.locator('form').waitFor({ state: 'visible', timeout: 15000 })
+	})
+
+	test('renders the offer headline and all form fields', async ({ page }) => {
+		await expect(
+			page.getByRole('heading', {
+				name: /see your new website before you pay anything/i
+			})
+		).toBeVisible()
+
+		await expect(page.locator('#firstName')).toBeVisible()
+		await expect(page.locator('#lastName')).toBeVisible()
+		await expect(page.locator('#email')).toBeVisible()
+		await expect(page.locator('#businessName')).toBeVisible()
+		await expect(page.locator('#currentSite')).toBeVisible()
+		await expect(page.locator('#phone')).toBeVisible()
+
+		const submit = page.locator('button[type="submit"]')
+		await expect(submit).toBeVisible()
+		await expect(submit).toHaveText(/free mockup/i)
+	})
+
+	test('a submit attempt on an invalid form surfaces inline errors and does not proceed', async ({
+		page
+	}) => {
+		// Empty required fields + click submit (punish late).
+		await page.locator('button[type="submit"]').click()
+
+		await expect(
+			page.getByText('Please enter a valid email address')
+		).toBeVisible({ timeout: 5000 })
+
+		// Form stays; success screen never renders.
+		await expect(page.locator('form')).toBeVisible()
+		const successShown = await page
+			.getByRole('heading', { name: /request received/i })
+			.isVisible()
+			.catch(() => false)
+		expect(successShown).toBe(false)
+	})
+
+	test('submits successfully with valid data (API mocked)', async ({ page }) => {
+		await page.route('**/api/contact', async (route: Route) => {
+			if (route.request().method() === 'POST') {
+				await route.fulfill({
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify({
+						success: true,
+						message: 'Thank you! Your message has been sent successfully.'
+					})
+				})
+				return
+			}
+			await route.continue()
+		})
+
+		await page.fill('#firstName', 'Maria')
+		await page.fill('#lastName', 'Lopez')
+		await page.fill('#email', 'maria@example.com')
+		await page.fill('#businessName', "Maria's Tacos")
+
+		await page.locator('button[type="submit"]').click()
+
+		await expect(
+			page.getByRole('heading', { name: /request received/i })
+		).toBeVisible({ timeout: 15000 })
+		await expect(page.locator('form')).not.toBeVisible()
+	})
+
+	test('has accessible labels and a focusable form', async ({ page }) => {
+		await expect(page.locator('label[for="firstName"]')).toBeVisible()
+		await expect(page.locator('label[for="email"]')).toBeVisible()
+		await expect(page.locator('label[for="businessName"]')).toBeVisible()
+
+		await page.locator('#firstName').focus()
+		await expect(page.locator('#firstName')).toBeFocused()
+		await page.keyboard.press('Tab')
+		await expect(page.locator('#lastName')).toBeFocused()
+	})
+})

--- a/src/app/(admin)/admin/showcase/[id]/edit/EditShowcaseForm.tsx
+++ b/src/app/(admin)/admin/showcase/[id]/edit/EditShowcaseForm.tsx
@@ -76,6 +76,7 @@ export function EditShowcaseForm({ row }: EditShowcaseFormProps) {
 	return (
 		<div className="space-y-6">
 			<form
+				noValidate
 				onSubmit={e => {
 					e.preventDefault()
 					void form.handleSubmit()

--- a/src/app/(admin)/admin/showcase/_form/useShowcaseForm.ts
+++ b/src/app/(admin)/admin/showcase/_form/useShowcaseForm.ts
@@ -114,10 +114,12 @@ export function useShowcaseForm({
 
 	const form = useAppForm({
 		defaultValues,
-		// Reward early, punish late: errors on blur, then revalidate on change
-		// after a submit attempt. Server action still validates on submit.
+		// Reward early, punish late: validate on submit, then revalidate on
+		// change so errors clear as the user fixes them. Requires noValidate on
+		// the form (set in the create/edit showcase form components). Server
+		// action still validates on submit.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: { onDynamic: showcaseFormClientSchema },

--- a/src/app/(admin)/admin/showcase/new/CreateShowcaseForm.tsx
+++ b/src/app/(admin)/admin/showcase/new/CreateShowcaseForm.tsx
@@ -61,6 +61,7 @@ export function CreateShowcaseForm() {
 
 	return (
 		<form
+			noValidate
 			onSubmit={e => {
 				e.preventDefault()
 				void form.handleSubmit()

--- a/src/app/(admin)/admin/testimonials/[id]/edit/EditTestimonialForm.tsx
+++ b/src/app/(admin)/admin/testimonials/[id]/edit/EditTestimonialForm.tsx
@@ -54,10 +54,11 @@ export function EditTestimonialForm({ row }: EditTestimonialFormProps) {
 
 	const form = useAppForm({
 		defaultValues: defaults,
-		// Reward early, punish late: errors on blur, then revalidate on change
-		// after a submit attempt. Server action still validates on submit.
+		// Reward early, punish late: validate on submit, then revalidate on
+		// change so errors clear as the user fixes them. Requires noValidate on
+		// the form. Server action still validates on submit.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: { onDynamic: updateAdminTestimonialSchema },
@@ -94,6 +95,7 @@ export function EditTestimonialForm({ row }: EditTestimonialFormProps) {
 	return (
 		<div className="space-y-8">
 			<form
+				noValidate
 				onSubmit={e => {
 					e.preventDefault()
 					void form.handleSubmit()

--- a/src/app/(admin)/admin/testimonials/new/CreateTestimonialForm.tsx
+++ b/src/app/(admin)/admin/testimonials/new/CreateTestimonialForm.tsx
@@ -54,10 +54,11 @@ export function CreateTestimonialForm() {
 
 	const form = useAppForm({
 		defaultValues: DEFAULTS,
-		// Reward early, punish late: errors on blur, then revalidate on change
-		// after a submit attempt. Server action still validates on submit.
+		// Reward early, punish late: validate on submit, then revalidate on
+		// change so errors clear as the user fixes them. Requires noValidate on
+		// the form. Server action still validates on submit.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: { onDynamic: createAdminTestimonialSchema },
@@ -91,6 +92,7 @@ export function CreateTestimonialForm() {
 
 	return (
 		<form
+			noValidate
 			onSubmit={e => {
 				e.preventDefault()
 				void form.handleSubmit()

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -49,10 +49,12 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 			timeline: 'flexible',
 			message: ''
 		},
-		// Reward early, punish late: first error on blur, then revalidate on
-		// change once the form has been submitted. Canonical TanStack pattern.
+		// Reward early, punish late: validate on submit (surfaces all errors at
+		// once), then revalidate on change so they clear as the user fixes them.
+		// Requires noValidate on the form so the native required-check does not
+		// block the submit event before handleSubmit runs.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: { onDynamic: contactFormClientSchema },
@@ -93,6 +95,7 @@ function ContactFormInner({ className = '' }: { className?: string }) {
 			// happy path; this is a defense-in-depth fallback against the
 			// audit-reported GET behavior (#237).
 			method="post"
+			noValidate
 			onSubmit={e => {
 				e.preventDefault()
 				e.stopPropagation()

--- a/src/components/forms/FreeMockupForm.tsx
+++ b/src/components/forms/FreeMockupForm.tsx
@@ -34,10 +34,12 @@ function FreeMockupFormInner({ className = '' }: { className?: string }) {
 			currentSite: '',
 			phone: ''
 		},
-		// Reward early, punish late: first error on blur, then revalidate on
-		// change once the form has been submitted. Canonical TanStack pattern.
+		// Reward early, punish late: validate on submit (surfaces all errors at
+		// once), then revalidate on change so they clear as the user fixes them.
+		// Requires noValidate on the form so the browser's native required-check
+		// does not block the submit event before handleSubmit runs.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: { onDynamic: freeMockupFormSchema },
@@ -73,6 +75,10 @@ function FreeMockupFormInner({ className = '' }: { className?: string }) {
 			// method="post" so a pre-hydration submit uses POST and keeps the
 			// payload out of the URL (mirrors ContactForm, audit #237).
 			method="post"
+			// noValidate hands validation to TanStack + Zod: without it the
+			// browser's native `required` check blocks the submit event before
+			// handleSubmit runs, so our inline FieldError errors never show.
+			noValidate
 			onSubmit={e => {
 				e.preventDefault()
 				e.stopPropagation()

--- a/src/components/forms/NewsletterSignup.tsx
+++ b/src/components/forms/NewsletterSignup.tsx
@@ -42,10 +42,12 @@ function NewsletterSignupContent({
 		defaultValues: {
 			email: ''
 		},
-		// Reward early, punish late: first error on blur, then revalidate on
-		// change once the form has been submitted. Canonical TanStack pattern.
+		// Reward early, punish late: validate on submit (surfaces all errors at
+		// once), then revalidate on change so they clear as the user fixes them.
+		// Requires noValidate on the form so the native required-check does not
+		// block the submit event before handleSubmit runs.
 		validationLogic: revalidateLogic({
-			mode: 'blur',
+			mode: 'submit',
 			modeAfterSubmission: 'change'
 		}),
 		validators: {
@@ -83,6 +85,7 @@ function NewsletterSignupContent({
 
 				<form
 					method="post"
+					noValidate
 					onSubmit={e => {
 						e.preventDefault()
 						e.stopPropagation()
@@ -192,6 +195,7 @@ function NewsletterSignupContent({
 
 				<form
 					method="post"
+					noValidate
 					onSubmit={e => {
 						e.preventDefault()
 						e.stopPropagation()
@@ -308,6 +312,7 @@ function NewsletterSignupContent({
 
 					<form
 						method="post"
+						noValidate
 						onSubmit={e => {
 							e.preventDefault()
 							e.stopPropagation()

--- a/src/hooks/form-hook.tsx
+++ b/src/hooks/form-hook.tsx
@@ -309,18 +309,18 @@ function SubmitButton({
 	loadingLabel = 'Submitting...'
 }: SubmitButtonProps) {
 	const form = useFormContext()
+	// Stay clickable while the form is invalid: a submit attempt then triggers
+	// validation and surfaces the errors (reward early, punish late). Gating on
+	// canSubmit would leave the button greyed out with no explanation under
+	// blur-mode validation. Only disable while a submission is in flight to
+	// prevent double-submit.
 	return (
-		<form.Subscribe
-			selector={state => [state.canSubmit, state.isSubmitting] as const}
-		>
-			{result => {
-				const [canSubmit, isSubmitting] = result
-				return (
-					<Button type="submit" disabled={!canSubmit || isSubmitting}>
-						{isSubmitting ? loadingLabel : label}
-					</Button>
-				)
-			}}
+		<form.Subscribe selector={state => state.isSubmitting}>
+			{isSubmitting => (
+				<Button type="submit" disabled={isSubmitting}>
+					{isSubmitting ? loadingLabel : label}
+				</Button>
+			)}
 		</form.Subscribe>
 	)
 }


### PR DESCRIPTION
## Problem
The client-side validation merged in #324 was **non-functional on submit**. Two root causes:

1. **Native validation blocked submit.** The forms had no `noValidate`, and inputs carry the HTML `required` attribute. The browser's native required-check fired first and blocked the submit event, so TanStack's `handleSubmit` never ran and the Zod `onDynamic` validators never executed. Inline `FieldError` messages never appeared on submit.
2. **`mode: 'blur'` didn't proceed.** With `revalidateLogic({ mode: 'blur' })`, a submit on filled-but-un-blurred fields didn't validate or proceed, so valid data also failed to submit.
3. **Submit button disabled on invalid.** With validators added, the shared `SubmitButton` gated on `canSubmit`, greying out with no explanation under blur-mode validation.

Caught by adding the missing e2e coverage for the conversion flow.

## Fix
- Add `noValidate` to **every** form (contact, free-mockup, newsletter x3 variants, both testimonial forms, both showcase forms) and switch `revalidateLogic` to **`mode: 'submit'`**: a submit attempt surfaces all errors at once, then revalidates on change as the user fixes them (reward early, punish late).
- `SubmitButton` only disables while submitting, not on `!canSubmit`, so a submit can run validation and reveal errors.
- New e2e: `e2e/free-mockup.spec.ts` (renders, inline validation on submit, mocked success, a11y).
- Fix a stale contact-form e2e option label (`Web Development` -> `Website Design`).

## Verification
- `bun run typecheck`: clean
- `bun run lint`: clean
- `bun run build`: succeeds
- `bun test` (unit): 940 pass / 21 pre-existing fails (documented bun:test mock-pollution, CI-invisible), zero new
- e2e: free-mockup 4/4 pass; contact-form 6/6 pass (excluding the real-email-sending tests)

[hudsor01]