### PR TITLE
fix(paystub): use official 2025 tax tables, stop silent $0 for unsupported states

### DIFF
--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -9,93 +9,153 @@
  * Full interaction tests (form submission, PDF generation) are out of scope.
  */
 
-import { test, expect } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 
 test.describe('Tools Index', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools')
-    await page.waitForLoadState('networkidle')
-  })
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/tools')
+		await page.waitForLoadState('networkidle')
+	})
 
-  test('should display tools page heading', async ({ page }) => {
-    await expect(page.locator('h1')).toBeVisible()
-    await expect(page.locator('h1')).toContainText(/business tools/i)
-  })
+	test('should display tools page heading', async ({ page }) => {
+		await expect(page.locator('h1')).toBeVisible()
+		await expect(page.locator('h1')).toContainText(/business tools/i)
+	})
 
-  test('should display tool cards linking to /tools/*', async ({ page }) => {
-    const toolLinks = page.locator('a[href^="/tools/"]')
-    const count = await toolLinks.count()
-    expect(count).toBeGreaterThanOrEqual(13)
-  })
+	test('should display tool cards linking to /tools/*', async ({ page }) => {
+		const toolLinks = page.locator('a[href^="/tools/"]')
+		const count = await toolLinks.count()
+		expect(count).toBeGreaterThanOrEqual(13)
+	})
 
-  test('should link to the paystub calculator', async ({ page }) => {
-    await expect(page.locator('a[href="/tools/paystub-calculator"]')).toBeVisible()
-  })
+	test('should link to the paystub calculator', async ({ page }) => {
+		await expect(
+			page.locator('a[href="/tools/paystub-calculator"]')
+		).toBeVisible()
+	})
 
-  test('should link to the invoice generator', async ({ page }) => {
-    await expect(page.locator('a[href="/tools/invoice-generator"]')).toBeVisible()
-  })
+	test('should link to the invoice generator', async ({ page }) => {
+		await expect(
+			page.locator('a[href="/tools/invoice-generator"]')
+		).toBeVisible()
+	})
 
-  test('should link to the contract generator', async ({ page }) => {
-    await expect(page.locator('a[href="/tools/contract-generator"]')).toBeVisible()
-  })
+	test('should link to the contract generator', async ({ page }) => {
+		await expect(
+			page.locator('a[href="/tools/contract-generator"]')
+		).toBeVisible()
+	})
 })
 
 test.describe('Paystub Calculator', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/paystub-calculator')
-    await page.waitForLoadState('networkidle')
-  })
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/tools/paystub-calculator')
+		await page.waitForLoadState('networkidle')
+	})
 
-  test('should display paystub page heading', async ({ page }) => {
-    const heading = page.locator('h1, h2').filter({ hasText: /paystub/i }).first()
-    await expect(heading).toBeVisible()
-  })
+	test('should display paystub page heading', async ({ page }) => {
+		const heading = page
+			.locator('h1, h2')
+			.filter({ hasText: /paystub/i })
+			.first()
+		await expect(heading).toBeVisible()
+	})
 
-  test('should display at least one input field', async ({ page }) => {
-    const inputs = page.locator('input, textarea')
-    expect(await inputs.count()).toBeGreaterThan(0)
-  })
+	test('should display at least one input field', async ({ page }) => {
+		const inputs = page.locator('input, textarea')
+		expect(await inputs.count()).toBeGreaterThan(0)
+	})
 
-  test('tax year dropdown offers only 2025 (no 2023/2024)', async ({ page }) => {
-    await page.locator('#taxYear').click()
-    const options = page.locator('[role="option"]')
-    await expect(options.filter({ hasText: '2025' })).toHaveCount(1)
-    await expect(options.filter({ hasText: '2024' })).toHaveCount(0)
-    await expect(options.filter({ hasText: '2023' })).toHaveCount(0)
-  })
+	test('tax year dropdown offers only 2025 (no 2023/2024)', async ({
+		page
+	}) => {
+		await page.locator('#taxYear').click()
+		const options = page.locator('[role="option"]')
+		await expect(options.filter({ hasText: '2025' })).toHaveCount(1)
+		await expect(options.filter({ hasText: '2024' })).toHaveCount(0)
+		await expect(options.filter({ hasText: '2023' })).toHaveCount(0)
+	})
+})
+
+test.describe('Paystub Calculator URL restore (PAYSTUB-10 intersect)', () => {
+	test('?state=AL (unsupported) does NOT select Alabama', async ({ page }) => {
+		await page.goto('/tools/paystub-calculator?state=AL')
+		await page.waitForLoadState('networkidle')
+		// The state trigger keeps its placeholder; an unsupported code is dropped.
+		const stateTrigger = page.locator('#state')
+		await expect(stateTrigger).not.toContainText(/alabama/i)
+		await expect(stateTrigger).toContainText(/select state/i)
+	})
+
+	test('?state=ca (supported, lowercase) selects California', async ({
+		page
+	}) => {
+		await page.goto('/tools/paystub-calculator?state=ca')
+		await page.waitForLoadState('networkidle')
+		await expect(page.locator('#state')).toContainText(/california/i)
+	})
+
+	test('?state=TX (no-income-tax) selects Texas', async ({ page }) => {
+		await page.goto('/tools/paystub-calculator?state=TX')
+		await page.waitForLoadState('networkidle')
+		await expect(page.locator('#state')).toContainText(/texas/i)
+	})
+
+	test('?year=2024 (stale) clamps to 2025, does not block the form', async ({
+		page
+	}) => {
+		await page.goto('/tools/paystub-calculator?year=2024')
+		await page.waitForLoadState('networkidle')
+		// A stale year is clamped to the supported default; the trigger shows 2025.
+		await expect(page.locator('#taxYear')).toContainText('2025')
+		await expect(page.locator('#taxYear')).not.toContainText('2024')
+	})
 })
 
 test.describe('Invoice Generator', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/invoice-generator')
-    await page.waitForLoadState('networkidle')
-  })
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/tools/invoice-generator')
+		await page.waitForLoadState('networkidle')
+	})
 
-  test('should display invoice page heading', async ({ page }) => {
-    const heading = page.locator('h1, h2').filter({ hasText: /invoice/i }).first()
-    await expect(heading).toBeVisible()
-  })
+	test('should display invoice page heading', async ({ page }) => {
+		const heading = page
+			.locator('h1, h2')
+			.filter({ hasText: /invoice/i })
+			.first()
+		await expect(heading).toBeVisible()
+	})
 
-  test('should display at least one input field or button', async ({ page }) => {
-    const interactive = page.locator('input, textarea, button[type="button"], button[type="submit"]')
-    expect(await interactive.count()).toBeGreaterThan(0)
-  })
+	test('should display at least one input field or button', async ({
+		page
+	}) => {
+		const interactive = page.locator(
+			'input, textarea, button[type="button"], button[type="submit"]'
+		)
+		expect(await interactive.count()).toBeGreaterThan(0)
+	})
 })
 
 test.describe('Contract Generator', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/tools/contract-generator')
-    await page.waitForLoadState('networkidle')
-  })
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/tools/contract-generator')
+		await page.waitForLoadState('networkidle')
+	})
 
-  test('should display contract page heading', async ({ page }) => {
-    const heading = page.locator('h1, h2').filter({ hasText: /contract/i }).first()
-    await expect(heading).toBeVisible()
-  })
+	test('should display contract page heading', async ({ page }) => {
+		const heading = page
+			.locator('h1, h2')
+			.filter({ hasText: /contract/i })
+			.first()
+		await expect(heading).toBeVisible()
+	})
 
-  test('should display at least one input field or button', async ({ page }) => {
-    const interactive = page.locator('input, textarea, button[type="button"], button[type="submit"]')
-    expect(await interactive.count()).toBeGreaterThan(0)
-  })
+	test('should display at least one input field or button', async ({
+		page
+	}) => {
+		const interactive = page.locator(
+			'input, textarea, button[type="button"], button[type="submit"]'
+		)
+		expect(await interactive.count()).toBeGreaterThan(0)
+	})
 })

--- a/e2e/tools.spec.ts
+++ b/e2e/tools.spec.ts
@@ -56,6 +56,14 @@ test.describe('Paystub Calculator', () => {
     const inputs = page.locator('input, textarea')
     expect(await inputs.count()).toBeGreaterThan(0)
   })
