### PR TITLE
fix(error-boundary): make Report Error actually report (real POST + honest toast)

### DIFF
--- a/src/app/api/error-report/route.ts
+++ b/src/app/api/error-report/route.ts
@@ -1,0 +1,50 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { withMutationGuards } from '@/lib/api/guards'
+import { reportError } from '@/lib/error-tracking'
+import { logger } from '@/lib/logger'
+import { errorReportSchema } from '@/lib/schemas/error-report'
+
+async function handleErrorReport(request: NextRequest) {
+	try {
+		const body = await request.json()
+		const parsed = errorReportSchema.safeParse(body)
+		if (!parsed.success) {
+			return new NextResponse(null, { status: 400 })
+		}
+		const r = parsed.data
+
+		// Always-on capture (console in dev, error_logs in prod, server-side).
+		// The logger sink runs redactSensitive on this metadata before it is
+		// persisted, so URLs / user-agents carrying tokens are masked.
+		logger.error('[ErrorReport] client error boundary report', {
+			url: r.url,
+			userAgent: r.userAgent,
+			platform: r.platform,
+			language: r.language,
+			timestamp: r.timestamp,
+			stack: r.stack
+		})
+
+		// Env-gated Sentry forward (no-op when SENTRY_DSN unset).
+		const errorObj = new Error(r.message)
+		if (r.stack) {
+			errorObj.stack = r.stack
+		}
+		reportError(errorObj, { source: 'error-boundary', url: r.url })
+
+		return new NextResponse(null, { status: 204 })
+	} catch (error) {
+		logger.warn('Invalid error report received', {
+			error: error instanceof Error ? error.message : String(error)
+		})
+		return new NextResponse(null, { status: 400 })
+	}
+}
+
+// The crashed-page ErrorBoundary cannot mint a CSRF token; the same-origin
+// check in withMutationGuards is the substitute defense for this public
+// telemetry POST (matches csp-reports / web-vitals).
+export const POST = withMutationGuards(handleErrorReport, {
+	rateLimit: 'api',
+	csrf: false
+})

--- a/src/components/utilities/ErrorBoundary.tsx
+++ b/src/components/utilities/ErrorBoundary.tsx
@@ -8,6 +8,7 @@ import {
 	useState
 } from 'react'
 import { ErrorBoundary as ReactErrorBoundary } from 'react-error-boundary'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { BUSINESS_INFO } from '@/lib/constants/business'
@@ -29,11 +30,12 @@ interface ErrorBoundaryProps {
 	resetKeys?: Array<string | number>
 }
 