+
+  test('tax year dropdown offers only 2025 (no 2023/2024)', async ({ page }) => {
+    await page.locator('#taxYear').click()
+    const options = page.locator('[role="option"]')
+    await expect(options.filter({ hasText: '2025' })).toHaveCount(1)
+    await expect(options.filter({ hasText: '2024' })).toHaveCount(0)
+    await expect(options.filter({ hasText: '2023' })).toHaveCount(0)
+  })
 })
 
 test.describe('Invoice Generator', () => {

--- a/src/app/(public)/tools/paystub-calculator/PaystubCalculatorClient.tsx
+++ b/src/app/(public)/tools/paystub-calculator/PaystubCalculatorClient.tsx
@@ -165,7 +165,7 @@ export default function PaystubCalculatorClient() {
 	return (
 		<ToolPageLayout
 			title="Paystub Calculator"
-			description="Generate accurate payroll breakdowns with federal and state tax calculations for any pay period"
+			description="Estimate your 2025 federal and state income tax breakdown by pay period. State income tax is supported for CA, NY, IL, PA, and MA. This is an estimate and does not account for W-4 allowances, deductions, or credits."
 			columns="single"
 			formSlot={formSlot}
 			resultSlot={resultSlot}

--- a/src/app/(public)/tools/paystub-calculator/page.tsx
+++ b/src/app/(public)/tools/paystub-calculator/page.tsx
@@ -1,6 +1,6 @@
 /**
  * Paystub Calculator
- * Generate detailed payroll breakdowns with federal and state tax calculations
+ * Estimate 2025 payroll tax breakdowns with federal and state income tax
  */
 
 import type { Metadata } from 'next'
@@ -10,10 +10,11 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/tools/paystub-calculator' },
 	title: 'Paystub Calculator | Hudson Digital Solutions',
 	description:
-		'Generate detailed payroll breakdowns with federal and state tax calculations. Free paystub calculator for employers and employees.',
+		'Estimate 2025 payroll tax breakdowns with our free paystub calculator. Federal tax for all filers and state income tax for CA, NY, IL, PA, and MA.',
 	openGraph: {
 		title: 'Paystub Calculator',
-		description: 'Generate detailed payroll breakdowns with tax calculations.'
+		description:
+			'Estimate 2025 payroll tax breakdowns with our free paystub calculator.'
 	}
 }
 

--- a/src/components/paystub/PaystubForm.tsx
+++ b/src/components/paystub/PaystubForm.tsx
@@ -19,6 +19,7 @@ import {
 	getIncomeTaxStates,
 	getNoIncomeTaxStates
 } from '@/lib/paystub-calculator/states-utils'
+import { getSupportedTaxYears } from '@/lib/paystub-calculator/tax-data'
 import type { FormErrors } from '@/types/common'
 import type { FilingStatus, PayFrequency, PaystubData } from '@/types/paystub'
 
@@ -197,8 +198,11 @@ export function PaystubForm({
 								<SelectValue placeholder="Select year" />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="2024">2024</SelectItem>
-								<SelectItem value="2023">2023</SelectItem>
+								{getSupportedTaxYears().map(year => (
+									<SelectItem key={year} value={String(year)}>
+										{year}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 					</div>

--- a/src/components/paystub/PaystubForm.tsx
+++ b/src/components/paystub/PaystubForm.tsx
@@ -194,7 +194,13 @@ export function PaystubForm({
 								}))
 							}
 						>
-							<SelectTrigger id="taxYear">
+							<SelectTrigger
+								id="taxYear"
+								aria-invalid={!!formErrors.taxYear}
+								className={
+									formErrors.taxYear ? 'border-destructive border-2' : undefined
+								}
+							>
 								<SelectValue placeholder="Select year" />
 							</SelectTrigger>
 							<SelectContent>
@@ -205,6 +211,11 @@ export function PaystubForm({
 								))}
 							</SelectContent>
 						</Select>
+						{formErrors.taxYear && (
+							<p className="text-destructive text-xs" role="alert">
+								{formErrors.taxYear}
+							</p>
+						)}
 					</div>
 
 					<div className="space-y-tight">

--- a/src/hooks/use-paystub-form.ts
+++ b/src/hooks/use-paystub-form.ts
@@ -10,7 +10,7 @@ const INITIAL_PAYSTUB: PaystubData = {
 	hourlyRate: 0,
 	hoursPerPeriod: 0,
 	filingStatus: 'single',
-	taxYear: 2024,
+	taxYear: 2025,
 	payPeriods: [],
 	totals: {
 		hours: 0,

--- a/src/hooks/use-paystub-generator.ts
+++ b/src/hooks/use-paystub-generator.ts
@@ -2,23 +2,15 @@
 
 import { useEffect, useRef } from 'react'
 import {
-	getIncomeTaxStates,
-	getNoIncomeTaxStates
-} from '@/lib/paystub-calculator/states-utils'
+	isSupportedStateCode,
+	isSupportedTaxYear
+} from '@/lib/paystub-calculator/supported-inputs'
 import { usePaystubCalculations } from './use-paystub-calculations'
 import { usePaystubForm } from './use-paystub-form'
 import { usePaystubPersistence } from './use-paystub-persistence'
 import { usePaystubUI } from './use-paystub-ui'
 import { usePaystubUrlState } from './use-paystub-url-state'
 import { usePaystubValidation } from './use-paystub-validation'
-
-// PAYSTUB-10: the full supported-state allow-list (income-tax + no-income-tax codes).
-// nuqs passes a shared ?state=AL through unchanged, so the URL-restore path must
-// intersect against this set; an unsupported code is dropped rather than applied,
-// so it can never reach calculateStateTax's defensive $0 and present a silent zero.
-const SUPPORTED_STATE_CODES = new Set(
-	[...getIncomeTaxStates(), ...getNoIncomeTaxStates()].map(state => state.value)
-)
 
 export function usePaystubGenerator() {
 	const formState = usePaystubForm()
@@ -79,16 +71,21 @@ export function usePaystubGenerator() {
 			hourlyRate: urlState.rate ?? prev.hourlyRate,
 			hoursPerPeriod: urlState.hours ?? prev.hoursPerPeriod,
 			filingStatus: urlState.status ?? prev.filingStatus,
-			taxYear: urlState.year ?? prev.taxYear
+			// Clamp a restored year to the supported set; a stale shared ?year=2024
+			// (HIGH/LOW asymmetry: nuqs passes it through unchanged) falls back to the
+			// form default rather than feeding an unbacked year into the calculation.
+			taxYear:
+				urlState.year != null && isSupportedTaxYear(urlState.year)
+					? urlState.year
+					: prev.taxYear
 		}))
 
 		if (urlState.state) {
-			const restoredStateCode = urlState.state.toUpperCase()
 			// Only restore a supported code; drop unsupported values (e.g. AL) so a
 			// stale shared URL never feeds an unsupported state into the calculation
 			// and never produces a defensive silent $0 (PAYSTUB-10).
-			if (SUPPORTED_STATE_CODES.has(restoredStateCode)) {
-				formState.setSelectedState(restoredStateCode)
+			if (isSupportedStateCode(urlState.state)) {
+				formState.setSelectedState(urlState.state.toUpperCase())
 			}
 		}
 

--- a/src/hooks/use-paystub-generator.ts
+++ b/src/hooks/use-paystub-generator.ts
@@ -1,12 +1,24 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import {
+	getIncomeTaxStates,
+	getNoIncomeTaxStates
+} from '@/lib/paystub-calculator/states-utils'
 import { usePaystubCalculations } from './use-paystub-calculations'
 import { usePaystubForm } from './use-paystub-form'
 import { usePaystubPersistence } from './use-paystub-persistence'
 import { usePaystubUI } from './use-paystub-ui'
 import { usePaystubUrlState } from './use-paystub-url-state'
 import { usePaystubValidation } from './use-paystub-validation'
+
+// PAYSTUB-10: the full supported-state allow-list (income-tax + no-income-tax codes).
+// nuqs passes a shared ?state=AL through unchanged, so the URL-restore path must
+// intersect against this set; an unsupported code is dropped rather than applied,
+// so it can never reach calculateStateTax's defensive $0 and present a silent zero.
+const SUPPORTED_STATE_CODES = new Set(
+	[...getIncomeTaxStates(), ...getNoIncomeTaxStates()].map(state => state.value)
+)
 
 export function usePaystubGenerator() {
 	const formState = usePaystubForm()
@@ -71,7 +83,13 @@ export function usePaystubGenerator() {
 		}))
 
 		if (urlState.state) {
-			formState.setSelectedState(urlState.state)
+			const restoredStateCode = urlState.state.toUpperCase()
+			// Only restore a supported code; drop unsupported values (e.g. AL) so a
+			// stale shared URL never feeds an unsupported state into the calculation
+			// and never produces a defensive silent $0 (PAYSTUB-10).
+			if (SUPPORTED_STATE_CODES.has(restoredStateCode)) {
+				formState.setSelectedState(restoredStateCode)
+			}
 		}
 
 		hasInitializedFromUrl.current = true

--- a/src/hooks/use-paystub-persistence.ts
+++ b/src/hooks/use-paystub-persistence.ts
@@ -6,6 +6,10 @@ import {
 	loadFormData,
 	saveFormData
 } from '@/lib/paystub-calculator/storage'
+import {
+	isSupportedStateCode,
+	isSupportedTaxYear
+} from '@/lib/paystub-calculator/supported-inputs'
 import type { FilingStatus, PaystubData } from '@/types/paystub'
 
 interface UsePaystubPersistenceProps {
@@ -55,12 +59,19 @@ export function usePaystubPersistence({
 			hoursPerPeriod: savedData.hoursPerPeriod || prev.hoursPerPeriod,
 			filingStatus:
 				(savedData.filingStatus as FilingStatus) || prev.filingStatus,
-			taxYear: savedData.taxYear || prev.taxYear
+			// Clamp a stale persisted year (e.g. a returning user with taxYear:2024)
+			// to a supported year rather than carrying it into the calculation, which
+			// would dead-end on an unbacked year (HIGH).
+			taxYear:
+				savedData.taxYear != null && isSupportedTaxYear(savedData.taxYear)
+					? savedData.taxYear
+					: prev.taxYear
 		}))
 
-		// Restore selected state if saved
-		if (savedData.state) {
-			setSelectedState(savedData.state)
+		// Restore selected state only when supported; a stale unsupported code is
+		// dropped so it never reaches calculateStateTax's defensive $0 twin (MEDIUM).
+		if (savedData.state && isSupportedStateCode(savedData.state)) {
+			setSelectedState(savedData.state.toUpperCase())
 		}
 
 		hasLoadedRef.current = true

--- a/src/hooks/use-paystub-validation.ts
+++ b/src/hooks/use-paystub-validation.ts
@@ -85,6 +85,12 @@ export function usePaystubValidation({
 			if (validationResult.errors.employeeName) {
 				combinedErrors.employeeName = validationResult.errors.employeeName
 			}
+			// Forward the tax-year error so an unbacked year (e.g. a stale shared URL
+			// that slipped past the restore clamp) surfaces at the Tax Year field
+			// rather than only in a generic toast (defense-in-depth).
+			if (validationResult.errors.taxYear) {
+				combinedErrors.taxYear = validationResult.errors.taxYear
+			}
 		}
 
 		setFormErrors(combinedErrors)

--- a/src/lib/paystub-calculator/state-tax-calculations.ts
+++ b/src/lib/paystub-calculator/state-tax-calculations.ts
@@ -10,7 +10,12 @@ export const calculateStateTax = (
 ) => {
 	const stateBrackets = getStateTaxBrackets(state, year)
 	if (!stateBrackets) {
-		return 0 // Unknown state -> assume no income tax
+		// Defensive fallback for input the UI can no longer produce: the state
+		// dropdown is derived from getSupportedIncomeTaxStateCodes, so a state without
+		// bracket data is unreachable through normal use. Returning 0 keeps a stale
+		// shared URL (?state=AL) from crashing the per-period useMemo calc. State-side
+		// stale-URL rejection lands in 11-04.
+		return 0
 	}
 
 	const brackets = stateBrackets[filingStatus].length

--- a/src/lib/paystub-calculator/state-tax-data.ts
+++ b/src/lib/paystub-calculator/state-tax-data.ts
@@ -1,125 +1,167 @@
 import type { TaxData } from '@/types/paystub'
 
-// Simplified state tax data by year. Add or adjust per annual releases.
+// Official 2025 state income-tax data by year. Add or adjust per annual releases.
+// Surtaxes (CA 1% Mental Health Services over $1M, MA 4% over $1,083,150) are
+// encoded as additional top brackets so calculateStateTax needs no new math path.
 type StateTaxBrackets = Record<string, TaxData['federalBrackets']>
 
+function flatBrackets(rate: number): TaxData['federalBrackets'] {
+	return {
+		single: [{ limit: Infinity, rate }],
+		marriedJoint: [{ limit: Infinity, rate }],
+		marriedSeparate: [{ limit: Infinity, rate }],
+		headOfHousehold: [{ limit: Infinity, rate }],
+		qualifyingSurvivingSpouse: [{ limit: Infinity, rate }]
+	}
+}
+
+// MA 2025: flat 5.0% on income up to 1083150, then 9.0% (5% + 4% surtax) over it.
+// Not flatBrackets (that emits a single Infinity band only).
+function massachusettsBrackets(): TaxData['federalBrackets'] {
+	const bands = [
+		{ limit: 1083150, rate: 0.05 },
+		{ limit: Infinity, rate: 0.09 }
+	]
+	return {
+		single: bands,
+		marriedJoint: bands,
+		marriedSeparate: bands,
+		headOfHousehold: bands,
+		qualifyingSurvivingSpouse: bands
+	}
+}
+
 const stateTaxDataByYear: Record<number, StateTaxBrackets> = {
-	2024: {
+	2025: {
+		// FTB 2025 Schedules X/Y/Z + 1% MHS surtax band over 1000000 (effective 13.3% top).
 		CA: {
+			// Schedule X (Single / MFS): 1000000 sits inside the 12.3% band (over 742953).
 			single: [
-				{ limit: 9325, rate: 0.01 },
-				{ limit: 22107, rate: 0.02 },
-				{ limit: 34892, rate: 0.04 },
-				{ limit: 48435, rate: 0.06 },
-				{ limit: 61214, rate: 0.08 },
-				{ limit: 312686, rate: 0.093 },
-				{ limit: 375221, rate: 0.103 },
-				{ limit: 625369, rate: 0.113 },
-				{ limit: Infinity, rate: 0.123 }
+				{ limit: 11079, rate: 0.01 },
+				{ limit: 26264, rate: 0.02 },
+				{ limit: 41452, rate: 0.04 },
+				{ limit: 57542, rate: 0.06 },
+				{ limit: 72724, rate: 0.08 },
+				{ limit: 371479, rate: 0.093 },
+				{ limit: 445771, rate: 0.103 },
+				{ limit: 742953, rate: 0.113 },
+				{ limit: 1000000, rate: 0.123 },
+				{ limit: Infinity, rate: 0.133 }
 			],
+			// Schedule Y (MFJ / QSS): 1000000 sits inside the 11.3% band (891542..1485906).
 			marriedJoint: [
-				{ limit: 18650, rate: 0.01 },
-				{ limit: 44214, rate: 0.02 },
-				{ limit: 69784, rate: 0.04 },
-				{ limit: 96870, rate: 0.06 },
-				{ limit: 122428, rate: 0.08 },
-				{ limit: 625372, rate: 0.093 },
-				{ limit: 750442, rate: 0.103 },
-				{ limit: 1250738, rate: 0.113 },
-				{ limit: Infinity, rate: 0.123 }
+				{ limit: 22158, rate: 0.01 },
+				{ limit: 52528, rate: 0.02 },
+				{ limit: 82904, rate: 0.04 },
+				{ limit: 115084, rate: 0.06 },
+				{ limit: 145448, rate: 0.08 },
+				{ limit: 742958, rate: 0.093 },
+				{ limit: 891542, rate: 0.103 },
+				{ limit: 1000000, rate: 0.113 },
+				{ limit: 1485906, rate: 0.123 },
+				{ limit: Infinity, rate: 0.133 }
 			],
+			// Schedule X (Single / MFS): 1000000 sits inside the 12.3% band (over 742953).
 			marriedSeparate: [
-				{ limit: 9325, rate: 0.01 },
-				{ limit: 22107, rate: 0.02 },
-				{ limit: 34892, rate: 0.04 },
-				{ limit: 48435, rate: 0.06 },
-				{ limit: 61214, rate: 0.08 },
-				{ limit: 312686, rate: 0.093 },
-				{ limit: 375221, rate: 0.103 },
-				{ limit: 625369, rate: 0.113 },
-				{ limit: Infinity, rate: 0.123 }
+				{ limit: 11079, rate: 0.01 },
+				{ limit: 26264, rate: 0.02 },
+				{ limit: 41452, rate: 0.04 },
+				{ limit: 57542, rate: 0.06 },
+				{ limit: 72724, rate: 0.08 },
+				{ limit: 371479, rate: 0.093 },
+				{ limit: 445771, rate: 0.103 },
+				{ limit: 742953, rate: 0.113 },
+				{ limit: 1000000, rate: 0.123 },
+				{ limit: Infinity, rate: 0.133 }
 			],
+			// Schedule Z (HoH): 1000000 sits inside the 11.3% band (606251..1010417).
 			headOfHousehold: [
-				{ limit: 18650, rate: 0.01 },
-				{ limit: 44214, rate: 0.02 },
-				{ limit: 69784, rate: 0.04 },
-				{ limit: 96870, rate: 0.06 },
-				{ limit: 122428, rate: 0.08 },
-				{ limit: 625372, rate: 0.093 },
-				{ limit: 750442, rate: 0.103 },
-				{ limit: 1250738, rate: 0.113 },
-				{ limit: Infinity, rate: 0.123 }
+				{ limit: 22173, rate: 0.01 },
+				{ limit: 52530, rate: 0.02 },
+				{ limit: 67716, rate: 0.04 },
+				{ limit: 83805, rate: 0.06 },
+				{ limit: 98990, rate: 0.08 },
+				{ limit: 505208, rate: 0.093 },
+				{ limit: 606251, rate: 0.103 },
+				{ limit: 1000000, rate: 0.113 },
+				{ limit: 1010417, rate: 0.123 },
+				{ limit: Infinity, rate: 0.133 }
 			],
+			// Schedule Y (MFJ / QSS): 1000000 sits inside the 11.3% band (891542..1485906).
 			qualifyingSurvivingSpouse: [
-				{ limit: 18650, rate: 0.01 },
-				{ limit: 44214, rate: 0.02 },
-				{ limit: 69784, rate: 0.04 },
-				{ limit: 96870, rate: 0.06 },
-				{ limit: 122428, rate: 0.08 },
-				{ limit: 625372, rate: 0.093 },
-				{ limit: 750442, rate: 0.103 },
-				{ limit: 1250738, rate: 0.113 },
-				{ limit: Infinity, rate: 0.123 }
+				{ limit: 22158, rate: 0.01 },
+				{ limit: 52528, rate: 0.02 },
+				{ limit: 82904, rate: 0.04 },
+				{ limit: 115084, rate: 0.06 },
+				{ limit: 145448, rate: 0.08 },
+				{ limit: 742958, rate: 0.093 },
+				{ limit: 891542, rate: 0.103 },
+				{ limit: 1000000, rate: 0.113 },
+				{ limit: 1485906, rate: 0.123 },
+				{ limit: Infinity, rate: 0.133 }
 			]
 		},
+		// DTF IT-201-I 2025 (unchanged from 2024); includes 9.65 / 10.3 / 10.9 high brackets.
 		NY: {
 			single: [
 				{ limit: 8500, rate: 0.04 },
 				{ limit: 11700, rate: 0.045 },
 				{ limit: 13900, rate: 0.0525 },
-				{ limit: 21400, rate: 0.059 },
-				{ limit: 80650, rate: 0.0621 },
-				{ limit: 215400, rate: 0.0649 },
+				{ limit: 80650, rate: 0.055 },
+				{ limit: 215400, rate: 0.06 },
 				{ limit: 1077550, rate: 0.0685 },
-				{ limit: Infinity, rate: 0.0882 }
+				{ limit: 5000000, rate: 0.0965 },
+				{ limit: 25000000, rate: 0.103 },
+				{ limit: Infinity, rate: 0.109 }
 			],
 			marriedJoint: [
 				{ limit: 17150, rate: 0.04 },
 				{ limit: 23600, rate: 0.045 },
-				{ limit: 27950, rate: 0.0525 },
-				{ limit: 43000, rate: 0.059 },
-				{ limit: 161550, rate: 0.0621 },
-				{ limit: 323200, rate: 0.0649 },
-				{ limit: 2155000, rate: 0.0685 },
-				{ limit: Infinity, rate: 0.0882 }
+				{ limit: 27900, rate: 0.0525 },
+				{ limit: 161550, rate: 0.055 },
+				{ limit: 323200, rate: 0.06 },
+				{ limit: 2155350, rate: 0.0685 },
+				{ limit: 5000000, rate: 0.0965 },
+				{ limit: 25000000, rate: 0.103 },
+				{ limit: Infinity, rate: 0.109 }
 			],
 			marriedSeparate: [
 				{ limit: 8500, rate: 0.04 },
 				{ limit: 11700, rate: 0.045 },
 				{ limit: 13900, rate: 0.0525 },
-				{ limit: 21400, rate: 0.059 },
-				{ limit: 80650, rate: 0.0621 },
-				{ limit: 215400, rate: 0.0649 },
+				{ limit: 80650, rate: 0.055 },
+				{ limit: 215400, rate: 0.06 },
 				{ limit: 1077550, rate: 0.0685 },
-				{ limit: Infinity, rate: 0.0882 }
+				{ limit: 5000000, rate: 0.0965 },
+				{ limit: 25000000, rate: 0.103 },
+				{ limit: Infinity, rate: 0.109 }
 			],
 			headOfHousehold: [
 				{ limit: 12800, rate: 0.04 },
 				{ limit: 17650, rate: 0.045 },
-				{ limit: 20800, rate: 0.0525 },
-				{ limit: 32200, rate: 0.059 },
-				{ limit: 107650, rate: 0.0621 },
-				{ limit: 269300, rate: 0.0649 },
+				{ limit: 20900, rate: 0.0525 },
+				{ limit: 107650, rate: 0.055 },
+				{ limit: 269300, rate: 0.06 },
 				{ limit: 1616450, rate: 0.0685 },
-				{ limit: Infinity, rate: 0.0882 }
+				{ limit: 5000000, rate: 0.0965 },
+				{ limit: 25000000, rate: 0.103 },
+				{ limit: Infinity, rate: 0.109 }
 			],
 			qualifyingSurvivingSpouse: [
 				{ limit: 17150, rate: 0.04 },
 				{ limit: 23600, rate: 0.045 },
-				{ limit: 27950, rate: 0.0525 },
-				{ limit: 43000, rate: 0.059 },
-				{ limit: 161550, rate: 0.0621 },
-				{ limit: 323200, rate: 0.0649 },
-				{ limit: 2155000, rate: 0.0685 },
-				{ limit: Infinity, rate: 0.0882 }
+				{ limit: 27900, rate: 0.0525 },
+				{ limit: 161550, rate: 0.055 },
+				{ limit: 323200, rate: 0.06 },
+				{ limit: 2155350, rate: 0.0685 },
+				{ limit: 5000000, rate: 0.0965 },
+				{ limit: 25000000, rate: 0.103 },
+				{ limit: Infinity, rate: 0.109 }
 			]
 		},
 		IL: flatBrackets(0.0495),
 		PA: flatBrackets(0.0307),
-		MA: flatBrackets(0.0535),
-		TX: flatBrackets(0),
-		FL: flatBrackets(0),
-		WA: flatBrackets(0)
+		MA: massachusettsBrackets()
 	}
 }
 
@@ -135,12 +177,16 @@ export function getStateTaxBrackets(
 	return yearTable?.[normalizedState]
 }
 
-function flatBrackets(rate: number): TaxData['federalBrackets'] {
-	return {
-		single: [{ limit: Infinity, rate }],
-		marriedJoint: [{ limit: Infinity, rate }],
-		marriedSeparate: [{ limit: Infinity, rate }],
-		headOfHousehold: [{ limit: Infinity, rate }],
-		qualifyingSurvivingSpouse: [{ limit: Infinity, rate }]
+// Single source of truth for the selectable income-tax states: the union of every
+// state code present across all year tables. After the 2025 re-key + TX/FL/WA removal
+// this returns CA, NY, IL, PA, MA. 11-03 wires the dropdown to this so the UI can
+// never offer a state without bracket data.
+export function getSupportedIncomeTaxStateCodes(): string[] {
+	const codes = new Set<string>()
+	for (const yearTable of Object.values(stateTaxDataByYear)) {
+		for (const code of Object.keys(yearTable)) {
+			codes.add(code)
+		}
 	}
+	return [...codes]
 }

--- a/src/lib/paystub-calculator/states-utils.ts
+++ b/src/lib/paystub-calculator/states-utils.ts
@@ -1,13 +1,19 @@
 // Native states utilities - logic only, no data bloat
 
 import statesData from '@/data/states.json'
+import { getSupportedIncomeTaxStateCodes } from './state-tax-data'
 
 const NO_INCOME_TAX_CODES = ['AK', 'FL', 'NV', 'SD', 'TN', 'TX', 'WA', 'WY']
 const NO_INCOME_TAX_STATES_CACHE = statesData.states.filter(state =>
 	NO_INCOME_TAX_CODES.includes(state.value)
 )
-const INCOME_TAX_STATES_CACHE = statesData.states.filter(
-	state => !NO_INCOME_TAX_CODES.includes(state.value)
+// Single source of truth: the selectable income-tax states are exactly the codes
+// that have bracket data (getSupportedIncomeTaxStateCodes), mapped to states.json
+// labels. Deriving here (instead of "all states minus the no-tax codes") keeps the
+// dropdown in lockstep with the data so it can never offer a state with no brackets.
+const SUPPORTED_INCOME_TAX_CODES = new Set(getSupportedIncomeTaxStateCodes())
+const INCOME_TAX_STATES_CACHE = statesData.states.filter(state =>
+	SUPPORTED_INCOME_TAX_CODES.has(state.value)
 )
 
 /**

--- a/src/lib/paystub-calculator/supported-inputs.ts
+++ b/src/lib/paystub-calculator/supported-inputs.ts
@@ -1,0 +1,22 @@
+import { getIncomeTaxStates, getNoIncomeTaxStates } from './states-utils'
+import { getSupportedTaxYears } from './tax-data'
+
+// PAYSTUB-10: the full supported-state allow-list (income-tax + no-income-tax codes).
+// nuqs passes a shared ?state=AL through unchanged, so the URL-restore path must
+// intersect against this set; an unsupported code is dropped rather than applied,
+// so it can never reach calculateStateTax's defensive $0 and present a silent zero.
+// Single source of truth shared by both restore paths (URL + localStorage).
+export const SUPPORTED_STATE_CODES: Set<string> = new Set(
+	[...getIncomeTaxStates(), ...getNoIncomeTaxStates()].map(state => state.value)
+)
+
+// Case-insensitive membership check; restore paths pass raw query/storage strings.
+export function isSupportedStateCode(code: string): boolean {
+	return SUPPORTED_STATE_CODES.has(code.toUpperCase())
+}
+
+// Year is "supported" only when it has backing tax data (getSupportedTaxYears).
+// A stale ?year=2024 or localStorage taxYear:2024 fails this and is clamped.
+export function isSupportedTaxYear(year: number): boolean {
+	return getSupportedTaxYears().includes(year)
+}

--- a/src/lib/paystub-calculator/tax-data.ts
+++ b/src/lib/paystub-calculator/tax-data.ts
@@ -1,9 +1,11 @@
 import type { TaxData } from '@/types/paystub'
 
 // Versioned federal tax data by tax year. Add new entries per IRS releases.
+// Official 2025 federal brackets per IRS Rev. Proc. 2024-40 (Tables 1-4);
+// Social Security wage base 176100 per SSA 2025 COLA.
 const taxDataByYear: Record<number, TaxData> = {
-	2024: {
-		ssWageBase: 168600,
+	2025: {
+		ssWageBase: 176100,
 		ssRate: 0.062,
 		medicareRate: 0.0145,
 		additionalMedicareRate: 0.009,
@@ -16,73 +18,73 @@ const taxDataByYear: Record<number, TaxData> = {
 		},
 		federalBrackets: {
 			single: [
-				{ limit: 11000, rate: 0.1 },
-				{ limit: 44725, rate: 0.12 },
-				{ limit: 95375, rate: 0.22 },
-				{ limit: 182100, rate: 0.24 },
-				{ limit: 231250, rate: 0.32 },
-				{ limit: 578125, rate: 0.35 },
+				{ limit: 11925, rate: 0.1 },
+				{ limit: 48475, rate: 0.12 },
+				{ limit: 103350, rate: 0.22 },
+				{ limit: 197300, rate: 0.24 },
+				{ limit: 250525, rate: 0.32 },
+				{ limit: 626350, rate: 0.35 },
 				{ limit: Infinity, rate: 0.37 }
 			],
 			marriedJoint: [
-				{ limit: 22000, rate: 0.1 },
-				{ limit: 89450, rate: 0.12 },
-				{ limit: 190750, rate: 0.22 },
-				{ limit: 364200, rate: 0.24 },
-				{ limit: 462500, rate: 0.32 },
-				{ limit: 693750, rate: 0.35 },
+				{ limit: 23850, rate: 0.1 },
+				{ limit: 96950, rate: 0.12 },
+				{ limit: 206700, rate: 0.22 },
+				{ limit: 394600, rate: 0.24 },
+				{ limit: 501050, rate: 0.32 },
+				{ limit: 751600, rate: 0.35 },
 				{ limit: Infinity, rate: 0.37 }
 			],
 			marriedSeparate: [
-				{ limit: 11000, rate: 0.1 },
-				{ limit: 44725, rate: 0.12 },
-				{ limit: 95375, rate: 0.22 },
-				{ limit: 182100, rate: 0.24 },
-				{ limit: 231250, rate: 0.32 },
-				{ limit: 346875, rate: 0.35 },
+				{ limit: 11925, rate: 0.1 },
+				{ limit: 48475, rate: 0.12 },
+				{ limit: 103350, rate: 0.22 },
+				{ limit: 197300, rate: 0.24 },
+				{ limit: 250525, rate: 0.32 },
+				{ limit: 375800, rate: 0.35 },
 				{ limit: Infinity, rate: 0.37 }
 			],
 			headOfHousehold: [
-				{ limit: 15700, rate: 0.1 },
-				{ limit: 59850, rate: 0.12 },
-				{ limit: 95350, rate: 0.22 },
-				{ limit: 182100, rate: 0.24 },
-				{ limit: 231250, rate: 0.32 },
-				{ limit: 578100, rate: 0.35 },
+				{ limit: 17000, rate: 0.1 },
+				{ limit: 64850, rate: 0.12 },
+				{ limit: 103350, rate: 0.22 },
+				{ limit: 197300, rate: 0.24 },
+				{ limit: 250500, rate: 0.32 },
+				{ limit: 626350, rate: 0.35 },
 				{ limit: Infinity, rate: 0.37 }
 			],
 			qualifyingSurvivingSpouse: [
-				{ limit: 22000, rate: 0.1 },
-				{ limit: 89450, rate: 0.12 },
-				{ limit: 190750, rate: 0.22 },
-				{ limit: 364200, rate: 0.24 },
-				{ limit: 462500, rate: 0.32 },
-				{ limit: 693750, rate: 0.35 },
+				{ limit: 23850, rate: 0.1 },
+				{ limit: 96950, rate: 0.12 },
+				{ limit: 206700, rate: 0.22 },
+				{ limit: 394600, rate: 0.24 },
+				{ limit: 501050, rate: 0.32 },
+				{ limit: 751600, rate: 0.35 },
 				{ limit: Infinity, rate: 0.37 }
 			]
 		}
 	}
 }
 
-// 2025 uses 2024 figures as placeholder until official tables update
-taxDataByYear[2025] = JSON.parse(JSON.stringify(taxDataByYear[2024])) as TaxData
-
 export function getTaxDataForYear(year?: number): TaxData {
 	const currentYear = new Date().getFullYear()
 	const targetYear = year ?? currentYear
 	const availableYears = Object.keys(taxDataByYear).map(Number)
 
-	const defaultData = taxDataByYear[2024]
+	const defaultData = taxDataByYear[2025]
 
 	if (!defaultData) {
-		throw new Error('Missing baseline tax data for 2024')
+		throw new Error('Missing baseline tax data for 2025')
 	}
 
 	if (availableYears.length === 0) {
-		// Fallback to 2024 if no data is available (shouldn't happen in practice)
+		// Fallback to baseline if no data is available (shouldn't happen in practice)
 		return defaultData
 	}
 
+	// Defense-in-depth: a target year without data resolves to the latest backed
+	// year. Unreachable from the UI once year-membership validation (11-03)
+	// rejects unbacked years; retained as a safety net for stale shared URLs.
 	const fallbackYear = Math.max(...availableYears)
 	const fallbackData = taxDataByYear[fallbackYear] ?? defaultData
 

--- a/src/lib/paystub-calculator/tax-data.ts
+++ b/src/lib/paystub-calculator/tax-data.ts
@@ -66,6 +66,15 @@ const taxDataByYear: Record<number, TaxData> = {
 	}
 }
 
+// Single source of truth for the selectable / valid tax-year set, derived from
+// the data table (not a parallel literal). Consumed by 11-03 validation and the
+// 11-04 form dropdown so the year surface can never drift from backed data.
+export function getSupportedTaxYears(): number[] {
+	return Object.keys(taxDataByYear)
+		.map(Number)
+		.sort((a, b) => b - a)
+}
+
 export function getTaxDataForYear(year?: number): TaxData {
 	const currentYear = new Date().getFullYear()
 	const targetYear = year ?? currentYear

--- a/src/lib/paystub-calculator/validation.ts
+++ b/src/lib/paystub-calculator/validation.ts
@@ -1,4 +1,5 @@
 import type { PaystubCalculationParams } from './calculate-paystub-totals'
+import { getSupportedTaxYears } from './tax-data'
 
 export interface ValidationResult {
 	isValid: boolean
@@ -42,10 +43,13 @@ export const validatePaystubInputs = (
 			'Overtime rate should be higher than regular hourly rate'
 	}
 
-	// Validate tax year
-	const currentYear = new Date().getFullYear()
-	if (params.taxYear < 2020 || params.taxYear > currentYear + 5) {
-		errors.taxYear = `Tax year must be between 2020 and ${currentYear + 5}`
+	// Validate tax year as a membership check against the years that actually have
+	// data (getSupportedTaxYears), not a hardcoded range. A year without backing data
+	// (e.g. a stale shared URL carrying ?year=2024) is rejected here rather than
+	// silently falling through to getTaxDataForYear's defense-in-depth fallback.
+	const supportedYears = getSupportedTaxYears()
+	if (!supportedYears.includes(params.taxYear)) {
+		errors.taxYear = `Tax year must be one of: ${supportedYears.join(', ')}`
 	}
 
 	// Validate pay frequency

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -7,4 +7,5 @@ export interface FormErrors {
 	employeeName?: string
 	hourlyRate?: string
 	hoursPerPeriod?: string
+	taxYear?: string
 }

--- a/tests/pay-periods-generation.test.ts
+++ b/tests/pay-periods-generation.test.ts
@@ -19,7 +19,7 @@ describe('Pay period generation and overtime', () => {
 			hourlyRate: 25,
 			hoursPerPeriod: 80,
 			filingStatus: 'single' as const,
-			taxYear: 2024,
+			taxYear: 2025,
 			state: 'TX',
 			overtimeHours: 0,
 			overtimeRate: 37.5,

--- a/tests/paystub-federal-tax.test.ts
+++ b/tests/paystub-federal-tax.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import {
+	calculateFederalTax,
+	calculateSocialSecurity
+} from '@/lib/paystub-calculator/tax-calculations'
+import {
+	getSupportedTaxYears,
+	getTaxDataForYear
+} from '@/lib/paystub-calculator/tax-data'
+
+/**
+ * Federal Tax + FICA 2025 golden-value tests.
+ *
+ * Locks the Wave 1 (11-01) data re-key: official 2025 IRS federal brackets
+ * (Rev. Proc. 2024-40) and the 2025 Social Security wage base ($176,100).
+ */
+describe('PAYSTUB-02: supported tax years', () => {
+	it('getSupportedTaxYears() returns exactly [2025]', () => {
+		expect(getSupportedTaxYears()).toEqual([2025])
+	})
+})
+
+describe('PAYSTUB-05: federal 2025 brackets', () => {
+	it('computes the single golden case (gross 50000, ytd 0)', () => {
+		// 0.10*11925 + 0.12*(48475-11925) + 0.22*(50000-48475)
+		// = 1192.50 + 4386.00 + 335.50 = 5914.00
+		const tax = calculateFederalTax(50000, 'single', 0, 2025)
+		expect(tax).toBeCloseTo(5914, 2)
+	})
+
+	it('locks the 10% ceiling at 11925 (not the old 11000)', () => {
+		// At gross exactly 11925 (single, ytd 0) the whole slice is 10% -> 1192.50.
+		// Under the old 11000 ceiling the 925 over would have been taxed at 12%.
+		const tax = calculateFederalTax(11925, 'single', 0, 2025)
+		expect(tax).toBeCloseTo(1192.5, 2)
+	})
+})
+
+describe('PAYSTUB-05: SS wage base 2025', () => {
+	it('taxes the full 176100 base at 6.2%', () => {
+		// 176100 * 0.062 = 10918.20
+		const ss = calculateSocialSecurity(176100, 0, 2025)
+		expect(ss).toBeCloseTo(10918.2, 2)
+	})
+
+	it('caps contributions at the 176100 base (not the old 168600)', () => {
+		// ytd 170000 + gross 10000 crosses 176100: (176100 - 170000) * 0.062
+		// = 6100 * 0.062 = 378.20. Under the old 168600 base this would have been 0.
+		const ss = calculateSocialSecurity(10000, 170000, 2025)
+		expect(ss).toBeCloseTo(378.2, 2)
+	})
+})
+
+describe('getTaxDataForYear defensive fallback', () => {
+	it('resolves an unbacked year to the latest backed year (defense-in-depth)', () => {
+		// getTaxDataForYear keeps a Math.max(...availableYears) fallback so an
+		// unbacked year (e.g. a stale shared URL) resolves to 2025 rather than
+		// throwing. This path is UI-unreachable once validatePaystubInputs rejects
+		// unbacked years (Task 1); asserted here as defense-in-depth, not user-facing.
+		const fallback = getTaxDataForYear(2024)
+		const current = getTaxDataForYear(2025)
+		expect(fallback.federalBrackets.single[0]?.limit).toBe(
+			current.federalBrackets.single[0]?.limit
+		)
+	})
+})

--- a/tests/paystub-federal-tax.test.ts
+++ b/tests/paystub-federal-tax.test.ts
@@ -34,6 +34,49 @@ describe('PAYSTUB-05: federal 2025 brackets', () => {
 		const tax = calculateFederalTax(11925, 'single', 0, 2025)
 		expect(tax).toBeCloseTo(1192.5, 2)
 	})
+
+	it('locks the MFS top-bracket split at 375800 (copy-paste hazard vs single)', () => {
+		// MFS shares the first six limits with single but caps the 35% band at 375800
+		// (single caps at 626350). gross 400000 ytd 0 straddles the 35%/37% split:
+		// 0.10*11925 + 0.12*(48475-11925) + 0.22*(103350-48475)
+		//   + 0.24*(197300-103350) + 0.32*(250525-197300)
+		//   + 0.35*(375800-250525) + 0.37*(400000-375800)
+		// = 1192.50 + 4386.00 + 12072.50 + 22548.00 + 17032.00 + 43846.25 + 8954.00
+		// = 110031.25
+		const tax = calculateFederalTax(400000, 'marriedSeparate', 0, 2025)
+		expect(tax).toBeCloseTo(110031.25, 2)
+	})
+
+	it('locks the marriedJoint golden (gross 250000, ytd 0)', () => {
+		// 0.10*23850 + 0.12*(96950-23850) + 0.22*(206700-96950)
+		//   + 0.24*(250000-206700)
+		// = 2385.00 + 8772.00 + 24145.00 + 10392.00 = 45694.00
+		const tax = calculateFederalTax(250000, 'marriedJoint', 0, 2025)
+		expect(tax).toBeCloseTo(45694, 2)
+	})
+
+	it('locks the headOfHousehold golden crossing 64850/103350 (gross 120000)', () => {
+		// HoH has its own schedule (17000/64850/103350...), distinct from single.
+		// 0.10*17000 + 0.12*(64850-17000) + 0.22*(103350-64850)
+		//   + 0.24*(120000-103350)
+		// = 1700.00 + 5742.00 + 8470.00 + 3996.00 = 19908.00
+		const tax = calculateFederalTax(120000, 'headOfHousehold', 0, 2025)
+		expect(tax).toBeCloseTo(19908, 2)
+	})
+
+	it('locks the qualifyingSurvivingSpouse golden (QSS == MFJ schedule, gross 300000)', () => {
+		// QSS mirrors MFJ (23850/96950/206700...).
+		// 0.10*23850 + 0.12*(96950-23850) + 0.22*(206700-96950)
+		//   + 0.24*(300000-206700)
+		// = 2385.00 + 8772.00 + 24145.00 + 22392.00 = 57694.00
+		const tax = calculateFederalTax(
+			300000,
+			'qualifyingSurvivingSpouse',
+			0,
+			2025
+		)
+		expect(tax).toBeCloseTo(57694, 2)
+	})
 })
 
 describe('PAYSTUB-05: SS wage base 2025', () => {
@@ -52,15 +95,16 @@ describe('PAYSTUB-05: SS wage base 2025', () => {
 })
 
 describe('getTaxDataForYear defensive fallback', () => {
-	it('resolves an unbacked year to the latest backed year (defense-in-depth)', () => {
+	it('resolves an unbacked year to the official 2025 data (defense-in-depth)', () => {
 		// getTaxDataForYear keeps a Math.max(...availableYears) fallback so an
 		// unbacked year (e.g. a stale shared URL) resolves to 2025 rather than
 		// throwing. This path is UI-unreachable once validatePaystubInputs rejects
 		// unbacked years (Task 1); asserted here as defense-in-depth, not user-facing.
+		// Assert against the official 2025 VALUES (single 10% ceiling 11925, SS wage
+		// base 176100), not call-to-call equality, so the test proves the fallback
+		// lands on real 2025 data rather than merely "the same thing twice".
 		const fallback = getTaxDataForYear(2024)
-		const current = getTaxDataForYear(2025)
-		expect(fallback.federalBrackets.single[0]?.limit).toBe(
-			current.federalBrackets.single[0]?.limit
-		)
+		expect(fallback.federalBrackets.single[0]?.limit).toBe(11925)
+		expect(fallback.ssWageBase).toBe(176100)
 	})
 })

--- a/tests/paystub-persistence.test.ts
+++ b/tests/paystub-persistence.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test'
+import {
+	isSupportedStateCode,
+	isSupportedTaxYear,
+	SUPPORTED_STATE_CODES
+} from '@/lib/paystub-calculator/supported-inputs'
+
+/**
+ * Stale-restore regression tests (PR #332 review, HIGH).
+ *
+ * Both restore paths (URL via nuqs, localStorage via loadFormData) clamp a
+ * restored taxYear/state to the supported set before applying it to form state.
+ * Mocking the React hooks + localStorage is heavy, so per the plan we unit-test
+ * the shared predicates and the exact clamp expressions the hooks use. This proves
+ * a returning user whose localStorage carries `taxYear: 2024` and an unsupported
+ * state has the year clamped to 2025 and the unsupported state dropped.
+ */
+describe('supported-inputs predicates', () => {
+	describe('isSupportedTaxYear', () => {
+		it('accepts 2025 (the only backed year)', () => {
+			expect(isSupportedTaxYear(2025)).toBe(true)
+		})
+
+		it('rejects a stale 2024 (no backing data)', () => {
+			expect(isSupportedTaxYear(2024)).toBe(false)
+		})
+
+		it('rejects 2023', () => {
+			expect(isSupportedTaxYear(2023)).toBe(false)
+		})
+	})
+
+	describe('isSupportedStateCode', () => {
+		it('accepts a supported income-tax state (CA)', () => {
+			expect(isSupportedStateCode('CA')).toBe(true)
+		})
+
+		it('accepts a supported no-income-tax state (TX)', () => {
+			expect(isSupportedStateCode('TX')).toBe(true)
+		})
+
+		it('is case-insensitive (lowercase ca)', () => {
+			expect(isSupportedStateCode('ca')).toBe(true)
+		})
+
+		it('rejects an unsupported state code (AL)', () => {
+			expect(isSupportedStateCode('AL')).toBe(false)
+		})
+
+		it('SUPPORTED_STATE_CODES contains the income-tax + no-income-tax union', () => {
+			// CA/NY/IL/PA/MA (income tax) + the no-income-tax codes are all present.
+			for (const code of ['CA', 'NY', 'IL', 'PA', 'MA', 'TX', 'FL', 'WA']) {
+				expect(SUPPORTED_STATE_CODES.has(code)).toBe(true)
+			}
+			expect(SUPPORTED_STATE_CODES.has('AL')).toBe(false)
+		})
+	})
+})
+
+describe('stale-restore clamp (returning user with taxYear:2024 + unsupported state)', () => {
+	// Mirror of the seed a returning user would have in localStorage.
+	const savedData = { taxYear: 2024, state: 'AL' }
+	const prevTaxYear = 2025 // form default
+
+	it('clamps a stale taxYear:2024 to the supported default (2025)', () => {
+		// Exact clamp expression from use-paystub-persistence / use-paystub-generator.
+		const restoredYear =
+			savedData.taxYear != null && isSupportedTaxYear(savedData.taxYear)
+				? savedData.taxYear
+				: prevTaxYear
+		expect(restoredYear).toBe(2025)
+	})
+
+	it('drops the unsupported state (AL) so it never reaches the calc', () => {
+		const shouldRestoreState = !!(
+			savedData.state && isSupportedStateCode(savedData.state)
+		)
+		expect(shouldRestoreState).toBe(false)
+	})
+
+	it('restores a valid persisted year/state unchanged', () => {
+		const valid = { taxYear: 2025, state: 'ca' }
+		const restoredYear =
+			valid.taxYear != null && isSupportedTaxYear(valid.taxYear)
+				? valid.taxYear
+				: prevTaxYear
+		const restoredState =
+			valid.state && isSupportedStateCode(valid.state)
+				? valid.state.toUpperCase()
+				: null
+		expect(restoredYear).toBe(2025)
+		expect(restoredState).toBe('CA')
+	})
+})

--- a/tests/paystub-validation.test.ts
+++ b/tests/paystub-validation.test.ts
@@ -20,7 +20,7 @@ describe('calculatePaystubTotals validation', () => {
 			hourlyRate: 25,
 			hoursPerPeriod: 80,
 			filingStatus: 'single' as const,
-			taxYear: 2024,
+			taxYear: 2025,
 			state: 'TX',
 			payFrequency: 'biweekly' as const
 		}
@@ -68,5 +68,26 @@ describe('calculatePaystubTotals validation', () => {
 		expect(() => calculatePaystubTotals(invalidParams)).toThrow(
 			/Invalid paystub inputs/
 		)
+	})
+
+	it('rejects a tax year with no backing data', () => {
+		// PAYSTUB-03: a year not in getSupportedTaxYears() (e.g. a stale shared URL
+		// carrying 2024) must fail validation instead of silently falling back.
+		if (!validBase) {
+			return
+		}
+		const invalidParams = { ...validBase, taxYear: 2024 }
+		const validation = validatePaystubInputs(invalidParams)
+
+		expect(validation.isValid).toBe(false)
+		expect(validation.errors.taxYear).toBeDefined()
+	})
+
+	it('accepts the supported tax year 2025', () => {
+		// PAYSTUB-03: the only backed year passes the membership check.
+		if (!validBase) {
+			return
+		}
+		expect(validatePaystubInputs(validBase).isValid).toBe(true)
 	})
 })

--- a/tests/state-tax-calculations.test.ts
+++ b/tests/state-tax-calculations.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, it } from 'bun:test'
 import { calculateStateTax } from '@/lib/paystub-calculator/state-tax-calculations'
+import { getSupportedIncomeTaxStateCodes } from '@/lib/paystub-calculator/state-tax-data'
+import { getIncomeTaxStates } from '@/lib/paystub-calculator/states-utils'
 
 describe('State Tax Calculations', () => {
+	describe('PAYSTUB-01: dropdown <-> data parity', () => {
+		it('selectable income-tax states equal the states with bracket data', () => {
+			// Bidirectional parity: the dropdown list (getIncomeTaxStates) is derived
+			// from the bracket-data keys (getSupportedIncomeTaxStateCodes), so the two
+			// can never drift. Dedupe + sort both sides and compare.
+			const selectable = [
+				...new Set(getIncomeTaxStates().map(s => s.value))
+			].sort()
+			const withData = [...new Set(getSupportedIncomeTaxStateCodes())].sort()
+
+			expect(selectable).toEqual(withData)
+		})
+
+		it('the supported income-tax set is exactly CA, IL, MA, NY, PA', () => {
+			expect(getIncomeTaxStates().map(s => s.value).sort()).toEqual([
+				'CA',
+				'IL',
+				'MA',
+				'NY',
+				'PA'
+			])
+		})
+	})
+
 	describe('Illinois State Tax (4.95% flat)', () => {
 		it('should calculate IL state tax correctly', () => {
 			const grossPay = 5000
@@ -36,15 +62,15 @@ describe('State Tax Calculations', () => {
 		})
 	})
 
-	describe('Massachusetts State Tax (progressive)', () => {
+	describe('Massachusetts State Tax (flat 5.0%)', () => {
 		it('should calculate MA state tax for low income', () => {
 			const grossPay = 2000
 			const ytdGross = 10000
 
 			const tax = calculateStateTax(grossPay, ytdGross, 'MA', 'single')
 
-			// MA has progressive rates starting at 5.35%
-			expect(tax).toBeCloseTo(107, 2) // 2000 * 0.0535
+			// MA is a flat 5.0% below the 1083150 surtax threshold
+			expect(tax).toBeCloseTo(100, 2) // 2000 * 0.05
 		})
 
 		it('should calculate MA state tax for higher income', () => {
@@ -53,13 +79,39 @@ describe('State Tax Calculations', () => {
 
 			const tax = calculateStateTax(grossPay, ytdGross, 'MA', 'single')
 
-			// MA progressive: first bracket up to ~$1M at 5.35%
-			expect(tax).toBeCloseTo(267.5, 2) // 5000 * 0.0535
+			// Still flat 5.0%, well below the 1083150 surtax threshold
+			expect(tax).toBeCloseTo(250, 2) // 5000 * 0.05
 		})
 	})
 
-	describe('No State Income Tax states', () => {
-		it('should return 0 for Texas (no state income tax)', () => {
+	describe('Corrected 2025 surtax boundaries', () => {
+		it('applies the MA 4% surtax over 1083150 (effective 9.0%)', () => {
+			// cumulative 1000000 -> 1100000: 83150 at 5% (up to 1083150) + 16850 at 9%
+			// = 4157.50 + 1516.50 = 5674.00
+			const tax = calculateStateTax(100000, 1000000, 'MA', 'single')
+			expect(tax).toBeCloseTo(5674, 2)
+		})
+
+		it('applies the CA Mental Health Services surtax over 1000000 (13.3%)', () => {
+			// cumulative 1000000 -> 1050000: entire 50000 slice is over 1000000 at 13.3%
+			// = 50000 * 0.133 = 6650.00
+			const tax = calculateStateTax(50000, 1000000, 'CA', 'single')
+			expect(tax).toBeCloseTo(6650, 2)
+		})
+
+		it('hits the NY 10.9% top bracket over 25000000', () => {
+			// cumulative 25000000 -> 26000000: entire 1000000 slice is over 25000000
+			// at 10.9% = 1000000 * 0.109 = 109000.00
+			const tax = calculateStateTax(1000000, 25000000, 'NY', 'single')
+			expect(tax).toBeCloseTo(109000, 2)
+		})
+	})
+
+	describe('Defensive fallback for UI-unreachable input', () => {
+		it('returns 0 for Texas (TX is in NO_INCOME_TAX_CODES, not selectable here)', () => {
+			// Defensive fallback: TX has no bracket data, so calculateStateTax returns 0.
+			// The UI groups TX under "No State Income Tax", so this path is only reached
+			// by direct/stale input, not by a user selecting a taxed state.
 			const grossPay = 5000
 			const ytdGross = 25000
 
@@ -68,7 +120,9 @@ describe('State Tax Calculations', () => {
 			expect(tax).toBe(0)
 		})
 
-		it('should return 0 for Florida (no state income tax)', () => {
+		it('returns 0 for Florida (FL is in NO_INCOME_TAX_CODES, not selectable here)', () => {
+			// Defensive fallback: same as TX. Not user-facing "graceful" behavior, since
+			// FL is never offered in the income-tax dropdown group.
 			const grossPay = 6000
 			const ytdGross = 30000
 
@@ -78,8 +132,11 @@ describe('State Tax Calculations', () => {
 		})
 	})
 
-	describe('Error handling', () => {
-		it('should handle unknown states gracefully', () => {
+	describe('Defensive fallback for unknown state codes', () => {
+		it('returns 0 for an unknown state code (UI cannot produce this)', () => {
+			// Defensive fallback for input the UI can no longer produce: the dropdown is
+			// derived from getSupportedIncomeTaxStateCodes, so 'XX' is unreachable through
+			// normal use. Returning 0 keeps a stale shared URL from crashing the calc.
 			const grossPay = 5000
 			const ytdGross = 25000
 
@@ -108,8 +165,10 @@ describe('State Tax Calculations', () => {
 		})
 	})
 
-	describe('States with no income tax', () => {
-		it('returns zero for TX', () => {
+	describe('Defensive fallback in the no-income-tax group', () => {
+		it('returns 0 for TX (defensive, not user-facing graceful behavior)', () => {
+			// Defensive fallback: TX is in NO_INCOME_TAX_CODES and has no bracket data,
+			// so this exercises the UI-unreachable return-0 path, not a real $0 estimate.
 			const tax = calculateStateTax(4000, 10000, 'TX', 'single')
 			expect(tax).toBe(0)
 		})

--- a/tests/state-tax-calculations.test.ts
+++ b/tests/state-tax-calculations.test.ts
@@ -18,13 +18,11 @@ describe('State Tax Calculations', () => {
 		})
 
 		it('the supported income-tax set is exactly CA, IL, MA, NY, PA', () => {
-			expect(getIncomeTaxStates().map(s => s.value).sort()).toEqual([
-				'CA',
-				'IL',
-				'MA',
-				'NY',
-				'PA'
-			])
+			expect(
+				getIncomeTaxStates()
+					.map(s => s.value)
+					.sort()
+			).toEqual(['CA', 'IL', 'MA', 'NY', 'PA'])
 		})
 	})
 
@@ -146,22 +144,45 @@ describe('State Tax Calculations', () => {
 		})
 	})
 
-	describe('California State Tax (progressive)', () => {
-		it('calculates CA state tax for single filer', () => {
-			const tax = calculateStateTax(5000, 20000, 'CA', 'single')
-			expect(tax).toBeGreaterThan(0)
+	describe('California State Tax (progressive, per-status schedule)', () => {
+		it('uses the Schedule X (single) golden, not Schedule Z (gross 70000)', () => {
+			// Schedule X single: 11079/26264/41452/57542/72724 ...
+			// 0.01*11079 + 0.02*(26264-11079) + 0.04*(41452-26264)
+			//   + 0.06*(57542-41452) + 0.08*(70000-57542)
+			// = 110.79 + 303.70 + 607.52 + 965.40 + 996.64 = 2984.05
+			const tax = calculateStateTax(70000, 0, 'CA', 'single')
+			expect(tax).toBeCloseTo(2984.05, 2)
 		})
 
-		it('falls back to single brackets for headOfHousehold', () => {
-			const tax = calculateStateTax(5000, 20000, 'CA', 'headOfHousehold')
-			expect(tax).toBeGreaterThan(0)
+		it('uses the Schedule Z (HoH) golden, distinct from single (gross 70000)', () => {
+			// Schedule Z HoH: 22173/52530/67716/83805 ... distinguishes per-status from
+			// single (single at 70000 = 2984.05, HoH = 1573.35 -- not the same schedule).
+			// 0.01*22173 + 0.02*(52530-22173) + 0.04*(67716-52530)
+			//   + 0.06*(70000-67716)
+			// = 221.73 + 607.14 + 607.44 + 137.04 = 1573.35
+			const tax = calculateStateTax(70000, 0, 'CA', 'headOfHousehold')
+			expect(tax).toBeCloseTo(1573.35, 2)
 		})
 	})
 
-	describe('New York State Tax (progressive)', () => {
-		it('handles married separate using fallback brackets', () => {
-			const tax = calculateStateTax(3000, 10000, 'ny', 'marriedSeparate')
-			expect(tax).toBeGreaterThan(0)
+	describe('New York State Tax (progressive, per-status schedule)', () => {
+		it('uses the single schedule golden (gross 100000)', () => {
+			// Single: 8500/11700/13900/80650/215400 ...
+			// 0.04*8500 + 0.045*(11700-8500) + 0.0525*(13900-11700)
+			//   + 0.055*(80650-13900) + 0.06*(100000-80650)
+			// = 340.00 + 144.00 + 115.50 + 3671.25 + 1161.00 = 5431.75
+			const tax = calculateStateTax(100000, 0, 'ny', 'single')
+			expect(tax).toBeCloseTo(5431.75, 2)
+		})
+
+		it('uses the MFJ schedule golden, distinct from single (gross 100000)', () => {
+			// MFJ: 17150/23600/27900/161550 ... distinguishes per-status from single
+			// (single at 100000 = 5431.75, MFJ = 5167.50 -- wider low brackets).
+			// 0.04*17150 + 0.045*(23600-17150) + 0.0525*(27900-23600)
+			//   + 0.055*(100000-27900)
+			// = 686.00 + 290.25 + 225.75 + 3965.50 = 5167.50
+			const tax = calculateStateTax(100000, 0, 'ny', 'marriedJoint')
+			expect(tax).toBeCloseTo(5167.5, 2)
 		})
 	})
 

--- a/tests/z-paystub-calculator.test.ts
+++ b/tests/z-paystub-calculator.test.ts
@@ -26,7 +26,7 @@ describe('Paystub Calculator Hooks', () => {
 				hourlyRate: 40,
 				hoursPerPeriod: 80,
 				filingStatus: 'single',
-				taxYear: 2024,
+				taxYear: 2025,
 				payPeriods: [],
 				totals: {
 					hours: 0,
@@ -91,7 +91,7 @@ describe('Paystub Calculator Hooks', () => {
 				hourlyRate: 25,
 				hoursPerPeriod: 45, // Regular hours
 				filingStatus: 'single',
-				taxYear: 2024,
+				taxYear: 2025,
 				payPeriods: [],
 				totals: {
 					hours: 0,
@@ -138,7 +138,7 @@ describe('Paystub Calculator Hooks', () => {
 				hourlyRate: 0,
 				hoursPerPeriod: 0,
 				filingStatus: 'single',
-				taxYear: 2024,
+				taxYear: 2025,
 				payPeriods: [],
 				totals: {
 					hours: 0,
@@ -186,7 +186,7 @@ describe('Paystub Calculator Hooks', () => {
 				hourlyRate: 25,
 				hoursPerPeriod: 40,
 				filingStatus: 'single',
-				taxYear: 2024,
+				taxYear: 2025,
 				payPeriods: [],
 				totals: {
 					hours: 0,


### PR DESCRIPTION
## What

Makes the paystub calculator stop telling users a confident lie about take-home pay. It now computes the **official 2025 tax year** and only exposes inputs it can actually compute.

## Why

An audit found the calculator advertised "accurate ... state tax calculations for any pay period" while:
- The state dropdown offered all 42 income-tax states but only 5 had data, so ~37 states silently returned **$0 state tax** and an inflated net pay.
- The federal year dropdown offered a dead "2023" toggle that silently used other-year figures.
- Verifying against primary sources (IRS Rev. Proc. 2024-40, CA FTB, NY DTF, Mass.gov DOR, SSA) showed the federal brackets and CA/NY/MA were themselves **stale** (2023 values mislabeled, MA at a pre-2020 rate).

## Changes

- **Official 2025 data**: federal brackets (all 5 filing statuses), SS wage base $176,100, CA/NY/MA corrected. Full-fidelity high-income tiers implemented as top brackets: CA 1% MHS (>$1M), MA 4% surtax (>$1,083,150), NY 9.65/10.3/10.9%. IL (4.95%) and PA (3.07%) confirmed unchanged.
- **Single source of truth**: the selectable income-tax states (CA/NY/IL/PA/MA) and the valid year (2025) are now *derived from the data tables*, so the dropdowns can never drift from the data again.
- **No silent fallbacks**: year validation rejects any year without data; a stale shared `?state=` URL is intersected with supported codes so it can't reach the defensive `$0`.
- **Honest copy**: hero/metadata reframed from "accurate" to "estimate" (the engine taxes gross with no W-4/deductions/credits, so it is not true withholding per IRS Pub 15-T).
- **Tests**: 34 paystub tests lock the brackets, surtaxes, federal goldens, SS cap, dropdown/data parity, and year validation.

## Verification

`bun run lint` clean · `bun run typecheck` clean · `bun run build` succeeds · full paystub suite green. (Pre-existing, unrelated `homepage`/`navigation` RTL test-pollution failures are untouched and out of scope.)

[hudsor01]