-function DefaultErrorFallback({
+export function DefaultErrorFallback({
 	error,
 	resetErrorBoundary
 }: ErrorFallbackProps) {
 	const [copied, setCopied] = useState(false)
+	const [sending, setSending] = useState(false)
 	const errorObj = error instanceof Error ? error : new Error(String(error))
 
 	const copyErrorDetails = async () => {
@@ -61,35 +63,44 @@ function DefaultErrorFallback({
 		}
 	}
 
-	// Function to send error report to support
+	// Transmit the error report to the server. The toast reflects the real
+	// POST result - we never claim a report was filed unless res.ok.
 	const reportError = async () => {
-		if (!error) {
+		if (!error || sending) {
 			return
 		}
 
+		setSending(true)
+		const errorReport = {
+			message: errorObj.message,
+			stack: errorObj.stack,
+			url: window.location.href,
+			userAgent: navigator.userAgent,
+			timestamp: new Date().toISOString(),
+			platform: navigator.platform,
+			language: navigator.language
+		}
+
 		try {
-			const errorReport = {
-				message: errorObj.message,
-				stack: errorObj.stack,
-				url: window.location.href,
-				userAgent: navigator.userAgent,
-				timestamp: new Date().toISOString(),
-				platform: navigator.platform,
-				language: navigator.language
+			const res = await fetch('/api/error-report', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(errorReport)
+			})
+			if (res.ok) {
+				toast.success('Error report sent. Thanks for helping us fix this.')
+			} else {
+				toast.error(
+					'Could not send the report. Copy the details below and email us.'
+				)
 			}
-
-			// In a real app, you would send this to your backend
-			// await fetch('/api/error-report', {
-			//   method: 'POST',
-			//   body: JSON.stringify(errorReport)
-			// });
-
-			logger.warn('[ErrorBoundary] Error report prepared', errorReport)
-			alert(
-				'Error report has been prepared. Please contact support with the error details.'
-			)
 		} catch (err) {
 			logger.error('[ErrorBoundary] Failed to report error', err)
+			toast.error(
+				'Could not send the report. Copy the details below and email us.'
+			)
+		} finally {
+			setSending(false)
 		}
 	}
 
@@ -149,6 +160,7 @@ function DefaultErrorFallback({
 									</button>
 									<button
 										onClick={reportError}
+										disabled={sending}
 										className="flex items-center gap-tight text-xs link-primary py-1"
 									>
 										<AlertTriangle className="w-3 h-3" />

--- a/src/lib/schemas/error-report.ts
+++ b/src/lib/schemas/error-report.ts
@@ -1,0 +1,26 @@
+/**
+ * Error Report Validation Schema
+ *
+ * Zod schema for the client-originated error-boundary report POSTed to
+ * /api/error-report. The `.max()` length caps are the input-validation
+ * control (sanity bounds against oversized stacks / malformed bodies);
+ * the route rejects anything that fails this shape with a 400.
+ *
+ * Own-file schema by project convention: NOT added to the Drizzle table
+ * barrel (src/lib/schemas/schema.ts) — that barrel holds table definitions
+ * only.
+ */
+
+import { z } from 'zod'
+
+export const errorReportSchema = z.object({
+	message: z.string().min(1).max(2_000),
+	stack: z.string().max(10_000).optional(),
+	url: z.string().url().max(2_000),
+	userAgent: z.string().max(1_000),
+	timestamp: z.string().datetime(),
+	platform: z.string().max(200).optional(),
+	language: z.string().max(50).optional()
+})
+
+export type ErrorReport = z.infer<typeof errorReportSchema>

--- a/tests/unit/api-error-report.test.ts
+++ b/tests/unit/api-error-report.test.ts
@@ -1,0 +1,89 @@
+/**
+ * /api/error-report smoke tests.
+ *
+ * Confirms the route accepts a well-formed error-boundary report (204),
+ * captures it via logger.error, forwards it to Sentry via reportError, and
+ * rejects malformed bodies (400). The route is unauthenticated public
+ * telemetry — anyone can POST a report — so the only protection is Zod
+ * shape validation + mutation-guards (origin + rate-limit), which we mock
+ * through.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { NextRequest } from 'next/server'
+import { cleanupMocks, setupApiMocks } from '../test-utils'
+
+const reportErrorSpy = mock()
+
+function makeRequest(body: unknown): NextRequest {
+	return new NextRequest('http://localhost/api/error-report', {
+		method: 'POST',
+		body: JSON.stringify(body),
+		headers: { 'Content-Type': 'application/json' }
+	})
+}
+
+describe('POST /api/error-report', () => {
+	let mocks: ReturnType<typeof setupApiMocks>
+
+	beforeEach(() => {
+		mocks = setupApiMocks()
+		reportErrorSpy.mockClear()
+		mock.module('@/lib/error-tracking', () => ({
+			reportError: reportErrorSpy
+		}))
+	})
+
+	afterEach(() => {
+		cleanupMocks()
+	})
+
+	it('returns 204 for a well-formed report and captures it', async () => {
+		const { POST } = await import('@/app/api/error-report/route')
+		const res = await POST(
+			makeRequest({
+				message: 'Something broke',
+				stack: 'Error: Something broke\n    at foo (bar.ts:1:1)',
+				url: 'https://example.com/page',
+				userAgent: 'Mozilla/5.0',
+				timestamp: new Date().toISOString(),
+				platform: 'MacIntel',
+				language: 'en-US'
+			})
+		)
+		expect(res.status).toBe(204)
+		expect(mocks.mockLogger.error).toHaveBeenCalled()
+		expect(reportErrorSpy).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns 400 when the body is missing message', async () => {
+		const { POST } = await import('@/app/api/error-report/route')
+		const res = await POST(
+			makeRequest({
+				url: 'https://example.com/page',
+				userAgent: 'Mozilla/5.0',
+				timestamp: new Date().toISOString()
+			})
+		)
+		expect(res.status).toBe(400)
+	})
+
+	it('returns 400 when the url is not a valid URL', async () => {
+		const { POST } = await import('@/app/api/error-report/route')
+		const res = await POST(
+			makeRequest({
+				message: 'Something broke',
+				url: 'not-a-url',
+				userAgent: 'Mozilla/5.0',
+				timestamp: new Date().toISOString()
+			})
+		)
+		expect(res.status).toBe(400)
+	})
+
+	it('returns 400 when the body is a raw string', async () => {
+		const { POST } = await import('@/app/api/error-report/route')
+		const res = await POST(makeRequest('plain string'))
+		expect(res.status).toBe(400)
+	})
+})

--- a/tests/unit/error-boundary-report.test.tsx
+++ b/tests/unit/error-boundary-report.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * ErrorBoundary "Report Error" client behavior.
+ *
+ * The DefaultErrorFallback.reportError handler must transmit a real POST to
+ * /api/error-report and give honest Sonner feedback: toast.success only when
+ * the POST returns ok, toast.error on a non-ok response or a thrown fetch.
+ * It must never claim a report was filed unless res.ok, and the alert() that
+ * lied about it must be gone.
+ *
+ * We mock `sonner` (toast spies) and `@/lib/logger` BEFORE importing the
+ * component, stub `global.fetch` per case, click "Report Error", and flush
+ * the in-flight async fetch with waitFor before asserting.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanupMocks } from '../test-utils'
+
+const toastSuccess = mock()
+const toastError = mock()
+
+mock.module('sonner', () => ({
+	toast: { success: toastSuccess, error: toastError },
+	Toaster: () => null
+}))
+
+const { DefaultErrorFallback } = await import(
+	'@/components/utilities/ErrorBoundary'
+)
+
+// `@/lib/logger` is mock.module'd globally in tests/setup.ts and re-applied
+// in its beforeEach (a fresh mock instance per test). We must read the
+// CURRENT instance at assert time so we see the same spy the component's
+// live import binding resolves to.
+async function currentLoggerError(): Promise<ReturnType<typeof mock>> {
+	const { logger } = await import('@/lib/logger')
+	return logger.error as ReturnType<typeof mock>
+}
+
+function renderFallback() {
+	return render(
+		<DefaultErrorFallback
+			error={new Error('Boom')}
+			resetErrorBoundary={() => {}}
+		/>
+	)
+}
+
+describe('ErrorBoundary reportError', () => {
+	beforeEach(() => {
+		toastSuccess.mockClear()
+		toastError.mockClear()
+	})
+
+	afterEach(() => {
+		cleanupMocks()
+	})
+
+	it('shows a success toast and not an error toast when the POST is ok (Case A)', async () => {
+		global.fetch = mock().mockResolvedValue({
+			ok: true
+		}) as unknown as typeof fetch
+		renderFallback()
+
+		fireEvent.click(screen.getByText('Report Error'))
+
+		await waitFor(() => {
+			expect(toastSuccess).toHaveBeenCalledTimes(1)
+		})
+		expect(toastError).not.toHaveBeenCalled()
+	})
+
+	it('shows an error toast and no success toast when the POST is not ok (Case B)', async () => {
+		global.fetch = mock().mockResolvedValue({
+			ok: false
+		}) as unknown as typeof fetch
+		renderFallback()
+
+		fireEvent.click(screen.getByText('Report Error'))
+
+		await waitFor(() => {
+			expect(toastError).toHaveBeenCalledTimes(1)
+		})
+		expect(toastSuccess).not.toHaveBeenCalled()
+	})
+
+	it('shows an error toast and logs when the fetch rejects (Case C)', async () => {
+		global.fetch = mock().mockRejectedValue(
+			new Error('network')
+		) as unknown as typeof fetch
+		renderFallback()
+
+		fireEvent.click(screen.getByText('Report Error'))
+
+		await waitFor(() => {
+			expect(toastError).toHaveBeenCalledTimes(1)
+		})
+		expect(await currentLoggerError()).toHaveBeenCalled()
+		expect(toastSuccess).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## What

Makes the global ErrorBoundary "Report Error" button tell the truth. It previously built an error report, had its `fetch` commented out (no route existed), and then `alert()`'d "Error report has been prepared" — claiming a report was filed when nothing was sent. The boundary wraps the root layout, so this shipped in production, and it was the only `alert()` in the codebase.

## Changes

- **New `POST /api/error-report`** — Zod-validated body (`safeParse` -> 400, `.max()` length caps), logs server-side via `logger.error` (always-on, PII-redacted, persisted), and forwards to Sentry via the existing env-gated `reportError`. Returns 204, leaks no internals. Guarded with `withMutationGuards(..., { rateLimit: 'api', csrf: false })` — verbatim the `csp-reports`/`web-vitals` pattern; `csrf:false` is required because a crashed page cannot mint a CSRF token, and the same-origin check is the substitute defense.
- **ErrorBoundary rewired** — `reportError` now `await`s the real POST and shows a Sonner toast keyed on `res.ok` (success vs error); the failure path keeps "Copy Error Details" and never claims success. Added an in-flight `sending` guard. Deleted the `alert()` and the lying `logger.warn('...prepared')`. The client does not import Sentry/error-tracking (server route owns that).

## Tests

- `tests/unit/api-error-report.test.ts` — valid -> 204 + logger/​Sentry spies; missing message / bad url / raw-string body -> 400.
- `tests/unit/error-boundary-report.test.tsx` — toast.success on ok, toast.error on failure/throw.

## Verification

`bun run lint` clean - `bun run typecheck` clean - `bun run build` succeeds (`/api/error-report` in the route manifest) - new tests 7/0. Full suite has only the pre-existing, unrelated homepage/navigation RTL test-pollution failures (0 net-new). Goal-backward verified: zero `alert(` and zero "Error report prepared" remain in `src/`.

[hudsor01]