### PR TITLE
feat(admin): distinguish DB failure from empty data across all admin surfaces

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { getBlogPostForAdmin } from '@/lib/admin/blog-queries'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getAuthors, getTags } from '@/lib/blog'
@@ -45,17 +46,21 @@ async function EditLoader({ params }: EditBlogPostPageProps) {
 		notFound()
 	}
 	await connection()
-	const [row, authors, tags] = await Promise.all([
+	const [postResult, authors, tags] = await Promise.all([
 		getBlogPostForAdmin(id),
 		getAuthors(),
 		getTags()
 	])
-	if (!row) {
+	if (postResult.status === 'not-found') {
 		notFound()
 	}
+	if (postResult.status === 'error') {
+		return <AdminErrorState resource="blog post" />
+	}
+	const post = postResult.data
 	return (
 		<EditBlogForm
-			row={row}
+			row={post}
 			authorOptions={authors.map(a => ({ id: a.id, name: a.name }))}
 			tagOptions={tags.map(t => ({ id: t.id, name: t.name }))}
 		/>

--- a/src/app/(admin)/admin/blog/page.tsx
+++ b/src/app/(admin)/admin/blog/page.tsx
@@ -25,6 +25,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { PublishToggle } from '@/components/admin/PublishToggle'
 import { ResourceListPage } from '@/components/admin/ResourceListPage'
 import { SearchInput } from '@/components/admin/SearchInput'
@@ -74,10 +75,14 @@ async function BlogList({ searchParams }: AdminBlogPageProps) {
 	await connection()
 	const { q: rawQ, cursor } = await searchParams
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listBlogPostsForAdmin({
+	const result = await listBlogPostsForAdmin({
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="blog posts" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> =
 		q.length > 0 ? { q } : {}
 

--- a/src/app/(admin)/admin/dashboard/page.tsx
+++ b/src/app/(admin)/admin/dashboard/page.tsx
@@ -8,10 +8,13 @@
  * Suspense boundary.
  *
  * Per-widget error isolation lives in the query layer: every function in
- * dashboard-queries.ts wraps its DB call in try/catch and returns [] on
- * failure. That means one bad query renders the affected widget's empty
- * state instead of blanking the whole page, and Promise.all itself never
- * rejects.
+ * dashboard-queries.ts wraps its DB call in try/catch and RETURNS a
+ * discriminated AdminQueryResult on failure (the error variant) rather than
+ * throwing or returning a bare []. Each widget receives its own result and
+ * renders its own inline AdminErrorState card on the error variant, so one
+ * failed query shows an error in that widget alone while the other widgets
+ * and the page still render. Because the failure is returned (not thrown),
+ * Promise.all never rejects and one bad widget cannot blank the page.
  *
  * Composition:
  *   Row 1: VisitorsChart (full width)
@@ -76,13 +79,13 @@ async function DashboardWidgets() {
 	return (
 		<div className="space-y-6">
 			<h1 className="sr-only">Admin Dashboard</h1>
-			<VisitorsChart data={visitors} />
-			<WebVitalsCards rows={vitals} />
+			<VisitorsChart result={visitors} />
+			<WebVitalsCards result={vitals} />
 			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-				<TopPagesTable rows={topPages} />
+				<TopPagesTable result={topPages} />
 				<div className="space-y-6">
-					<TrafficSourcesPie data={sources} />
-					<RecentLeadsPanel leads={recentLeads} />
+					<TrafficSourcesPie result={sources} />
+					<RecentLeadsPanel result={recentLeads} />
 				</div>
 			</div>
 		</div>

--- a/src/app/(admin)/admin/emails/[id]/page.tsx
+++ b/src/app/(admin)/admin/emails/[id]/page.tsx
@@ -2,7 +2,10 @@
  * Admin Scheduled-Email detail page (server component).
  *
  * Phase 05 §5.4 per-row surface. Loads the row by id via the admin query
- * layer, 404s when missing, and renders four sections:
+ * layer and renders four sections. Phase 13 (ADMINERR-04): the loader 3-way
+ * switches on the `AdminDetailResult` -- `notFound()` ONLY on a genuinely
+ * missing row, an `<AdminErrorState>` on a caught DB error (never a misleading
+ * 404), and the row render on `'found'`. The four sections are:
  *   1. Email      - sequenceId, stepId, recipient name, variables jsonb
  *   2. Delivery   - status, sent-at, retries, error (when non-null)
  *   3. Actions    - retry (when allowed) + cancel (when pending)
@@ -23,6 +26,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
@@ -72,10 +76,14 @@ async function EmailDetailLoader({ params }: EmailDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const row = await getScheduledEmailById(id)
-	if (!row) {
+	const result = await getScheduledEmailById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
+	if (result.status === 'error') {
+		return <AdminErrorState resource="scheduled email" />
+	}
+	const row = result.data
 
 	const max = row.maxRetries ?? 3
 	const canRetry = row.retryCount < max

--- a/src/app/(admin)/admin/emails/page.tsx
+++ b/src/app/(admin)/admin/emails/page.tsx
@@ -3,12 +3,20 @@
  *
  * Phase 10 Wave 2: cursor-paginated + search-aware. The existing 4
  * queue-health stat cards stay UNFILTERED -- `getQueueCounts()` is called
- * WITHOUT arguments inside `Promise.all` so the cards always reflect the
- * full queue state regardless of the active `?status=` / `?q=` / `?cursor=`
- * params. The existing `<StatusFilterBar>` chip row stays byte-equal and
- * composes alongside the new `<SearchInput>` (client, nuqs) and shadcn
- * `<Pagination>` (server, cursor-driven `<Link>`s built via
- * `buildPaginationHref`).
+ * WITHOUT arguments inside `Promise.all` so the cards reflect the full queue
+ * state regardless of the active `?status=` / `?q=` / `?cursor=` params. The
+ * existing `<StatusFilterBar>` chip row composes alongside the
+ * `<SearchInput>` (client, nuqs) and shadcn `<Pagination>` (server,
+ * cursor-driven `<Link>`s built via `buildPaginationHref`).
+ *
+ * Phase 13 (ADMINERR-01 / ADMINERR-03): both reads now return INDEPENDENT
+ * `AdminQueryResult`s. On a `getQueueCounts` failure the page renders ONE
+ * grid-spanning `<AdminErrorState>` in place of the four cards (never four
+ * falsely-healthy "0" cards), and the chip row omits the per-status count
+ * badges; on a list failure it renders a separate `<AdminErrorState>` in the
+ * list region. Each result is narrowed on its own so a counts failure does
+ * not blank the list and a list failure does not blank the counts. Both
+ * failures are RETURNED variants, so the shared `Promise.all` never rejects.
  *
  * Param composition matrix (matches Plan 10-05 / 10-06 / 10-07):
  *  - `?status=` round-trips via `<StatusFilterBar>` chip submissions (single
@@ -32,6 +40,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { SearchInput } from '@/components/admin/SearchInput'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import {
@@ -83,8 +92,10 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 
 	// CRITICAL: getQueueCounts() is called with NO arguments. The 4 stat
 	// cards reflect the FULL queue regardless of the active status / q /
-	// cursor filters. Only the paginated list helper sees the filters.
-	const [counts, { rows, prevCursor, nextCursor }] = await Promise.all([
+	// cursor filters. Only the paginated list helper sees the filters. Both
+	// reads return INDEPENDENT AdminQueryResults; neither throws, so the
+	// Promise.all always resolves and each is narrowed on its own below.
+	const [counts, list] = await Promise.all([
 		getQueueCounts(),
 		listScheduledEmailsForAdmin({
 			status,
@@ -93,12 +104,15 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 		})
 	])
 
+	// Chip count badges only when the counts read succeeded. On a counts
+	// failure the chips render without per-status badges rather than reading
+	// off the error variant.
 	const filterOptions: StatusFilterOption[] = [
 		{ value: null, label: 'All' },
 		...EMAIL_STATUSES.map(s => ({
 			value: s,
 			label: s.charAt(0).toUpperCase() + s.slice(1),
-			count: counts[s]
+			...(counts.ok ? { count: counts.data[s] } : {})
 		}))
 	]
 
@@ -112,21 +126,25 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 
 	return (
 		<>
-			<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-				{EMAIL_STATUSES.map(s => (
-					<div
-						key={s}
-						className="rounded-xl border border-border bg-surface-raised p-4"
-					>
-						<div className="text-xs uppercase tracking-wider text-muted-foreground">
-							{s}
+			{counts.ok ? (
+				<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+					{EMAIL_STATUSES.map(s => (
+						<div
+							key={s}
+							className="rounded-xl border border-border bg-surface-raised p-4"
+						>
+							<div className="text-xs uppercase tracking-wider text-muted-foreground">
+								{s}
+							</div>
+							<div className="text-2xl font-semibold text-foreground mt-1">
+								{counts.data[s].toLocaleString('en-US')}
+							</div>
 						</div>
-						<div className="text-2xl font-semibold text-foreground mt-1">
-							{counts[s].toLocaleString('en-US')}
-						</div>
-					</div>
-				))}
-			</div>
+					))}
+				</div>
+			) : (
+				<AdminErrorState inline resource="queue health" />
+			)}
 
 			<StatusFilterBar
 				baseHref="/admin/emails"
@@ -136,7 +154,9 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 
 			<SearchInput placeholder="Search emails" />
 
-			{rows.length === 0 ? (
+			{!list.ok ? (
+				<AdminErrorState resource="scheduled emails" />
+			) : list.data.rows.length === 0 ? (
 				q ? (
 					<div className="rounded-xl border border-border bg-surface-raised p-8 text-center">
 						<p className="text-sm text-muted-foreground">
@@ -169,7 +189,7 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{rows.map(r => (
+							{list.data.rows.map(r => (
 								<TableRow key={r.id}>
 									<TableCell className="text-foreground">
 										<Link
@@ -203,7 +223,7 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 					<Pagination className="mt-4 justify-between">
 						<PaginationContent>
 							<PaginationItem>
-								{prevCursor === null ? (
+								{list.data.prevCursor === null ? (
 									<PaginationPrevious
 										aria-disabled="true"
 										className="pointer-events-none opacity-50"
@@ -212,14 +232,14 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 									<PaginationPrevious
 										href={buildPaginationHref(
 											'/admin/emails',
-											prevCursor,
+											list.data.prevCursor,
 											preservedForPagination
 										)}
 									/>
 								)}
 							</PaginationItem>
 							<PaginationItem>
-								{nextCursor === null ? (
+								{list.data.nextCursor === null ? (
 									<PaginationNext
 										aria-disabled="true"
 										className="pointer-events-none opacity-50"
@@ -228,7 +248,7 @@ async function EmailsList({ searchParams }: AdminEmailsPageProps) {
 									<PaginationNext
 										href={buildPaginationHref(
 											'/admin/emails',
-											nextCursor,
+											list.data.nextCursor,
 											preservedForPagination
 										)}
 									/>

--- a/src/app/(admin)/admin/leads/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/[id]/page.tsx
@@ -24,6 +24,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
@@ -65,11 +66,14 @@ async function LeadDetailLoader({ params }: AdminLeadDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const detail = await getLeadById(id)
-	if (!detail) {
+	const result = await getLeadById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
-	const { lead, attribution, notes } = detail
+	if (result.status === 'error') {
+		return <AdminErrorState resource="lead" />
+	}
+	const { lead, attribution, notes } = result.data
 
 	return (
 		<div className="space-y-6">

--- a/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
@@ -18,6 +18,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
@@ -92,10 +93,14 @@ async function CalculatorLeadDetail({
 		notFound()
 	}
 	await connection()
-	const row = await getCalculatorLeadById(id)
-	if (!row) {
+	const result = await getCalculatorLeadById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
+	if (result.status === 'error') {
+		return <AdminErrorState resource="calculator submission" />
+	}
+	const row = result.data
 
 	const leadEntries: Array<[string, React.ReactNode]> = []
 	if (row.name) {

--- a/src/app/(admin)/admin/leads/calculator/page.tsx
+++ b/src/app/(admin)/admin/leads/calculator/page.tsx
@@ -27,6 +27,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { SearchInput } from '@/components/admin/SearchInput'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import {
@@ -86,11 +87,15 @@ async function CalculatorLeadsList({
 		? (rawStatus as CalculatorLeadQuality)
 		: null
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listCalculatorLeadsForAdmin({
+	const result = await listCalculatorLeadsForAdmin({
 		quality,
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="calculator submissions" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> = {}
 	if (quality) {
 		preservedForPagination.status = quality

--- a/src/app/(admin)/admin/leads/page.tsx
+++ b/src/app/(admin)/admin/leads/page.tsx
@@ -32,6 +32,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { SearchInput } from '@/components/admin/SearchInput'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import {
@@ -84,11 +85,15 @@ async function LeadsList({ searchParams }: AdminLeadsPageProps) {
 		? (rawStatus as LeadStatus)
 		: null
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listLeadsForAdmin({
+	const result = await listLeadsForAdmin({
 		status,
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="leads" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> = {}
 	if (status) {
 		preservedForPagination.status = status

--- a/src/app/(admin)/admin/newsletter/[id]/page.tsx
+++ b/src/app/(admin)/admin/newsletter/[id]/page.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
@@ -74,10 +75,14 @@ async function SubscriberLoader({ params }: SubscriberDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const row = await getSubscriberById(id)
-	if (!row) {
+	const result = await getSubscriberById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
+	if (result.status === 'error') {
+		return <AdminErrorState resource="subscriber" />
+	}
+	const row = result.data
 	return (
 		<div className="space-y-8">
 			<div>

--- a/src/app/(admin)/admin/newsletter/page.tsx
+++ b/src/app/(admin)/admin/newsletter/page.tsx
@@ -28,6 +28,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { SearchInput } from '@/components/admin/SearchInput'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import {
@@ -83,11 +84,15 @@ async function NewsletterList({ searchParams }: AdminNewsletterPageProps) {
 		? (rawStatus as SubscriberStatus)
 		: null
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listSubscribersForAdmin({
+	const result = await listSubscribersForAdmin({
 		status,
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="subscribers" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> = {}
 	if (status) {
 		preservedForPagination.status = status

--- a/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getShowcaseById } from '@/lib/admin/showcase-queries'
 import { EditShowcaseForm } from './EditShowcaseForm'
@@ -42,11 +43,14 @@ async function EditLoader({ params }: EditShowcasePageProps) {
 		notFound()
 	}
 	await connection()
-	const row = await getShowcaseById(id)
-	if (!row) {
+	const result = await getShowcaseById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
-	return <EditShowcaseForm row={row} />
+	if (result.status === 'error') {
+		return <AdminErrorState resource="showcase entry" />
+	}
+	return <EditShowcaseForm row={result.data} />
 }
 
 export default function EditShowcasePage({ params }: EditShowcasePageProps) {

--- a/src/app/(admin)/admin/showcase/page.tsx
+++ b/src/app/(admin)/admin/showcase/page.tsx
@@ -21,6 +21,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { PublishToggle } from '@/components/admin/PublishToggle'
 import { ResourceListPage } from '@/components/admin/ResourceListPage'
 import { SearchInput } from '@/components/admin/SearchInput'
@@ -57,10 +58,14 @@ async function ShowcaseList({ searchParams }: AdminShowcasePageProps) {
 	await connection()
 	const { q: rawQ, cursor } = await searchParams
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listShowcasesForAdmin({
+	const result = await listShowcasesForAdmin({
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="showcase entries" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> =
 		q.length > 0 ? { q } : {}
 

--- a/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
@@ -16,6 +16,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getTestimonialById } from '@/lib/admin/testimonials-queries'
 import { EditTestimonialForm } from './EditTestimonialForm'
@@ -43,11 +44,14 @@ async function EditLoader({ params }: EditTestimonialPageProps) {
 		notFound()
 	}
 	await connection()
-	const row = await getTestimonialById(id)
-	if (!row) {
+	const result = await getTestimonialById(id)
+	if (result.status === 'not-found') {
 		notFound()
 	}
-	return <EditTestimonialForm row={row} />
+	if (result.status === 'error') {
+		return <AdminErrorState resource="testimonial" />
+	}
+	return <EditTestimonialForm row={result.data} />
 }
 
 export default function EditTestimonialPage({

--- a/src/app/(admin)/admin/testimonials/page.tsx
+++ b/src/app/(admin)/admin/testimonials/page.tsx
@@ -20,6 +20,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { PublishToggle } from '@/components/admin/PublishToggle'
 import { ResourceListPage } from '@/components/admin/ResourceListPage'
 import { SearchInput } from '@/components/admin/SearchInput'
@@ -62,10 +63,14 @@ async function TestimonialsList({ searchParams }: AdminTestimonialsPageProps) {
 	await connection()
 	const { q: rawQ, cursor } = await searchParams
 	const q = (rawQ ?? '').trim()
-	const { rows, prevCursor, nextCursor } = await listTestimonialsForAdmin({
+	const result = await listTestimonialsForAdmin({
 		q: q.length > 0 ? q : undefined,
 		cursor
 	})
+	if (!result.ok) {
+		return <AdminErrorState resource="testimonials" />
+	}
+	const { rows, prevCursor, nextCursor } = result.data
 	const preservedForPagination: Record<string, string> =
 		q.length > 0 ? { q } : {}
 

--- a/src/components/admin/AdminErrorState.tsx
+++ b/src/components/admin/AdminErrorState.tsx
@@ -1,0 +1,76 @@
+/**
+ * Shared admin error-state card (Phase 13, ADMINERR-01..04).
+ *
+ * The ONE error UI the admin surfaces render when a read query returns its
+ * failure variant (`AdminQueryResult` `ok: false` / `AdminDetailResult`
+ * `status: 'error'`). It is the visible counterpart to the existing empty-state
+ * cards: an empty state means "no data", this means "the read failed".
+ *
+ * Built on the already-vendored shadcn `Alert` primitive (`role="alert"`,
+ * `destructive` variant), so it announces to assistive tech automatically and
+ * matches the design system. Use across list pages, dashboard widgets, the
+ * `/admin/emails` queue cards, and detail pages for a consistent error UX.
+ *
+ * Security (threat T-13-01, info disclosure): this component NEVER accepts or
+ * renders a raw `Error` / exception object or `error.message`. Its only inputs
+ * are a `resource` label and an optional generic `message`. The caught
+ * exception lives in `logger.error` server-side only and must never cross into
+ * the rendered UI. The default copy is fixed, generic, and emoji / em-dash /
+ * en-dash free per CLAUDE.md.
+ *
+ * No `'use client'` here: the `Alert` it renders is the client boundary; this
+ * wrapper is a plain (server-compatible) component and is also safe to render
+ * from the two `'use client'` chart widgets.
+ */
+import { CircleAlert } from 'lucide-react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+
+interface AdminErrorStateProps {
+	/**
+	 * The resource that failed to load, e.g. "leads", "page analytics". Used in
+	 * the default title. Falls back to "this data" when absent so the sentence
+	 * reads cleanly.
+	 */
+	resource?: string
+	/**
+	 * Optional override for the body copy. Must be a fixed, generic string -
+	 * never a raw exception message. Defaults to the generic retry prompt.
+	 */
+	message?: string
+	/**
+	 * Compact variant for inside a widget card body: drops the outer card
+	 * chrome so the alert sits directly in the host card. When false / absent,
+	 * the alert is wrapped in the admin card chrome matching the empty-state
+	 * cards.
+	 */
+	inline?: boolean
+}
+
+const DEFAULT_BODY =
+	'Something went wrong loading this data. Refresh to try again.'
+
+export function AdminErrorState({
+	resource,
+	message,
+	inline
+}: AdminErrorStateProps) {
+	const title = `Could not load ${resource ?? 'this data'}`
+
+	const alert = (
+		<Alert variant="destructive">
+			<CircleAlert size={16} aria-hidden="true" />
+			<AlertTitle>{title}</AlertTitle>
+			<AlertDescription>{message ?? DEFAULT_BODY}</AlertDescription>
+		</Alert>
+	)
+
+	if (inline) {
+		return alert
+	}
+
+	return (
+		<div className="rounded-xl border border-border bg-surface-raised p-8">
+			{alert}
+		</div>
+	)
+}

--- a/src/components/admin/widgets/RecentLeadsPanel.tsx
+++ b/src/components/admin/widgets/RecentLeadsPanel.tsx
@@ -5,15 +5,19 @@
  * Uses U+00B7 MIDDLE DOT as the source/time separator (STATE.md decision),
  * never an em or en dash.
  */
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
+import type { AdminQueryResult } from '@/lib/admin/query-result'
 
 type RecentLeadsPanelProps = {
-	leads: Array<{
-		id: string
-		email: string
-		source: string | null
-		status: string | null
-		createdAt: Date
-	}>
+	result: AdminQueryResult<
+		Array<{
+			id: string
+			email: string
+			source: string | null
+			status: string | null
+			createdAt: Date
+		}>
+	>
 }
 
 const RELATIVE_FORMATTER = new Intl.RelativeTimeFormat(undefined, {
@@ -70,19 +74,21 @@ function statusClass(status: string | null): string {
 	return 'bg-muted text-muted-foreground'
 }
 
-export function RecentLeadsPanel({ leads }: RecentLeadsPanelProps) {
+export function RecentLeadsPanel({ result }: RecentLeadsPanelProps) {
 	return (
 		<div className="rounded-xl border border-border bg-surface-raised p-6">
 			<h2 className="text-sm font-semibold text-foreground mb-4">
 				Recent leads
 			</h2>
-			{leads.length === 0 ? (
+			{!result.ok ? (
+				<AdminErrorState inline resource="recent leads" />
+			) : result.data.length === 0 ? (
 				<p className="text-sm text-muted-foreground text-center py-8">
 					No leads yet.
 				</p>
 			) : (
 				<ul className="divide-y divide-border">
-					{leads.map(lead => (
+					{result.data.map(lead => (
 						<li
 							key={lead.id}
 							className="py-3 flex items-center justify-between gap-3"

--- a/src/components/admin/widgets/TopPagesTable.tsx
+++ b/src/components/admin/widgets/TopPagesTable.tsx
@@ -4,22 +4,28 @@
  * 30 days in a simple HTML table with tabular-aligned numeric columns.
  * Data comes from the dashboard page; no DB access happens here.
  */
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
+import type { AdminQueryResult } from '@/lib/admin/query-result'
 
 type TopPagesTableProps = {
-	rows: Array<{
-		pathname: string
-		pageviews: number
-		uniqueVisitors: number
-	}>
+	result: AdminQueryResult<
+		Array<{
+			pathname: string
+			pageviews: number
+			uniqueVisitors: number
+		}>
+	>
 }
 
-export function TopPagesTable({ rows }: TopPagesTableProps) {
+export function TopPagesTable({ result }: TopPagesTableProps) {
 	return (
 		<div className="rounded-xl border border-border bg-surface-raised p-6">
 			<h2 className="text-sm font-semibold text-foreground mb-4">
 				Top pages (last 30 days)
 			</h2>
-			{rows.length === 0 ? (
+			{!result.ok ? (
+				<AdminErrorState inline resource="page analytics" />
+			) : result.data.length === 0 ? (
 				<p className="text-sm text-muted-foreground text-center py-8">
 					No page analytics yet.
 				</p>
@@ -48,7 +54,7 @@ export function TopPagesTable({ rows }: TopPagesTableProps) {
 						</tr>
 					</thead>
 					<tbody>
-						{rows.map(row => (
+						{result.data.map(row => (
 							<tr key={row.pathname}>
 								<td className="py-2 text-foreground truncate max-w-[20rem]">
 									{row.pathname}

--- a/src/components/admin/widgets/TrafficSourcesPie.tsx
+++ b/src/components/admin/widgets/TrafficSourcesPie.tsx
@@ -15,9 +15,11 @@ import {
 	ResponsiveContainer,
 	Tooltip
 } from 'recharts'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
+import type { AdminQueryResult } from '@/lib/admin/query-result'
 
 type TrafficSourcesPieProps = {
-	data: Array<{ channel: string; count: number }>
+	result: AdminQueryResult<Array<{ channel: string; count: number }>>
 }
 
 const SLICE_COLORS = [
@@ -31,7 +33,11 @@ const SLICE_COLORS = [
 
 const TOP_N = 5
 
-export function TrafficSourcesPie({ data }: TrafficSourcesPieProps) {
+export function TrafficSourcesPie({ result }: TrafficSourcesPieProps) {
+	// Hooks must run unconditionally, so derive the rows before the render
+	// branch: on the error variant this is an empty array (the chart never
+	// renders in that case - the error card does).
+	const data = result.ok ? result.data : []
 	const chartData = useMemo(() => {
 		if (data.length <= TOP_N) {
 			return data
@@ -47,7 +53,9 @@ export function TrafficSourcesPie({ data }: TrafficSourcesPieProps) {
 			<h2 className="text-sm font-semibold text-foreground mb-4">
 				Traffic sources (last 30 days)
 			</h2>
-			{chartData.length === 0 ? (
+			{!result.ok ? (
+				<AdminErrorState inline resource="traffic source data" />
+			) : chartData.length === 0 ? (
 				<p className="text-sm text-muted-foreground text-center py-8">
 					No traffic source data yet.
 				</p>

--- a/src/components/admin/widgets/VisitorsChart.tsx
+++ b/src/components/admin/widgets/VisitorsChart.tsx
@@ -15,9 +15,11 @@ import {
 	XAxis,
 	YAxis
 } from 'recharts'
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
+import type { AdminQueryResult } from '@/lib/admin/query-result'
 
 type VisitorsChartProps = {
-	data: Array<{ date: string; pageviews: number }>
+	result: AdminQueryResult<Array<{ date: string; pageviews: number }>>
 }
 
 const DATE_FORMATTER = new Intl.DateTimeFormat(undefined, {
@@ -36,13 +38,15 @@ function formatTick(value: string): string {
 	return DATE_FORMATTER.format(parsed)
 }
 
-export function VisitorsChart({ data }: VisitorsChartProps) {
+export function VisitorsChart({ result }: VisitorsChartProps) {
 	return (
 		<div className="rounded-xl border border-border bg-surface-raised p-6">
 			<h2 className="text-sm font-semibold text-foreground mb-4">
 				Visitors (last 30 days)
 			</h2>
-			{data.length === 0 ? (
+			{!result.ok ? (
+				<AdminErrorState inline resource="traffic data" />
+			) : result.data.length === 0 ? (
 				<p className="text-sm text-muted-foreground text-center py-12">
 					No traffic data yet.
 				</p>
@@ -50,7 +54,7 @@ export function VisitorsChart({ data }: VisitorsChartProps) {
 				<div role="img" aria-label="Daily pageviews over the last 30 days">
 					<ResponsiveContainer width="100%" height={280}>
 						<LineChart
-							data={data}
+							data={result.data}
 							margin={{ top: 8, right: 16, bottom: 8, left: 0 }}
 						>
 							<CartesianGrid

--- a/src/components/admin/widgets/WebVitalsCards.tsx
+++ b/src/components/admin/widgets/WebVitalsCards.tsx
@@ -5,9 +5,13 @@
  * Each value is color-coded by the canonical CWV threshold rules (same
  * thresholds the /api/web-vitals route uses to assign a rating on ingest).
  */
+import { AdminErrorState } from '@/components/admin/AdminErrorState'
+import type { AdminQueryResult } from '@/lib/admin/query-result'
 
 type WebVitalsCardsProps = {
-	rows: Array<{ name: string; p75: number; sampleCount: number }>
+	result: AdminQueryResult<
+		Array<{ name: string; p75: number; sampleCount: number }>
+	>
 }
 
 type Rating = 'good' | 'needs-improvement' | 'poor'
@@ -59,7 +63,20 @@ function ratingClass(rating: Rating): string {
 	return 'text-destructive-text'
 }
 
-export function WebVitalsCards({ rows }: WebVitalsCardsProps) {
+export function WebVitalsCards({ result }: WebVitalsCardsProps) {
+	if (!result.ok) {
+		return (
+			<div className="rounded-xl border border-border bg-surface-raised p-6">
+				<h2 className="text-sm font-semibold text-foreground mb-4">
+					Web Vitals (last 7 days)
+				</h2>
+				<AdminErrorState inline resource="web vitals" />
+			</div>
+		)
+	}
+
+	const rows = result.data
+
 	return (
 		<div className="rounded-xl border border-border bg-surface-raised p-6">
 			<h2 className="text-sm font-semibold text-foreground mb-4">

--- a/src/lib/admin/blog-queries.ts
+++ b/src/lib/admin/blog-queries.ts
@@ -38,6 +38,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import type {
@@ -69,13 +78,6 @@ export type ListBlogPostsResult = {
 	hasMore: boolean
 	prevCursor: string | null
 	nextCursor: string | null
-}
-
-const EMPTY_RESULT: ListBlogPostsResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
 }
 
 // NULLS LAST sentinel: an unpublished row (publishedAt = null) sorts AFTER
@@ -121,11 +123,12 @@ function cursorPartsFor(row: {
  * sentinel row never reaches the join table query.
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` variant so the caller can render the error state instead of an
+ * empty list that masks the failure.
  */
 export async function listBlogPostsForAdmin(
 	opts?: ListBlogPostsOptions
-): Promise<ListBlogPostsResult> {
+): Promise<AdminQueryResult<ListBlogPostsResult>> {
 	const { q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -298,16 +301,16 @@ export async function listBlogPostsForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows, hasMore, prevCursor, nextCursor }
+		return ok({ rows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('blog-queries.listBlogPostsForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
 export async function getBlogPostForAdmin(
 	id: string
-): Promise<AdminBlogListRow | null> {
+): Promise<AdminDetailResult<AdminBlogListRow>> {
 	try {
 		const [row] = await db
 			.select({ post: blogPosts, author: blogAuthors })
@@ -316,15 +319,22 @@ export async function getBlogPostForAdmin(
 			.where(eq(blogPosts.id, id))
 			.limit(1)
 		if (!row) {
-			return null
+			return notFoundResult()
 		}
+		// The tag-id lookup is part of the detail read: a throw HERE (not just
+		// in the post select) is still a read failure, so it must yield the
+		// error variant, not a misleading 404.
 		const tagMap = await loadTagIdsForPosts([id])
-		return { post: row.post, author: row.author, tagIds: tagMap[id] ?? [] }
+		return found({
+			post: row.post,
+			author: row.author,
+			tagIds: tagMap[id] ?? []
+		})
 	} catch (error) {
 		logger.error('blog-queries.getBlogPostForAdmin failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 
@@ -383,7 +393,11 @@ export async function updateBlogPost(
 	id: string,
 	input: Omit<UpdateAdminBlogPostInput, 'id'>
 ): Promise<DbBlogPost | null> {
-	const existing = await getBlogPostForAdmin(id)
+	// getBlogPostForAdmin now returns the 3-way detail union; narrow it locally
+	// so a DB error and a missing row both collapse to null, preserving this
+	// helper's existing null-on-absent return contract byte-for-byte.
+	const result = await getBlogPostForAdmin(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return null
 	}
@@ -446,7 +460,10 @@ export async function deleteBlogPost(id: string): Promise<boolean> {
 export async function toggleBlogPostPublished(
 	id: string
 ): Promise<DbBlogPost | null> {
-	const existing = await getBlogPostForAdmin(id)
+	// Same local narrow as updateBlogPost: error + not-found both -> null, so
+	// the existing null-on-absent contract is preserved (lockstep migration).
+	const result = await getBlogPostForAdmin(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return null
 	}

--- a/src/lib/admin/calculator-leads-queries.ts
+++ b/src/lib/admin/calculator-leads-queries.ts
@@ -30,6 +30,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { type CalculatorLead, calculatorLeads } from '@/lib/schemas/schema'
@@ -53,13 +62,6 @@ export type ListCalculatorLeadsResult = {
 	nextCursor: string | null
 }
 
-const EMPTY_RESULT: ListCalculatorLeadsResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
-}
-
 /**
  * Cursor-paginated + search-aware admin calculator-leads list.
  *
@@ -80,11 +82,13 @@ const EMPTY_RESULT: ListCalculatorLeadsResult = {
  *    are safely filtered out.
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` failure variant (logged via `logger.error`); the caller renders a
+ * visible error state instead of an empty list that hides the failure. A
+ * successful-but-empty read returns `ok({ rows: [], ... })`.
  */
 export async function listCalculatorLeadsForAdmin(
 	opts?: ListCalculatorLeadsOptions
-): Promise<ListCalculatorLeadsResult> {
+): Promise<AdminQueryResult<ListCalculatorLeadsResult>> {
 	const { quality, q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -176,13 +180,13 @@ export async function listCalculatorLeadsForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error(
 			'calculator-leads-queries.listCalculatorLeadsForAdmin failed',
 			error
 		)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
@@ -191,22 +195,25 @@ function cursorPartsFor(row: CalculatorLeadRow): [Date, string] {
 }
 
 /**
- * Single calculator lead by id, or `null` when the row is missing or the
- * query fails. The detail page lifts this and calls `notFound()` on null.
+ * Single calculator lead by id as a 3-way `AdminDetailResult`: `found(row)`
+ * when the row exists, `notFoundResult()` when no row matches the id (the
+ * detail page 404s), and `errResult()` on a DB failure (the detail page
+ * renders a visible error state instead of a misleading 404). The caught
+ * error is logged via `logger.error` and never crosses into the rendered UI.
  */
 export async function getCalculatorLeadById(
 	id: string
-): Promise<CalculatorLeadRow | null> {
+): Promise<AdminDetailResult<CalculatorLeadRow>> {
 	try {
 		const [row] = await db
 			.select()
 			.from(calculatorLeads)
 			.where(eq(calculatorLeads.id, id))
 			.limit(1)
-		return row ?? null
+		return row ? found(row) : notFoundResult()
 	} catch (error) {
 		logger.error('calculator-leads-queries.getCalculatorLeadById failed', error)
-		return null
+		return errResult()
 	}
 }
 

--- a/src/lib/admin/dashboard-queries.ts
+++ b/src/lib/admin/dashboard-queries.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { and, count, desc, isNotNull, sql } from 'drizzle-orm'
+import { type AdminQueryResult, err, ok } from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import {
@@ -44,7 +45,7 @@ export type RecentLeadRow = Pick<
  */
 export async function getVisitorsByDay(
 	days: number = 30
-): Promise<VisitorsByDayRow[]> {
+): Promise<AdminQueryResult<VisitorsByDayRow[]>> {
 	try {
 		const dayExpr = sql<string>`to_char(date_trunc('day', ${pageAnalytics.date}), 'YYYY-MM-DD')`
 		const pageviewsExpr = sql<number>`coalesce(sum(${pageAnalytics.pageViews}), 0)::int`
@@ -61,13 +62,15 @@ export async function getVisitorsByDay(
 			.groupBy(dayExpr)
 			.orderBy(dayExpr)
 
-		return rows.map(row => ({
-			date: row.date,
-			pageviews: Number(row.pageviews)
-		}))
+		return ok(
+			rows.map(row => ({
+				date: row.date,
+				pageviews: Number(row.pageviews)
+			}))
+		)
 	} catch (error) {
 		logger.error('dashboard-queries.getVisitorsByDay failed', error)
-		return []
+		return err()
 	}
 }
 
@@ -77,7 +80,7 @@ export async function getVisitorsByDay(
 export async function getTopPages(
 	limit: number = 10,
 	days: number = 30
-): Promise<TopPagesRow[]> {
+): Promise<AdminQueryResult<TopPagesRow[]>> {
 	try {
 		const pageviewsExpr = sql<number>`coalesce(sum(${pageAnalytics.pageViews}), 0)::int`
 		const uniqueExpr = sql<number>`coalesce(sum(${pageAnalytics.uniqueVisitors}), 0)::int`
@@ -96,14 +99,16 @@ export async function getTopPages(
 			.orderBy(desc(pageviewsExpr))
 			.limit(limit)
 
-		return rows.map(row => ({
-			pathname: row.pathname,
-			pageviews: Number(row.pageviews),
-			uniqueVisitors: Number(row.uniqueVisitors)
-		}))
+		return ok(
+			rows.map(row => ({
+				pathname: row.pathname,
+				pageviews: Number(row.pageviews),
+				uniqueVisitors: Number(row.uniqueVisitors)
+			}))
+		)
 	} catch (error) {
 		logger.error('dashboard-queries.getTopPages failed', error)
-		return []
+		return err()
 	}
 }
 
@@ -113,7 +118,7 @@ export async function getTopPages(
  */
 export async function getTrafficSources(
 	days: number = 30
-): Promise<TrafficSourceRow[]> {
+): Promise<AdminQueryResult<TrafficSourceRow[]>> {
 	try {
 		const countExpr = count()
 
@@ -132,17 +137,20 @@ export async function getTrafficSources(
 			.groupBy(leadAttribution.channel)
 			.orderBy(desc(countExpr))
 
-		return rows
-			.filter(
-				(row): row is { channel: string; count: number } => row.channel !== null
-			)
-			.map(row => ({
-				channel: row.channel,
-				count: Number(row.count)
-			}))
+		return ok(
+			rows
+				.filter(
+					(row): row is { channel: string; count: number } =>
+						row.channel !== null
+				)
+				.map(row => ({
+					channel: row.channel,
+					count: Number(row.count)
+				}))
+		)
 	} catch (error) {
 		logger.error('dashboard-queries.getTrafficSources failed', error)
-		return []
+		return err()
 	}
 }
 
@@ -154,7 +162,7 @@ export async function getTrafficSources(
  */
 export async function getWebVitalsP75(
 	days: number = 7
-): Promise<WebVitalsP75Row[]> {
+): Promise<AdminQueryResult<WebVitalsP75Row[]>> {
 	try {
 		const p75Expr = sql<number>`percentile_cont(0.75) within group (order by ${webVitals.value}::numeric)`
 		const sampleExpr = sql<number>`count(*)::int`
@@ -172,14 +180,16 @@ export async function getWebVitalsP75(
 			.groupBy(webVitals.name)
 			.orderBy(webVitals.name)
 
-		return rows.map(row => ({
-			name: row.name,
-			p75: Number(row.p75),
-			sampleCount: Number(row.sampleCount)
-		}))
+		return ok(
+			rows.map(row => ({
+				name: row.name,
+				p75: Number(row.p75),
+				sampleCount: Number(row.sampleCount)
+			}))
+		)
 	} catch (error) {
 		logger.error('dashboard-queries.getWebVitalsP75 failed', error)
-		return []
+		return err()
 	}
 }
 
@@ -188,7 +198,7 @@ export async function getWebVitalsP75(
  */
 export async function getRecentLeads(
 	limit: number = 10
-): Promise<RecentLeadRow[]> {
+): Promise<AdminQueryResult<RecentLeadRow[]>> {
 	try {
 		const rows = await db
 			.select({
@@ -202,9 +212,9 @@ export async function getRecentLeads(
 			.orderBy(desc(leads.createdAt))
 			.limit(limit)
 
-		return rows
+		return ok(rows)
 	} catch (error) {
 		logger.error('dashboard-queries.getRecentLeads failed', error)
-		return []
+		return err()
 	}
 }

--- a/src/lib/admin/emails-queries.ts
+++ b/src/lib/admin/emails-queries.ts
@@ -15,8 +15,14 @@
  * Pattern mirrors `src/lib/admin/showcase-queries.ts` and
  * `src/lib/admin/leads-queries.ts`:
  *  - `import 'server-only'` to fail fast on accidental client imports.
- *  - Read helpers wrap their DB call in try/catch and return a safe default
- *    so a query blip renders an empty state instead of crashing the page.
+ *  - Read helpers wrap their DB call in try/catch and RETURN a discriminated
+ *    failure variant (Phase 13, ADMINERR-01..04). `getQueueCounts` /
+ *    `listScheduledEmailsForAdmin` return `AdminQueryResult` (`err()` on a
+ *    caught DB error, distinct from a successful-but-empty read), and
+ *    `getScheduledEmailById` returns `AdminDetailResult` (`'error'` vs
+ *    `'not-found'`). The caught exception stays in `logger.error` server-side;
+ *    the page renders an explicit `AdminErrorState` so a query blip is never
+ *    mistaken for a healthy zeroed queue, an empty list, or a 404.
  *  - Write helpers let exceptions propagate; the Server Action layer catches
  *    and translates them into generic form errors. `deleteScheduledEmail`
  *    swallows errors so the action can redirect to the list either way.
@@ -49,6 +55,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import { type ScheduledEmail, scheduledEmails } from '@/lib/schemas/schema'
@@ -76,13 +91,6 @@ export type ListScheduledEmailsResult = {
 	nextCursor: string | null
 }
 
-const EMPTY_RESULT: ListScheduledEmailsResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
-}
-
 function cursorPartsFor(row: ScheduledEmail): [Date, string] {
 	return [row.scheduledFor, row.id]
 }
@@ -99,14 +107,18 @@ export type RetryResult =
 
 /**
  * Counts of scheduled-email rows grouped by status. One aggregate query.
- * Returns a fully populated record (zeros for missing statuses) so the
- * stat-card grid in the list page never has to defensively check for
- * undefined values. Non-standard status strings in the table (defensive
- * against historical / migrated rows) are ignored. Returns the zero record
- * on query failure so the page still renders.
+ * On success returns `ok(...)` wrapping a fully populated record (zeros for
+ * missing statuses) so the stat-card grid in the list page never has to
+ * defensively check for undefined values. Non-standard status strings in the
+ * table (defensive against historical / migrated rows) are ignored.
+ *
+ * On a caught DB error returns `err()` (ADMINERR-03), NOT a falsely-healthy
+ * all-zero record: the page renders a grid-spanning `AdminErrorState` instead
+ * of four cards reading "0", so a query blip is never mistaken for an empty
+ * queue. The caught exception stays in `logger.error` server-side.
  */
-export async function getQueueCounts(): Promise<QueueCounts> {
-	const result: QueueCounts = {
+export async function getQueueCounts(): Promise<AdminQueryResult<QueueCounts>> {
+	const counts: QueueCounts = {
 		pending: 0,
 		sent: 0,
 		failed: 0,
@@ -122,13 +134,13 @@ export async function getQueueCounts(): Promise<QueueCounts> {
 				row.status &&
 				(EMAIL_STATUSES as readonly string[]).includes(row.status)
 			) {
-				result[row.status as EmailStatus] = Number(row.count)
+				counts[row.status as EmailStatus] = Number(row.count)
 			}
 		}
-		return result
+		return ok(counts)
 	} catch (error) {
 		logger.error('emails-queries.getQueueCounts failed', error)
-		return result
+		return err()
 	}
 }
 
@@ -153,16 +165,20 @@ export async function getQueueCounts(): Promise<QueueCounts> {
  *    input. `recipientName` is nullable -- ILIKE on a NULL column returns
  *    NULL (false) so those rows are safely filtered out by the OR.
  *
- * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * Malformed cursor: silently falls back to page 1. DB error: returns `err()`
+ * (ADMINERR-01) so the caller renders an `AdminErrorState` instead of an
+ * empty list; a successful-but-empty read returns `ok({ rows: [], ... })`,
+ * which the caller renders as the empty state. Error and empty are distinct.
  *
- * NOTE: `getQueueCounts()` is intentionally NOT touched and is still called
- * by the page WITHOUT arguments so the 4 stat cards stay reflecting the
- * full queue regardless of status / q / cursor.
+ * NOTE: `getQueueCounts()` is called by the page WITHOUT arguments (inside the
+ * same `Promise.all`) so the 4 stat cards reflect the full queue regardless of
+ * status / q / cursor. The two reads are INDEPENDENT `AdminQueryResult`s:
+ * each is narrowed on its own, so a counts failure never blanks the list and
+ * a list failure never blanks the counts.
  */
 export async function listScheduledEmailsForAdmin(
 	opts?: ListScheduledEmailsOptions
-): Promise<ListScheduledEmailsResult> {
+): Promise<AdminQueryResult<ListScheduledEmailsResult>> {
 	const { status, q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -255,32 +271,38 @@ export async function listScheduledEmailsForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('emails-queries.listScheduledEmailsForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
 /**
- * Single scheduled-email row by id, or `null` when the row is missing or
- * the query fails. The detail page lifts this and calls `notFound()` on null.
+ * Single scheduled-email row by id as a 3-way `AdminDetailResult`:
+ *  - `found(row)`         when the row exists,
+ *  - `notFoundResult()`   when no row matches (detail page -> `notFound()`),
+ *  - `errResult()`        on a caught DB error (detail page -> error state).
+ *
+ * Distinguishing `'error'` from `'not-found'` (ADMINERR-04) means a transient
+ * DB failure never masquerades as a 404. The caught exception stays in
+ * `logger.error` server-side.
  */
 export async function getScheduledEmailById(
 	id: string
-): Promise<ScheduledEmail | null> {
+): Promise<AdminDetailResult<ScheduledEmail>> {
 	try {
 		const [row] = await db
 			.select()
 			.from(scheduledEmails)
 			.where(eq(scheduledEmails.id, id))
 			.limit(1)
-		return row ?? null
+		return row ? found(row) : notFoundResult()
 	} catch (error) {
 		logger.error('emails-queries.getScheduledEmailById failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 
@@ -299,7 +321,8 @@ export async function getScheduledEmailById(
  * to a generic form error.
  */
 export async function retryScheduledEmail(id: string): Promise<RetryResult> {
-	const existing = await getScheduledEmailById(id)
+	const result = await getScheduledEmailById(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return { ok: false, reason: 'not_found' }
 	}

--- a/src/lib/admin/leads-queries.ts
+++ b/src/lib/admin/leads-queries.ts
@@ -33,6 +33,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import type { LeadStatus } from '@/lib/schemas/admin-leads'
@@ -65,13 +74,6 @@ export type ListLeadsResult = {
 	nextCursor: string | null
 }
 
-const EMPTY_RESULT: ListLeadsResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
-}
-
 /**
  * Cursor-paginated + search-aware admin leads list.
  *
@@ -92,11 +94,13 @@ const EMPTY_RESULT: ListLeadsResult = {
  *    so those rows are safely filtered out.
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` failure variant (logged via `logger.error`); the caller renders a
+ * visible error state instead of an empty list that hides the failure. A
+ * successful-but-empty read returns `ok({ rows: [], ... })`.
  */
 export async function listLeadsForAdmin(
 	opts?: ListLeadsOptions
-): Promise<ListLeadsResult> {
+): Promise<AdminQueryResult<ListLeadsResult>> {
 	const { status, q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -183,10 +187,10 @@ export async function listLeadsForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('leads-queries.listLeadsForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
@@ -197,10 +201,15 @@ function cursorPartsFor(row: Lead): [Date, string] {
 /**
  * Full detail bundle for a single lead: the row itself, every attribution
  * touchpoint (newest first), and every operator-written note (newest first).
- * Returns `null` when the lead row is missing or when the query fails so
- * the detail page can call `notFound()` without an extra try/catch.
+ * Returns a 3-way `AdminDetailResult`: `found(detail)` when the lead row
+ * exists, `notFoundResult()` when no row matches the id (the detail page
+ * 404s), and `errResult()` on a DB failure (the detail page renders a visible
+ * error state instead of a misleading 404). The caught error is logged via
+ * `logger.error` and never crosses into the rendered UI.
  */
-export async function getLeadById(id: string): Promise<LeadDetail | null> {
+export async function getLeadById(
+	id: string
+): Promise<AdminDetailResult<LeadDetail>> {
 	try {
 		const [leadRows, attribution, notes] = await Promise.all([
 			db.select().from(leads).where(eq(leads.id, id)).limit(1),
@@ -217,14 +226,14 @@ export async function getLeadById(id: string): Promise<LeadDetail | null> {
 		])
 		const [lead] = leadRows
 		if (!lead) {
-			return null
+			return notFoundResult()
 		}
-		return { lead, attribution, notes }
+		return found({ lead, attribution, notes })
 	} catch (error) {
 		logger.error('leads-queries.getLeadById failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 

--- a/src/lib/admin/newsletter-queries.ts
+++ b/src/lib/admin/newsletter-queries.ts
@@ -42,6 +42,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import {
@@ -70,13 +79,6 @@ export type ListSubscribersResult = {
 	hasMore: boolean
 	prevCursor: string | null
 	nextCursor: string | null
-}
-
-const EMPTY_RESULT: ListSubscribersResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
 }
 
 // NULLS LAST sentinel: a subscriber with subscribedAt = null sorts AFTER
@@ -120,11 +122,13 @@ function cursorPartsFor(row: SubscriberRow): CursorParts {
  *    are safely filtered out when the search targets only the name column.
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` failure variant (logged via `logger.error`); the caller renders a
+ * visible error state instead of an empty list that hides the failure. A
+ * successful-but-empty read returns `ok({ rows: [], ... })`.
  */
 export async function listSubscribersForAdmin(
 	opts?: ListSubscribersOptions
-): Promise<ListSubscribersResult> {
+): Promise<AdminQueryResult<ListSubscribersResult>> {
 	const { status, q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -255,32 +259,35 @@ export async function listSubscribersForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('newsletter-queries.listSubscribersForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
 /**
- * Single subscriber by id, or `null` when the row is missing or the query
- * fails. The detail page lifts this and calls `notFound()` on null.
+ * Single subscriber by id as a 3-way `AdminDetailResult`: `found(row)` when
+ * the row exists, `notFoundResult()` when no row matches the id (the detail
+ * page 404s), and `errResult()` on a DB failure (the detail page renders a
+ * visible error state instead of a misleading 404). The caught error is
+ * logged via `logger.error` and never crosses into the rendered UI.
  */
 export async function getSubscriberById(
 	id: string
-): Promise<SubscriberRow | null> {
+): Promise<AdminDetailResult<SubscriberRow>> {
 	try {
 		const [row] = await db
 			.select()
 			.from(newsletterSubscribers)
 			.where(eq(newsletterSubscribers.id, id))
 			.limit(1)
-		return row ?? null
+		return row ? found(row) : notFoundResult()
 	} catch (error) {
 		logger.error('newsletter-queries.getSubscriberById failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 

--- a/src/lib/admin/query-result.ts
+++ b/src/lib/admin/query-result.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared discriminated-union result types for the admin data seam
+ * (`src/lib/admin/*-queries.ts`).
+ *
+ * Background (Phase 13, ADMINERR-01..04): every admin read query used to
+ * swallow DB errors and return a "safe default" indistinguishable from real
+ * emptiness (`[]` / `null` / an all-zero counts record). On a genuine failure
+ * the operator saw an empty list, a falsely-healthy zeroed queue, or - worst -
+ * a transient detail-page error masquerading as a 404. The fix is to RETURN a
+ * discriminated result so a failed `catch` is distinguishable from a
+ * successful-but-empty read, and each surface renders its own visible error
+ * state in place (preserving the v4 per-widget resilience: a returned failure
+ * never rejects a `Promise.all`, so one failed widget cannot blank the page).
+ *
+ * This module is INTENTIONALLY tier-agnostic: it contains only pure types and
+ * trivial constructors and MUST stay importable from any tier (no server-tier
+ * import guard). The two client widgets (`VisitorsChart`, `TrafficSourcesPie`)
+ * import these result types, so a server-tier guard would break their bundle
+ * build. Keep this file free of the server-tier import directive.
+ *
+ * Style matches the hand-rolled `RetryResult` union in `emails-queries.ts`
+ * (no external Result library).
+ */
+
+/**
+ * Two-variant result for list / widget / queue reads.
+ *
+ * `ok: true` carries the data (which may itself be legitimately empty);
+ * `ok: false` carries no payload - the raw exception stays in `logger.error`
+ * server-side only and never crosses into the rendered error state.
+ */
+export type AdminQueryResult<T> =
+	| { ok: true; data: T }
+	| { ok: false; error: true }
+
+/** Wrap a successful read (the data may be empty - that is still `ok`). */
+export const ok = <T>(data: T): AdminQueryResult<T> => ({ ok: true, data })
+
+/** Signal a failed read. Carries no payload by design (no info-leak). */
+export const err = (): AdminQueryResult<never> => ({ ok: false, error: true })
+
+/**
+ * Three-variant result for `get*ById` detail reads. Distinguishes a genuinely
+ * missing row (`'not-found'` -> `notFound()` / 404) from a DB failure
+ * (`'error'` -> error state, NOT a 404). The three statuses are mutually
+ * exclusive; switching on `result.status` is exhaustive.
+ */
+export type AdminDetailResult<T> =
+	| { status: 'found'; data: T }
+	| { status: 'not-found' }
+	| { status: 'error' }
+
+/** A row was found. */
+export const found = <T>(data: T): AdminDetailResult<T> => ({
+	status: 'found',
+	data
+})
+
+/** No row exists for this id - the consumer should 404. */
+export const notFoundResult = (): AdminDetailResult<never> => ({
+	status: 'not-found'
+})
+
+/** The detail read failed - the consumer should render an error state. */
+export const errResult = (): AdminDetailResult<never> => ({ status: 'error' })

--- a/src/lib/admin/showcase-queries.ts
+++ b/src/lib/admin/showcase-queries.ts
@@ -31,6 +31,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import type {
@@ -54,13 +63,6 @@ export type ListShowcasesResult = {
 	nextCursor: string | null
 }
 
-const EMPTY_RESULT: ListShowcasesResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
-}
-
 /**
  * Cursor-paginated + search-aware admin showcase list.
  *
@@ -77,11 +79,12 @@ const EMPTY_RESULT: ListShowcasesResult = {
  * pattern; backslash / `%` / `_` escaped via `escapeLikePattern`).
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` failure variant so the caller can render the error state (distinct
+ * from a genuinely empty `ok` result).
  */
 export async function listShowcasesForAdmin(
 	opts?: ListShowcasesOptions
-): Promise<ListShowcasesResult> {
+): Promise<AdminQueryResult<ListShowcasesResult>> {
 	const { q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -188,10 +191,10 @@ export async function listShowcasesForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('showcase-queries.listShowcasesForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
@@ -200,22 +203,27 @@ function cursorPartsFor(row: ShowcaseRow): [number, Date, string] {
 }
 
 /**
- * Single showcase row by id, or `null` when the row is missing or the query
- * fails. The edit page lifts this and calls `notFound()` on null.
+ * Single showcase row by id as a 3-way detail result: `found(row)` when the
+ * row exists, `notFoundResult()` when it is genuinely missing, `errResult()`
+ * when the query fails. The edit page 404s only on `'not-found'` and renders
+ * the error state on `'error'` (never a misleading 404). The two internal
+ * write-helper callers narrow this back to a row-or-null locally.
  */
-export async function getShowcaseById(id: string): Promise<ShowcaseRow | null> {
+export async function getShowcaseById(
+	id: string
+): Promise<AdminDetailResult<ShowcaseRow>> {
 	try {
 		const [row] = await db
 			.select()
 			.from(showcase)
 			.where(eq(showcase.id, id))
 			.limit(1)
-		return row ?? null
+		return row ? found(row) : notFoundResult()
 	} catch (error) {
 		logger.error('showcase-queries.getShowcaseById failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 
@@ -248,7 +256,8 @@ export async function updateShowcase(
 	id: string,
 	input: Omit<UpdateShowcaseInput, 'id'>
 ): Promise<ShowcaseRow | null> {
-	const existing = await getShowcaseById(id)
+	const result = await getShowcaseById(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return null
 	}
@@ -293,7 +302,8 @@ export async function deleteShowcase(id: string): Promise<boolean> {
 export async function toggleShowcasePublished(
 	id: string
 ): Promise<ShowcaseRow | null> {
-	const existing = await getShowcaseById(id)
+	const result = await getShowcaseById(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return null
 	}

--- a/src/lib/admin/testimonials-queries.ts
+++ b/src/lib/admin/testimonials-queries.ts
@@ -3,9 +3,13 @@
  *
  * Read side (`listTestimonialsForAdmin`, `getTestimonialById`) returns
  * EVERY row including unpublished. The list helper is now
- * cursor-paginated + search-aware (Phase 10 Wave 2); try/catch returns
- * the empty result shape / null so the list page renders an empty state
- * rather than crashing the whole shell.
+ * cursor-paginated + search-aware (Phase 10 Wave 2). Phase 13 Wave 2:
+ * both reads return discriminated-union results so a caught DB error is
+ * distinguishable from a successful-but-empty read - the list helper
+ * returns `AdminQueryResult<ListTestimonialsResult>` (`err()` on failure)
+ * and `getTestimonialById` returns the 3-way `AdminDetailResult<TestimonialRow>`
+ * (`found` / `not-found` / `error`). Consumers render `AdminErrorState`
+ * on failure instead of a misleading empty list / 404.
  *
  * Write side (`createTestimonial`, `updateTestimonial`,
  * `toggleTestimonialPublished`) intentionally does NOT touch any
@@ -26,6 +30,15 @@ import {
 	escapeLikePattern,
 	PAGE_SIZE
 } from '@/lib/admin/list-cursor'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
 import { db } from '@/lib/db'
 import { logger } from '@/lib/logger'
 import type {
@@ -50,13 +63,6 @@ export type ListTestimonialsResult = {
 	nextCursor: string | null
 }
 
-const EMPTY_RESULT: ListTestimonialsResult = {
-	rows: [],
-	hasMore: false,
-	prevCursor: null,
-	nextCursor: null
-}
-
 /**
  * Cursor-paginated + search-aware admin testimonials list.
  *
@@ -74,11 +80,12 @@ const EMPTY_RESULT: ListTestimonialsResult = {
  * `escapeLikePattern`).
  *
  * Malformed cursor: silently falls back to page 1. DB error: returns the
- * empty result shape; caller renders the empty state instead of crashing.
+ * `err()` failure variant so the caller can render the error state (distinct
+ * from a genuinely empty `ok` result).
  */
 export async function listTestimonialsForAdmin(
 	opts?: ListTestimonialsOptions
-): Promise<ListTestimonialsResult> {
+): Promise<AdminQueryResult<ListTestimonialsResult>> {
 	const { q: rawQ, cursor: rawCursor } = opts ?? {}
 	const cursor = decodeCursor(rawCursor)
 	const direction: Direction = cursor?.direction ?? 'after'
@@ -167,10 +174,10 @@ export async function listTestimonialsForAdmin(
 				? encodeCursor('before', cursorPartsFor(firstRow))
 				: null
 
-		return { rows: pageRows, hasMore, prevCursor, nextCursor }
+		return ok({ rows: pageRows, hasMore, prevCursor, nextCursor })
 	} catch (error) {
 		logger.error('testimonials-queries.listTestimonialsForAdmin failed', error)
-		return EMPTY_RESULT
+		return err()
 	}
 }
 
@@ -178,21 +185,29 @@ function cursorPartsFor(row: TestimonialRow): [Date, string] {
 	return [row.createdAt ?? new Date(0), row.id]
 }
 
+/**
+ * Single testimonial row by id as a 3-way detail result: `found(row)` when the
+ * row exists, `notFoundResult()` when it is genuinely missing, `errResult()`
+ * when the query fails. The edit page 404s only on `'not-found'` and renders
+ * the error state on `'error'` (never a misleading 404). The single internal
+ * write-helper caller (`toggleTestimonialPublished`) narrows this back to a
+ * row-or-null locally.
+ */
 export async function getTestimonialById(
 	id: string
-): Promise<TestimonialRow | null> {
+): Promise<AdminDetailResult<TestimonialRow>> {
 	try {
 		const [row] = await db
 			.select()
 			.from(testimonials)
 			.where(eq(testimonials.id, id))
 			.limit(1)
-		return row ?? null
+		return row ? found(row) : notFoundResult()
 	} catch (error) {
 		logger.error('testimonials-queries.getTestimonialById failed', error, {
 			metadata: { id }
 		})
-		return null
+		return errResult()
 	}
 }
 
@@ -251,7 +266,8 @@ export const deleteTestimonial = deleteTestimonialBase
 export async function toggleTestimonialPublished(
 	id: string
 ): Promise<TestimonialRow | null> {
-	const existing = await getTestimonialById(id)
+	const result = await getTestimonialById(id)
+	const existing = result.status === 'found' ? result.data : null
 	if (!existing) {
 		return null
 	}

--- a/tests/unit/admin/blog-queries.test.ts
+++ b/tests/unit/admin/blog-queries.test.ts
@@ -1,17 +1,26 @@
 /**
- * Tests for `listBlogPostsForAdmin` after the Phase 10 Wave 2 rewrite.
+ * Tests for the blog admin read layer after the Phase 13 Wave 2 migration.
  *
- * The helper now accepts an options object `{ q?, cursor?, direction? }`
- * and returns `{ rows, hasMore, prevCursor, nextCursor }`. We test the
- * CONTRACT and CONTROL FLOW here (PAGE_SIZE+1 read, hasMore detection,
+ * `listBlogPostsForAdmin` now returns `AdminQueryResult<ListBlogPostsResult>`
+ * (the `catch` returns `err()`, zero rows return `ok({...})`), and
+ * `getBlogPostForAdmin` returns the 3-way `AdminDetailResult<AdminBlogListRow>`
+ * (`found` / `not-found` / `error`; a throw in EITHER the post select OR the
+ * `loadTagIdsForPosts` await yields the error variant). The two internal
+ * write-helper callers (`updateBlogPost`, `toggleBlogPostPublished`) narrow the
+ * detail result locally and KEEP their existing `null`-on-absent contract,
+ * which the write-helper cases below pin.
+ *
+ * We test the CONTRACT and CONTROL FLOW (PAGE_SIZE+1 read, hasMore detection,
  * cursor encoding, before-direction row reversal, malformed-cursor safety,
- * DB-error safe default, search-WHERE composition, and the critical
- * "tag-id lookup runs over the trimmed page slice only").
+ * DB-error error-variant, search-WHERE composition, the critical "tag-id
+ * lookup runs over the trimmed page slice only", the 3-way detail, and the
+ * write-helper null-on-absent contract).
  *
- * Mock pattern mirrors `tests/unit/admin/showcase-queries.test.ts`: a
- * chainable mock that captures the `.where()` argument so we can assert
- * composition shape, and a configurable resolution stage so we can stage
- * different row counts and tag-lookup id-lists per case.
+ * Mock pattern: a chainable post-list select mock that captures the `.where()`
+ * argument and flips into a tag-lookup chain on the second `select()`, plus a
+ * stubbed `db.update()` chain and a `db.transaction()` stub so the write
+ * helpers (`toggleBlogPostPublished` via `db.update`, `updateBlogPost` via
+ * `db.transaction`) can run their full lookup+write path against one harness.
  */
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
@@ -32,6 +41,10 @@ interface MockState {
 	// Toggle which next select() call mode we are in (post-list vs tag-lookup).
 	selectMode: 'post-list' | 'tag-lookup'
 	shouldThrow: boolean
+	// Rows returned by the `db.update(...).set(...).where(...).returning()`
+	// chain that `toggleBlogPostPublished` runs (and the `tx.update(...)` chain
+	// inside `updateBlogPost`'s transaction).
+	updateRowsToReturn: unknown[]
 }
 
 const state: MockState = {
@@ -43,7 +56,8 @@ const state: MockState = {
 	tagRowsToReturn: [],
 	tagLookupIds: undefined,
 	selectMode: 'post-list',
-	shouldThrow: false
+	shouldThrow: false,
+	updateRowsToReturn: []
 }
 
 function resetState(): void {
@@ -56,6 +70,7 @@ function resetState(): void {
 	state.tagLookupIds = undefined
 	state.selectMode = 'post-list'
 	state.shouldThrow = false
+	state.updateRowsToReturn = []
 }
 
 // drizzle-orm's `inArray(column, values)` is mocked so we can capture the
@@ -120,7 +135,41 @@ function buildTagLookupChain(): unknown {
 	return chain
 }
 
+// UPDATE chain used by `toggleBlogPostPublished` (`db.update`) and by the
+// `tx.update(...)` call inside `updateBlogPost`'s transaction:
+// `update(t).set(v).where(c).returning()` resolves to `state.updateRowsToReturn`.
+function buildUpdateChain(): unknown {
+	const chain = {
+		set: () => chain,
+		where: () => chain,
+		returning: () => Promise.resolve(state.updateRowsToReturn)
+	}
+	return chain
+}
+
+// DELETE / INSERT chains used inside `updateBlogPost`'s transaction for the
+// tag-set replacement. They resolve to nothing meaningful; only their presence
+// matters so the transaction body runs to completion.
+function buildDeleteChain(): unknown {
+	const chain = {
+		where: () => Promise.resolve(undefined)
+	}
+	return chain
+}
+
+function buildInsertChain(): unknown {
+	const chain = {
+		values: () => Promise.resolve(undefined)
+	}
+	return chain
+}
+
 function setupDbMock(): void {
+	const tx = {
+		update: () => buildUpdateChain(),
+		delete: () => buildDeleteChain(),
+		insert: () => buildInsertChain()
+	}
 	mock.module('@/lib/db', () => ({
 		db: {
 			select: () => {
@@ -131,7 +180,9 @@ function setupDbMock(): void {
 					return buildPostListChain()
 				}
 				return buildTagLookupChain()
-			}
+			},
+			update: () => buildUpdateChain(),
+			transaction: (fn: (txArg: unknown) => unknown) => fn(tx)
 		}
 	}))
 }
@@ -143,7 +194,12 @@ setupDbMock()
 // real too -- drizzle column refs are just objects, and the helper only
 // passes them to the mocked drizzle operators.
 
-import { listBlogPostsForAdmin } from '@/lib/admin/blog-queries'
+import {
+	getBlogPostForAdmin,
+	listBlogPostsForAdmin,
+	toggleBlogPostPublished,
+	updateBlogPost
+} from '@/lib/admin/blog-queries'
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
 import { logger } from '@/lib/logger'
 
@@ -211,15 +267,19 @@ describe('listBlogPostsForAdmin: page-size + hasMore', () => {
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
 		expect(state.leftJoinCalled).toBe(true)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as MakeRowResult
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -235,19 +295,27 @@ describe('listBlogPostsForAdmin: page-size + hasMore', () => {
 
 		const result = await listBlogPostsForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.postRowsToReturn = []
 		state.tagRowsToReturn = []
 
 		const result = await listBlogPostsForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -278,17 +346,12 @@ describe('listBlogPostsForAdmin: tag-id lookup is page-slice scoped', () => {
 })
 
 describe('listBlogPostsForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the post-list query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the post-list query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listBlogPostsForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -333,11 +396,15 @@ describe('listBlogPostsForAdmin: cursor + direction', () => {
 
 		const result = await listBlogPostsForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -359,8 +426,12 @@ describe('listBlogPostsForAdmin: cursor + direction', () => {
 
 		const result = await listBlogPostsForAdmin({ cursor: beforeCursor })
 
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
 		// Rows must be reversed back into display order (ascending idx)
-		const ids = result.rows.map(r => r.post.id)
+		const ids = result.data.rows.map(r => r.post.id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `post-${String(i + 1).padStart(2, '0')}`
@@ -368,11 +439,11 @@ describe('listBlogPostsForAdmin: cursor + direction', () => {
 		expect(ids).toEqual(expectedIds)
 
 		// prevCursor stays set because hasMore=true (more rows backward)
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
 		// nextCursor also set because we navigated backward (page exists forward)
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -393,10 +464,14 @@ describe('listBlogPostsForAdmin: cursor + direction', () => {
 
 		const result = await listBlogPostsForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -417,8 +492,138 @@ describe('listBlogPostsForAdmin: cursor + direction', () => {
 
 		const result = await listBlogPostsForAdmin()
 
-		expect(result.nextCursor).not.toBeNull()
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.nextCursor).not.toBeNull()
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded?.parts[0]).toBe('\x00')
+	})
+})
+
+describe('getBlogPostForAdmin: 3-way detail result', () => {
+	test("returns 'found' with the row when it exists", async () => {
+		state.postRowsToReturn = [makeRow(0, { id: 'post-00' })]
+		state.tagRowsToReturn = [{ postId: 'post-00', tagId: 'tag-1' }]
+
+		const result = await getBlogPostForAdmin('post-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect(result.data.post.id).toBe('post-00')
+		expect(result.data.tagIds).toEqual(['tag-1'])
+	})
+
+	test("returns 'not-found' when no row exists", async () => {
+		state.postRowsToReturn = []
+		state.tagRowsToReturn = []
+
+		const result = await getBlogPostForAdmin('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the post select throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getBlogPostForAdmin('post-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('write helpers keep their null-on-absent contract after the get*ById migration', () => {
+	test('updateBlogPost returns the updated row when the row exists', async () => {
+		state.postRowsToReturn = [makeRow(0, { id: 'post-00' })]
+		state.tagRowsToReturn = []
+		const updated = makeRow(0, { id: 'post-00' })
+		state.updateRowsToReturn = [updated.post]
+
+		const row = await updateBlogPost('post-00', {
+			title: 'Updated',
+			slug: 'updated',
+			excerpt: 'desc',
+			content: 'body',
+			readingTime: 1,
+			featured: false,
+			published: true,
+			authorId: 'author-0',
+			tagIds: []
+		} as Parameters<typeof updateBlogPost>[1])
+
+		expect(row).not.toBeNull()
+		expect((row as { id: string }).id).toBe('post-00')
+	})
+
+	test('updateBlogPost returns null when the row does not exist', async () => {
+		state.postRowsToReturn = []
+		state.tagRowsToReturn = []
+
+		const row = await updateBlogPost('missing', {
+			title: 'Updated',
+			slug: 'updated',
+			excerpt: 'desc',
+			content: 'body',
+			readingTime: 1,
+			featured: false,
+			published: true,
+			authorId: 'author-0',
+			tagIds: []
+		} as Parameters<typeof updateBlogPost>[1])
+
+		expect(row).toBeNull()
+	})
+
+	test('updateBlogPost returns null when the lookup query throws (error narrowed to null)', async () => {
+		state.shouldThrow = true
+
+		const row = await updateBlogPost('post-00', {
+			title: 'Updated',
+			slug: 'updated',
+			excerpt: 'desc',
+			content: 'body',
+			readingTime: 1,
+			featured: false,
+			published: true,
+			authorId: 'author-0',
+			tagIds: []
+		} as Parameters<typeof updateBlogPost>[1])
+
+		expect(row).toBeNull()
+	})
+
+	test('toggleBlogPostPublished flips published + returns the updated row when it exists', async () => {
+		state.postRowsToReturn = [
+			makeRow(0, { id: 'post-00', publishedAt: null })
+		]
+		state.tagRowsToReturn = []
+		const toggled = makeRow(0, { id: 'post-00' })
+		state.updateRowsToReturn = [toggled.post]
+
+		const row = await toggleBlogPostPublished('post-00')
+
+		expect(row).not.toBeNull()
+		expect((row as { id: string }).id).toBe('post-00')
+	})
+
+	test('toggleBlogPostPublished returns null when the row does not exist', async () => {
+		state.postRowsToReturn = []
+		state.tagRowsToReturn = []
+
+		const row = await toggleBlogPostPublished('missing')
+
+		expect(row).toBeNull()
+	})
+
+	test('toggleBlogPostPublished returns null when the lookup query throws (error narrowed to null)', async () => {
+		state.shouldThrow = true
+
+		const row = await toggleBlogPostPublished('post-00')
+
+		expect(row).toBeNull()
 	})
 })

--- a/tests/unit/admin/blog-queries.test.ts
+++ b/tests/unit/admin/blog-queries.test.ts
@@ -597,9 +597,7 @@ describe('write helpers keep their null-on-absent contract after the get*ById mi
 	})
 
 	test('toggleBlogPostPublished flips published + returns the updated row when it exists', async () => {
-		state.postRowsToReturn = [
-			makeRow(0, { id: 'post-00', publishedAt: null })
-		]
+		state.postRowsToReturn = [makeRow(0, { id: 'post-00', publishedAt: null })]
 		state.tagRowsToReturn = []
 		const toggled = makeRow(0, { id: 'post-00' })
 		state.updateRowsToReturn = [toggled.post]

--- a/tests/unit/admin/calculator-leads-queries.test.ts
+++ b/tests/unit/admin/calculator-leads-queries.test.ts
@@ -41,6 +41,10 @@ function resetState(): void {
 }
 
 function buildSelectChain(): unknown {
+	const settle = (): Promise<unknown> =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
 	const chain = {
 		from: () => chain,
 		where: (arg: unknown) => {
@@ -53,10 +57,7 @@ function buildSelectChain(): unknown {
 		},
 		limit: (n: number) => {
 			state.limitArg = n
-			if (state.shouldThrow) {
-				return Promise.reject(new Error('db down'))
-			}
-			return Promise.resolve(state.rowsToReturn)
+			return settle()
 		}
 	}
 	return chain
@@ -76,7 +77,10 @@ setupDbMock()
 // real too -- drizzle column refs are just objects, and the helper only
 // passes them to mocked drizzle operators, which the chainable mock ignores.
 
-import { listCalculatorLeadsForAdmin } from '@/lib/admin/calculator-leads-queries'
+import {
+	getCalculatorLeadById,
+	listCalculatorLeadsForAdmin
+} from '@/lib/admin/calculator-leads-queries'
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
 import { logger } from '@/lib/logger'
 
@@ -142,15 +146,19 @@ describe('listCalculatorLeadsForAdmin: page-size + hasMore', () => {
 		const result = await listCalculatorLeadsForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -164,18 +172,26 @@ describe('listCalculatorLeadsForAdmin: page-size + hasMore', () => {
 
 		const result = await listCalculatorLeadsForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listCalculatorLeadsForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -185,17 +201,12 @@ describe('listCalculatorLeadsForAdmin: page-size + hasMore', () => {
 })
 
 describe('listCalculatorLeadsForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listCalculatorLeadsForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -251,11 +262,15 @@ describe('listCalculatorLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listCalculatorLeadsForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -273,17 +288,21 @@ describe('listCalculatorLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listCalculatorLeadsForAdmin({ cursor: beforeCursor })
 
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `row-${String(i + 1).padStart(2, '0')}`
 		)
 		expect(ids).toEqual(expectedIds)
 
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -300,10 +319,14 @@ describe('listCalculatorLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listCalculatorLeadsForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -318,9 +341,44 @@ describe('listCalculatorLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listCalculatorLeadsForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+	})
+})
+
+describe('getCalculatorLeadById: 3-way detail result', () => {
+	test("returns 'found' with the row when it exists", async () => {
+		state.rowsToReturn = [makeRow(0)]
+
+		const result = await getCalculatorLeadById('row-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect((result.data as { id: string }).id).toBe('row-00')
+	})
+
+	test("returns 'not-found' when no row exists", async () => {
+		state.rowsToReturn = []
+
+		const result = await getCalculatorLeadById('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the query throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getCalculatorLeadById('row-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })

--- a/tests/unit/admin/dashboard-queries.test.ts
+++ b/tests/unit/admin/dashboard-queries.test.ts
@@ -1,17 +1,16 @@
 /**
  * Tests for the admin dashboard widget queries (`src/lib/admin/dashboard-queries.ts`).
  *
- * WAVE 1 SCAFFOLD (Phase 13, plan 01): this file is created now so that plan 08
- * (Wave 2) only EXTENDS it - the file is owned by plan 08 thereafter. Today it
- * contains the chainable-db-mock harness (copied from `leads-queries.test.ts`)
- * plus ONE placeholder smoke test so the file is green and committable. The
- * real per-widget found-empty / error regression cases are added in plan 08.
+ * WAVE 1 SCAFFOLD (Phase 13, plan 01) -> POPULATED in plan 08 (Wave 2). The
+ * harness (chainable-db-mock copied from `leads-queries.test.ts`) is owned by
+ * plan 08; the Wave-1 placeholder smoke test has been replaced with the real
+ * per-widget found-empty / error regression cases below.
  *
  * ---------------------------------------------------------------------------
- * PLAN 08 MUST COVER (ADMINERR-02): for each of the FIVE widget queries below,
- * assert the catch path yields the failure variant (`{ ok: false, error: true }`)
- * - NOT the current `[]` - and that a zero-row read yields `ok` with empty data.
- * Mock the db to throw via `state.shouldThrow = true`.
+ * COVERAGE (ADMINERR-02): for each of the FIVE widget queries below, assert the
+ * catch path yields the failure variant (`{ ok: false, error: true }`) - NOT
+ * the old `[]` - and that a zero-row read yields `ok` with empty data. The db
+ * is mocked to throw via `state.shouldThrow = true`.
  *
  *   1. getVisitorsByDay   - .where().groupBy(dayExpr).orderBy(dayExpr)
  *   2. getTopPages        - .where().groupBy(pathname).orderBy(desc).limit(n)
@@ -96,6 +95,7 @@ import {
 	getVisitorsByDay,
 	getWebVitalsP75
 } from '@/lib/admin/dashboard-queries'
+import { logger } from '@/lib/logger'
 
 beforeEach(() => {
 	resetState()
@@ -105,19 +105,122 @@ beforeEach(() => {
 	setupDbMock()
 })
 
-describe('dashboard-queries: scaffold smoke', () => {
-	test('the module exports all five widget queries and they are callable', async () => {
-		expect(typeof getVisitorsByDay).toBe('function')
-		expect(typeof getTopPages).toBe('function')
-		expect(typeof getTrafficSources).toBe('function')
-		expect(typeof getWebVitalsP75).toBe('function')
-		expect(typeof getRecentLeads).toBe('function')
+// Each widget query is exercised twice: a thrown DB call must yield the failure
+// variant (`{ ok: false, error: true }`) and log once via `logger.error`; a
+// zero-row read must yield `ok` with empty `data` - the distinction that lets a
+// widget tell "DB down" from "no data yet".
 
-		// getRecentLeads exercises the .orderBy().limit() chain (no where/groupBy);
-		// the thenable mock resolves it to the empty rows fixture.
+describe('getVisitorsByDay: error vs ok-empty', () => {
+	test('returns the error variant + logs once when the query throws', async () => {
+		state.shouldThrow = true
+
+		const result = await getVisitorsByDay(30)
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns ok with empty data when the query yields zero rows', async () => {
 		state.rowsToReturn = []
-		const rows = await getRecentLeads(10)
-		expect(Array.isArray(rows)).toBe(true)
-		expect(rows).toEqual([])
+
+		const result = await getVisitorsByDay(30)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual([])
+	})
+})
+
+describe('getTopPages: error vs ok-empty', () => {
+	test('returns the error variant + logs once when the query throws', async () => {
+		state.shouldThrow = true
+
+		const result = await getTopPages(10, 30)
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns ok with empty data when the query yields zero rows', async () => {
+		state.rowsToReturn = []
+
+		const result = await getTopPages(10, 30)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual([])
+	})
+})
+
+describe('getTrafficSources: error vs ok-empty', () => {
+	test('returns the error variant + logs once when the query throws', async () => {
+		state.shouldThrow = true
+
+		const result = await getTrafficSources(30)
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns ok with empty data when the query yields zero rows', async () => {
+		state.rowsToReturn = []
+
+		const result = await getTrafficSources(30)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual([])
+	})
+})
+
+describe('getWebVitalsP75: error vs ok-empty', () => {
+	test('returns the error variant + logs once when the query throws', async () => {
+		state.shouldThrow = true
+
+		const result = await getWebVitalsP75(7)
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns ok with empty data when the query yields zero rows', async () => {
+		state.rowsToReturn = []
+
+		const result = await getWebVitalsP75(7)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual([])
+	})
+})
+
+describe('getRecentLeads: error vs ok-empty', () => {
+	test('returns the error variant + logs once when the query throws', async () => {
+		state.shouldThrow = true
+
+		const result = await getRecentLeads(10)
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test('returns ok with empty data when the query yields zero rows', async () => {
+		state.rowsToReturn = []
+
+		const result = await getRecentLeads(10)
+
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual([])
 	})
 })

--- a/tests/unit/admin/dashboard-queries.test.ts
+++ b/tests/unit/admin/dashboard-queries.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the admin dashboard widget queries (`src/lib/admin/dashboard-queries.ts`).
+ *
+ * WAVE 1 SCAFFOLD (Phase 13, plan 01): this file is created now so that plan 08
+ * (Wave 2) only EXTENDS it - the file is owned by plan 08 thereafter. Today it
+ * contains the chainable-db-mock harness (copied from `leads-queries.test.ts`)
+ * plus ONE placeholder smoke test so the file is green and committable. The
+ * real per-widget found-empty / error regression cases are added in plan 08.
+ *
+ * ---------------------------------------------------------------------------
+ * PLAN 08 MUST COVER (ADMINERR-02): for each of the FIVE widget queries below,
+ * assert the catch path yields the failure variant (`{ ok: false, error: true }`)
+ * - NOT the current `[]` - and that a zero-row read yields `ok` with empty data.
+ * Mock the db to throw via `state.shouldThrow = true`.
+ *
+ *   1. getVisitorsByDay   - .where().groupBy(dayExpr).orderBy(dayExpr)
+ *   2. getTopPages        - .where().groupBy(pathname).orderBy(desc).limit(n)
+ *   3. getTrafficSources  - .where(and(...)).groupBy(channel).orderBy(desc)
+ *   4. getWebVitalsP75    - .where().groupBy(name).orderBy(name)
+ *   5. getRecentLeads     - .orderBy(desc).limit(n)   (no where / no groupBy)
+ *
+ * NOTE: the widget queries call `.groupBy().orderBy().limit()` over `sql` exprs,
+ * so the mock chain MUST include `groupBy`. Different queries terminate on a
+ * different method (`orderBy` for visitors/sources/vitals, `limit` for top
+ * pages / recent leads), so the chain itself is awaitable (thenable) - awaiting
+ * after ANY method resolves to `state.rowsToReturn` (or rejects when
+ * `state.shouldThrow`). This matches the real Drizzle builder, which is
+ * thenable at every step.
+ * ---------------------------------------------------------------------------
+ *
+ * Mock pattern mirrors `tests/unit/admin/leads-queries.test.ts`.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+// --- Mock state shared across cases (re-initialized in beforeEach) ----------
+
+interface MockState {
+	rowsToReturn: unknown[]
+	shouldThrow: boolean
+}
+
+const state: MockState = {
+	rowsToReturn: [],
+	shouldThrow: false
+}
+
+function resetState(): void {
+	state.rowsToReturn = []
+	state.shouldThrow = false
+}
+
+/**
+ * A thenable chainable stub. Every builder method returns the same chain so any
+ * call sequence (`.from().where().groupBy().orderBy().limit()` in any subset)
+ * works. The chain is awaitable: `await chain` resolves to `state.rowsToReturn`
+ * or rejects when `state.shouldThrow` - so it does not matter which method the
+ * query under test treats as terminal.
+ */
+function buildSelectChain(): unknown {
+	const settle = () =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
+
+	const chain: Record<string, unknown> = {
+		from: () => chain,
+		where: () => chain,
+		groupBy: () => chain,
+		orderBy: () => chain,
+		limit: () => chain,
+		// Awaiting the builder at any step resolves like the real Drizzle query.
+		then: (
+			resolve: (v: unknown) => unknown,
+			reject?: (e: unknown) => unknown
+		) => settle().then(resolve, reject)
+	}
+	return chain
+}
+
+function setupDbMock(): void {
+	mock.module('@/lib/db', () => ({
+		db: {
+			select: () => buildSelectChain()
+		}
+	}))
+}
+
+setupDbMock()
+
+// Real schema barrel is used - drizzle column refs are just objects the mocked
+// chain ignores. `tests/setup.ts` auto-mocks `@/env` + `@/lib/logger`.
+import {
+	getRecentLeads,
+	getTopPages,
+	getTrafficSources,
+	getVisitorsByDay,
+	getWebVitalsP75
+} from '@/lib/admin/dashboard-queries'
+
+beforeEach(() => {
+	resetState()
+	// tests/setup.ts beforeEach runs `mock.restore()` BEFORE this file's
+	// beforeEach. Re-register the db mock so the chainable stub stays bound to
+	// the module under test for every case.
+	setupDbMock()
+})
+
+describe('dashboard-queries: scaffold smoke', () => {
+	test('the module exports all five widget queries and they are callable', async () => {
+		expect(typeof getVisitorsByDay).toBe('function')
+		expect(typeof getTopPages).toBe('function')
+		expect(typeof getTrafficSources).toBe('function')
+		expect(typeof getWebVitalsP75).toBe('function')
+		expect(typeof getRecentLeads).toBe('function')
+
+		// getRecentLeads exercises the .orderBy().limit() chain (no where/groupBy);
+		// the thenable mock resolves it to the empty rows fixture.
+		state.rowsToReturn = []
+		const rows = await getRecentLeads(10)
+		expect(Array.isArray(rows)).toBe(true)
+		expect(rows).toEqual([])
+	})
+})

--- a/tests/unit/admin/emails-queries.test.ts
+++ b/tests/unit/admin/emails-queries.test.ts
@@ -1,22 +1,31 @@
 /**
- * Tests for `listScheduledEmailsForAdmin` after the Phase 10 Wave 2 rewrite.
+ * Tests for the emails admin read layer after the Phase 13 Wave 2 migration.
  *
- * The helper now accepts an options object `{ status?, q?, cursor?, direction? }`
- * and returns `{ rows, hasMore, prevCursor, nextCursor }`. We test the
- * CONTRACT and CONTROL FLOW here (PAGE_SIZE+1 read, hasMore detection,
- * cursor encoding, before-direction row reversal, malformed-cursor safety,
- * DB-error safe default, status + search WHERE composition).
+ * `getQueueCounts` now returns `AdminQueryResult<QueueCounts>` (the `catch`
+ * returns `err()`, NOT a falsely-healthy all-zero record), and
+ * `listScheduledEmailsForAdmin` returns `AdminQueryResult<ListScheduledEmailsResult>`
+ * (the `catch` returns `err()`, zero rows return `ok({...})`).
+ * `getScheduledEmailById` returns the 3-way `AdminDetailResult<ScheduledEmail>`
+ * (`found` / `not-found` / `error`). The internal write-helper caller
+ * `retryScheduledEmail` narrows the detail result locally and KEEPS its
+ * existing `RetryResult` contract (`{ ok: false, reason: 'not_found' }` when
+ * the row is absent or the lookup failed), which the retry cases below pin.
+ *
+ * We still test the list CONTRACT and CONTROL FLOW (PAGE_SIZE+1 read, hasMore
+ * detection, cursor encoding, before-direction row reversal, malformed-cursor
+ * safety, status + search WHERE composition).
  *
  * Cursor shape: 2-part `[scheduledFor.toISOString(), id]`. Sort order is
  * `(scheduledFor DESC, id ASC)` for forward pages; flipped for backward.
  * `scheduledFor` is `.notNull()` in the schema so there is NO NULLS-LAST
  * sentinel -- straight 2-part cursor like Plan 10-04 / 10-05.
  *
- * Sanity check on getQueueCounts: assert it is byte-equal-callable (no args,
- * a function) so the page can call it without args and keep the 4 stat cards
- * reflecting the FULL queue regardless of filters.
- *
- * Mock pattern mirrors `tests/unit/admin/leads-queries.test.ts`.
+ * Mock pattern mirrors `tests/unit/admin/showcase-queries.test.ts`: a thenable
+ * chainable mock for `db.select()` (settles to `state.rowsToReturn` on whatever
+ * terminal method the query awaits, covering the list `.limit()`, the
+ * `getQueueCounts` `.groupBy()`, and the `getScheduledEmailById` `.limit(1)`)
+ * plus a stubbed `db.update()` chain that resolves to `state.updateRowsToReturn`
+ * so `retryScheduledEmail` can run its full lookup + update path.
  */
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
@@ -28,6 +37,7 @@ interface MockState {
 	limitArg: number | undefined
 	rowsToReturn: unknown[]
 	shouldThrow: boolean
+	updateRowsToReturn: unknown[]
 }
 
 const state: MockState = {
@@ -35,7 +45,8 @@ const state: MockState = {
 	orderByArgs: [],
 	limitArg: undefined,
 	rowsToReturn: [],
-	shouldThrow: false
+	shouldThrow: false,
+	updateRowsToReturn: []
 }
 
 function resetState(): void {
@@ -44,26 +55,51 @@ function resetState(): void {
 	state.limitArg = undefined
 	state.rowsToReturn = []
 	state.shouldThrow = false
+	state.updateRowsToReturn = []
 }
 
+// Thenable chainable mock for SELECT: every builder method returns the chain,
+// and the chain itself is awaitable. This covers the list query (terminates on
+// `.limit()`), `getQueueCounts` (terminates on `.groupBy()`), and
+// `getScheduledEmailById` (terminates on `.limit(1)`). Whatever terminal
+// method the query awaits, the chain settles to `state.rowsToReturn` (or
+// rejects when `state.shouldThrow`).
 function buildSelectChain(): unknown {
+	const settle = (): Promise<unknown> =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
 	const chain = {
 		from: () => chain,
 		where: (arg: unknown) => {
 			state.whereArg = arg
 			return chain
 		},
+		groupBy: () => settle(),
 		orderBy: (...args: unknown[]) => {
 			state.orderByArgs = args
 			return chain
 		},
 		limit: (n: number) => {
 			state.limitArg = n
-			if (state.shouldThrow) {
-				return Promise.reject(new Error('db down'))
-			}
-			return Promise.resolve(state.rowsToReturn)
-		}
+			return settle()
+		},
+		then: (
+			onFulfilled?: (value: unknown) => unknown,
+			onRejected?: (reason: unknown) => unknown
+		) => settle().then(onFulfilled, onRejected)
+	}
+	return chain
+}
+
+// UPDATE chain used by `retryScheduledEmail`:
+// `db.update(t).set(v).where(c).returning()` resolves to
+// `state.updateRowsToReturn`.
+function buildUpdateChain(): unknown {
+	const chain = {
+		set: () => chain,
+		where: () => chain,
+		returning: () => Promise.resolve(state.updateRowsToReturn)
 	}
 	return chain
 }
@@ -71,7 +107,8 @@ function buildSelectChain(): unknown {
 function setupDbMock(): void {
 	mock.module('@/lib/db', () => ({
 		db: {
-			select: () => buildSelectChain()
+			select: () => buildSelectChain(),
+			update: () => buildUpdateChain()
 		}
 	}))
 }
@@ -84,7 +121,9 @@ setupDbMock()
 
 import {
 	getQueueCounts,
-	listScheduledEmailsForAdmin
+	getScheduledEmailById,
+	listScheduledEmailsForAdmin,
+	retryScheduledEmail
 } from '@/lib/admin/emails-queries'
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
 import { logger } from '@/lib/logger'
@@ -98,6 +137,8 @@ function makeRow(
 		recipientName: string | null
 		stepId: string
 		status: string
+		retryCount: number
+		maxRetries: number
 	}> = {}
 ): Record<string, unknown> {
 	const id = overrides.id ?? `email-${String(idx).padStart(2, '0')}`
@@ -113,8 +154,8 @@ function makeRow(
 		sentAt: null,
 		status: overrides.status ?? 'pending',
 		variables: {},
-		retryCount: 0,
-		maxRetries: 3,
+		retryCount: overrides.retryCount ?? 0,
+		maxRetries: overrides.maxRetries ?? 3,
 		error: null,
 		createdAt: scheduledFor
 	}
@@ -128,6 +169,73 @@ beforeEach(() => {
 	setupDbMock()
 })
 
+describe('getQueueCounts: error vs healthy zero', () => {
+	test('returns ok with a fully-populated counts record on success', async () => {
+		state.rowsToReturn = [
+			{ status: 'pending', count: 3 },
+			{ status: 'sent', count: 10 },
+			{ status: 'failed', count: 2 },
+			{ status: 'cancelled', count: 1 }
+		]
+
+		const result = await getQueueCounts()
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.data).toEqual({
+				pending: 3,
+				sent: 10,
+				failed: 2,
+				cancelled: 1
+			})
+		}
+	})
+
+	test('returns ok with zeros for missing statuses (genuine empty queue)', async () => {
+		state.rowsToReturn = [{ status: 'sent', count: 5 }]
+
+		const result = await getQueueCounts()
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.data).toEqual({
+				pending: 0,
+				sent: 5,
+				failed: 0,
+				cancelled: 0
+			})
+		}
+	})
+
+	test('ignores non-standard status strings (defensive against migrated rows)', async () => {
+		state.rowsToReturn = [
+			{ status: 'pending', count: 4 },
+			{ status: 'bogus', count: 99 }
+		]
+
+		const result = await getQueueCounts()
+
+		expect(result.ok).toBe(true)
+		if (result.ok) {
+			expect(result.data).toEqual({
+				pending: 4,
+				sent: 0,
+				failed: 0,
+				cancelled: 0
+			})
+		}
+	})
+
+	test('returns the error variant + logs once when the query throws (NOT a zero record)', async () => {
+		state.shouldThrow = true
+
+		const result = await getQueueCounts()
+
+		expect(result).toEqual({ ok: false, error: true })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
 describe('listScheduledEmailsForAdmin: page-size + hasMore', () => {
 	test('returns PAGE_SIZE rows + hasMore=true + nextCursor encoded from LAST RETURNED row when DB yields PAGE_SIZE + 1', async () => {
 		const allRows = Array.from({ length: PAGE_SIZE + 1 }, (_, i) => makeRow(i))
@@ -136,15 +244,19 @@ describe('listScheduledEmailsForAdmin: page-size + hasMore', () => {
 		const result = await listScheduledEmailsForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -158,38 +270,40 @@ describe('listScheduledEmailsForAdmin: page-size + hasMore', () => {
 
 		const result = await listScheduledEmailsForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with the empty shape when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listScheduledEmailsForAdmin()
 
 		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
+			ok: true,
+			data: {
+				rows: [],
+				hasMore: false,
+				prevCursor: null,
+				nextCursor: null
+			}
 		})
 	})
 })
 
 describe('listScheduledEmailsForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant + logs error when the query throws (NOT an empty list)', async () => {
 		state.shouldThrow = true
 
 		const result = await listScheduledEmailsForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -245,11 +359,15 @@ describe('listScheduledEmailsForAdmin: cursor + direction', () => {
 
 		const result = await listScheduledEmailsForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -267,17 +385,21 @@ describe('listScheduledEmailsForAdmin: cursor + direction', () => {
 
 		const result = await listScheduledEmailsForAdmin({ cursor: beforeCursor })
 
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `email-${String(i + 1).padStart(2, '0')}`
 		)
 		expect(ids).toEqual(expectedIds)
 
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -294,10 +416,14 @@ describe('listScheduledEmailsForAdmin: cursor + direction', () => {
 
 		const result = await listScheduledEmailsForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -312,16 +438,95 @@ describe('listScheduledEmailsForAdmin: cursor + direction', () => {
 
 		const result = await listScheduledEmailsForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			return
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 })
 
-describe('getQueueCounts: byte-equal signature sanity', () => {
-	test('is still an arity-0 function so the page can call it without args (stat cards stay UNFILTERED)', () => {
-		expect(typeof getQueueCounts).toBe('function')
-		expect(getQueueCounts.length).toBe(0)
+describe('getScheduledEmailById: 3-way detail result', () => {
+	test('returns found(row) when the row exists', async () => {
+		const row = makeRow(0, { id: 'email-found' })
+		state.rowsToReturn = [row]
+
+		const result = await getScheduledEmailById('email-found')
+
+		expect(result.status).toBe('found')
+		if (result.status === 'found') {
+			expect((result.data as { id: string }).id).toBe('email-found')
+		}
+	})
+
+	test('returns not-found when no row exists', async () => {
+		state.rowsToReturn = []
+
+		const result = await getScheduledEmailById('missing')
+
+		expect(result).toEqual({ status: 'not-found' })
+	})
+
+	test('returns error + logs once when the query throws (NOT a 404)', async () => {
+		state.shouldThrow = true
+
+		const result = await getScheduledEmailById('boom')
+
+		expect(result).toEqual({ status: 'error' })
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('retryScheduledEmail: RetryResult contract unchanged after lockstep', () => {
+	test('resets a retriable row and returns { ok: true, row }', async () => {
+		const existing = makeRow(0, {
+			id: 'retry-ok',
+			status: 'failed',
+			retryCount: 1,
+			maxRetries: 3
+		})
+		state.rowsToReturn = [existing]
+		const updated = makeRow(0, { id: 'retry-ok', status: 'pending' })
+		state.updateRowsToReturn = [updated]
+
+		const outcome = await retryScheduledEmail('retry-ok')
+
+		expect(outcome.ok).toBe(true)
+		if (outcome.ok) {
+			expect((outcome.row as { id: string }).id).toBe('retry-ok')
+		}
+	})
+
+	test("returns { ok: false, reason: 'not_found' } when the row is absent", async () => {
+		state.rowsToReturn = []
+
+		const outcome = await retryScheduledEmail('gone')
+
+		expect(outcome).toEqual({ ok: false, reason: 'not_found' })
+	})
+
+	test("returns { ok: false, reason: 'not_found' } when the lookup query fails (error collapses to not_found)", async () => {
+		state.shouldThrow = true
+
+		const outcome = await retryScheduledEmail('boom')
+
+		expect(outcome).toEqual({ ok: false, reason: 'not_found' })
+	})
+
+	test("returns { ok: false, reason: 'max_retries_exceeded' } when retryCount >= maxRetries", async () => {
+		const maxed = makeRow(0, {
+			id: 'retry-maxed',
+			status: 'failed',
+			retryCount: 3,
+			maxRetries: 3
+		})
+		state.rowsToReturn = [maxed]
+
+		const outcome = await retryScheduledEmail('retry-maxed')
+
+		expect(outcome).toEqual({ ok: false, reason: 'max_retries_exceeded' })
 	})
 })

--- a/tests/unit/admin/leads-queries.test.ts
+++ b/tests/unit/admin/leads-queries.test.ts
@@ -41,7 +41,17 @@ function resetState(): void {
 	state.shouldThrow = false
 }
 
+// Thenable chainable mock: every builder method returns the chain, and the
+// chain itself is awaitable. This covers BOTH the list query (terminates on
+// `.limit()`) and `getLeadById`'s three `Promise.all` selects (the lead-row
+// select terminates on `.limit(1)`, the attribution + notes selects terminate
+// on `.orderBy()`). Whatever terminal method the query awaits, the chain
+// settles to `state.rowsToReturn` (or rejects when `state.shouldThrow`).
 function buildSelectChain(): unknown {
+	const settle = (): Promise<unknown> =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
 	const chain = {
 		from: () => chain,
 		where: (arg: unknown) => {
@@ -54,11 +64,12 @@ function buildSelectChain(): unknown {
 		},
 		limit: (n: number) => {
 			state.limitArg = n
-			if (state.shouldThrow) {
-				return Promise.reject(new Error('db down'))
-			}
-			return Promise.resolve(state.rowsToReturn)
-		}
+			return settle()
+		},
+		then: (
+			onFulfilled?: (value: unknown) => unknown,
+			onRejected?: (reason: unknown) => unknown
+		) => settle().then(onFulfilled, onRejected)
 	}
 	return chain
 }
@@ -77,7 +88,7 @@ setupDbMock()
 // real too -- drizzle column refs are just objects, and the helper only
 // passes them to mocked drizzle operators, which the chainable mock ignores.
 
-import { listLeadsForAdmin } from '@/lib/admin/leads-queries'
+import { getLeadById, listLeadsForAdmin } from '@/lib/admin/leads-queries'
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
 import { logger } from '@/lib/logger'
 
@@ -127,15 +138,19 @@ describe('listLeadsForAdmin: page-size + hasMore', () => {
 		const result = await listLeadsForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -149,18 +164,26 @@ describe('listLeadsForAdmin: page-size + hasMore', () => {
 
 		const result = await listLeadsForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listLeadsForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -170,17 +193,12 @@ describe('listLeadsForAdmin: page-size + hasMore', () => {
 })
 
 describe('listLeadsForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listLeadsForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -236,11 +254,15 @@ describe('listLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listLeadsForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -258,17 +280,21 @@ describe('listLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listLeadsForAdmin({ cursor: beforeCursor })
 
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `row-${String(i + 1).padStart(2, '0')}`
 		)
 		expect(ids).toEqual(expectedIds)
 
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -285,10 +311,14 @@ describe('listLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listLeadsForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -303,9 +333,47 @@ describe('listLeadsForAdmin: cursor + direction', () => {
 
 		const result = await listLeadsForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+	})
+})
+
+describe('getLeadById: 3-way detail result', () => {
+	test("returns 'found' with the bundle when the lead row exists", async () => {
+		// The lead-row select, attribution, and notes selects all read
+		// state.rowsToReturn under this harness; a non-empty value means the
+		// lead row is present.
+		state.rowsToReturn = [makeRow(0)]
+
+		const result = await getLeadById('row-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect((result.data.lead as { id: string }).id).toBe('row-00')
+	})
+
+	test("returns 'not-found' when no lead row exists", async () => {
+		state.rowsToReturn = []
+
+		const result = await getLeadById('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the query throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getLeadById('row-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })

--- a/tests/unit/admin/newsletter-queries.test.ts
+++ b/tests/unit/admin/newsletter-queries.test.ts
@@ -79,7 +79,10 @@ setupDbMock()
 // passes them to mocked drizzle operators, which the chainable mock ignores.
 
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
-import { listSubscribersForAdmin } from '@/lib/admin/newsletter-queries'
+import {
+	getSubscriberById,
+	listSubscribersForAdmin
+} from '@/lib/admin/newsletter-queries'
 import { logger } from '@/lib/logger'
 
 function makeRow(
@@ -127,15 +130,19 @@ describe('listSubscribersForAdmin: page-size + hasMore', () => {
 		const result = await listSubscribersForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -149,18 +156,26 @@ describe('listSubscribersForAdmin: page-size + hasMore', () => {
 
 		const result = await listSubscribersForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listSubscribersForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -170,17 +185,12 @@ describe('listSubscribersForAdmin: page-size + hasMore', () => {
 })
 
 describe('listSubscribersForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listSubscribersForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -236,11 +246,15 @@ describe('listSubscribersForAdmin: cursor + direction', () => {
 
 		const result = await listSubscribersForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -258,17 +272,21 @@ describe('listSubscribersForAdmin: cursor + direction', () => {
 
 		const result = await listSubscribersForAdmin({ cursor: beforeCursor })
 
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `sub-${String(i + 1).padStart(2, '0')}`
 		)
 		expect(ids).toEqual(expectedIds)
 
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -285,10 +303,14 @@ describe('listSubscribersForAdmin: cursor + direction', () => {
 
 		const result = await listSubscribersForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -303,10 +325,14 @@ describe('listSubscribersForAdmin: cursor + direction', () => {
 
 		const result = await listSubscribersForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test("NULLS-LAST sentinel: a row with subscribedAt=null encodes to the '\\x00' sentinel in the cursor tuple", async () => {
@@ -323,8 +349,43 @@ describe('listSubscribersForAdmin: cursor + direction', () => {
 
 		const result = await listSubscribersForAdmin()
 
-		expect(result.nextCursor).not.toBeNull()
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.nextCursor).not.toBeNull()
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded?.parts[0]).toBe('\x00')
+	})
+})
+
+describe('getSubscriberById: 3-way detail result', () => {
+	test("returns 'found' with the row when the subscriber exists", async () => {
+		state.rowsToReturn = [makeRow(0)]
+
+		const result = await getSubscriberById('sub-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect((result.data as { id: string }).id).toBe('sub-00')
+	})
+
+	test("returns 'not-found' when no subscriber row exists", async () => {
+		state.rowsToReturn = []
+
+		const result = await getSubscriberById('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the query throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getSubscriberById('sub-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })

--- a/tests/unit/admin/query-result.test.ts
+++ b/tests/unit/admin/query-result.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the shared admin result-type constructors (Phase 13, plan 01).
+ *
+ * These are pure functions with no DB / no I/O, so no mock harness is needed.
+ * We assert each constructor produces the exact discriminated-union shape and
+ * that narrowing works both 2-way (`AdminQueryResult`) and 3-way
+ * (`AdminDetailResult`). The 3-way exhaustiveness is verified at compile time
+ * via a `switch` with an `assertNever` default, and at runtime by routing.
+ */
+import { describe, expect, test } from 'bun:test'
+import {
+	type AdminDetailResult,
+	type AdminQueryResult,
+	err,
+	errResult,
+	found,
+	notFoundResult,
+	ok
+} from '@/lib/admin/query-result'
+
+describe('AdminQueryResult constructors', () => {
+	test('ok(data) produces { ok: true, data } and narrows to expose data', () => {
+		const result: AdminQueryResult<number[]> = ok([1, 2, 3])
+		expect(result).toEqual({ ok: true, data: [1, 2, 3] })
+		// Type narrowing: inside `result.ok === true`, `result.data` is reachable.
+		if (result.ok) {
+			expect(result.data).toEqual([1, 2, 3])
+		} else {
+			throw new Error('expected ok variant')
+		}
+	})
+
+	test('ok(data) carries an empty payload distinctly from err()', () => {
+		const empty: AdminQueryResult<string[]> = ok([])
+		expect(empty).toEqual({ ok: true, data: [] })
+		expect(empty.ok).toBe(true)
+		// A legitimately-empty success is NOT the error variant.
+		expect(empty).not.toEqual(err())
+	})
+
+	test('err() produces { ok: false, error: true } and carries no payload', () => {
+		const result: AdminQueryResult<number> = err()
+		expect(result).toEqual({ ok: false, error: true })
+		expect(result.ok).toBe(false)
+		expect('data' in result).toBe(false)
+	})
+})
+
+describe('AdminDetailResult constructors', () => {
+	test("found(data) produces { status: 'found', data }", () => {
+		const result: AdminDetailResult<{ id: string }> = found({ id: 'abc' })
+		expect(result).toEqual({ status: 'found', data: { id: 'abc' } })
+	})
+
+	test("notFoundResult() produces { status: 'not-found' } with no payload", () => {
+		const result: AdminDetailResult<unknown> = notFoundResult()
+		expect(result).toEqual({ status: 'not-found' })
+		expect('data' in result).toBe(false)
+	})
+
+	test("errResult() produces { status: 'error' } with no payload", () => {
+		const result: AdminDetailResult<unknown> = errResult()
+		expect(result).toEqual({ status: 'error' })
+		expect('data' in result).toBe(false)
+	})
+
+	test('the three detail statuses are mutually exclusive', () => {
+		expect(found({ id: 1 }).status).toBe('found')
+		expect(notFoundResult().status).toBe('not-found')
+		expect(errResult().status).toBe('error')
+	})
+})
+
+describe('AdminDetailResult 3-way narrowing is exhaustive', () => {
+	// Compile-time exhaustiveness guard: if a future variant is added without a
+	// matching case, `assertNever` fails to typecheck.
+	function assertNever(value: never): never {
+		throw new Error(`unexpected variant: ${JSON.stringify(value)}`)
+	}
+
+	function route<T>(result: AdminDetailResult<T>): 'render' | '404' | 'error' {
+		switch (result.status) {
+			case 'found':
+				// `result.data` is reachable only in this branch.
+				void result.data
+				return 'render'
+			case 'not-found':
+				return '404'
+			case 'error':
+				return 'error'
+			default:
+				return assertNever(result)
+		}
+	}
+
+	test('found routes to render', () => {
+		expect(route(found({ id: 'x' }))).toBe('render')
+	})
+
+	test('not-found routes to 404', () => {
+		expect(route(notFoundResult())).toBe('404')
+	})
+
+	test('error routes to error (NOT 404)', () => {
+		expect(route(errResult())).toBe('error')
+	})
+})

--- a/tests/unit/admin/showcase-queries.test.ts
+++ b/tests/unit/admin/showcase-queries.test.ts
@@ -1,17 +1,19 @@
 /**
- * Tests for `listShowcasesForAdmin` after the Phase 10 Wave 2 rewrite.
+ * Tests for the showcase admin read layer after the Phase 13 Wave 2 migration.
  *
- * The helper now accepts an options object `{ q?, cursor?, direction? }`
- * and returns `{ rows, hasMore, prevCursor, nextCursor }`. We test the
- * CONTRACT and CONTROL FLOW here (PAGE_SIZE+1 read, hasMore detection,
- * cursor encoding, before-direction row reversal, malformed-cursor safety,
- * DB-error safe default, search-WHERE composition). The full SQL behavior
- * is exercised in the Wave 3 integration verification pass.
+ * `listShowcasesForAdmin` now returns `AdminQueryResult<ListShowcasesResult>`
+ * (the `catch` returns `err()`, zero rows return `ok({...})`), and
+ * `getShowcaseById` returns the 3-way `AdminDetailResult<ShowcaseRow>`
+ * (`found` / `not-found` / `error`). The two internal write-helper callers
+ * (`updateShowcase`, `toggleShowcasePublished`) narrow the detail result
+ * locally and KEEP their existing `null`-on-absent contract, which the
+ * write-helper cases below pin.
  *
- * Mock pattern mirrors `tests/unit/showcase.test.ts`: chainable mock that
- * captures the `.where()` argument so we can assert composition shape, and
- * a configurable `.limit()` resolution so we can stage different row counts
- * per case.
+ * Mock pattern mirrors `tests/unit/admin/leads-queries.test.ts`: a thenable
+ * chainable mock for `db.select()` (the chain settles to `state.rowsToReturn`
+ * on whatever terminal method the query awaits) plus a stubbed `db.update()`
+ * chain that resolves to `state.updateRowsToReturn` so the write helpers can
+ * run their full path against the mock.
  */
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
@@ -23,6 +25,7 @@ interface MockState {
 	limitArg: number | undefined
 	rowsToReturn: unknown[]
 	shouldThrow: boolean
+	updateRowsToReturn: unknown[]
 }
 
 const state: MockState = {
@@ -30,7 +33,8 @@ const state: MockState = {
 	orderByArgs: [],
 	limitArg: undefined,
 	rowsToReturn: [],
-	shouldThrow: false
+	shouldThrow: false,
+	updateRowsToReturn: []
 }
 
 function resetState(): void {
@@ -39,9 +43,19 @@ function resetState(): void {
 	state.limitArg = undefined
 	state.rowsToReturn = []
 	state.shouldThrow = false
+	state.updateRowsToReturn = []
 }
 
+// Thenable chainable mock for SELECT: every builder method returns the chain,
+// and the chain itself is awaitable. This covers BOTH the list query
+// (terminates on `.limit()`) and `getShowcaseById` (terminates on `.limit(1)`).
+// Whatever terminal method the query awaits, the chain settles to
+// `state.rowsToReturn` (or rejects when `state.shouldThrow`).
 function buildSelectChain(): unknown {
+	const settle = (): Promise<unknown> =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
 	const chain = {
 		from: () => chain,
 		where: (arg: unknown) => {
@@ -54,11 +68,24 @@ function buildSelectChain(): unknown {
 		},
 		limit: (n: number) => {
 			state.limitArg = n
-			if (state.shouldThrow) {
-				return Promise.reject(new Error('db down'))
-			}
-			return Promise.resolve(state.rowsToReturn)
-		}
+			return settle()
+		},
+		then: (
+			onFulfilled?: (value: unknown) => unknown,
+			onRejected?: (reason: unknown) => unknown
+		) => settle().then(onFulfilled, onRejected)
+	}
+	return chain
+}
+
+// UPDATE chain used by `updateShowcase` / `toggleShowcasePublished`:
+// `db.update(t).set(v).where(c).returning()` resolves to
+// `state.updateRowsToReturn`.
+function buildUpdateChain(): unknown {
+	const chain = {
+		set: () => chain,
+		where: () => chain,
+		returning: () => Promise.resolve(state.updateRowsToReturn)
 	}
 	return chain
 }
@@ -66,7 +93,8 @@ function buildSelectChain(): unknown {
 function setupDbMock(): void {
 	mock.module('@/lib/db', () => ({
 		db: {
-			select: () => buildSelectChain()
+			select: () => buildSelectChain(),
+			update: () => buildUpdateChain()
 		}
 	}))
 }
@@ -78,7 +106,12 @@ setupDbMock()
 // passes them to mocked drizzle operators, which the chainable mock ignores.
 
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
-import { listShowcasesForAdmin } from '@/lib/admin/showcase-queries'
+import {
+	getShowcaseById,
+	listShowcasesForAdmin,
+	toggleShowcasePublished,
+	updateShowcase
+} from '@/lib/admin/showcase-queries'
 import { logger } from '@/lib/logger'
 
 function makeRow(
@@ -87,6 +120,8 @@ function makeRow(
 		id: string
 		displayOrder: number | null
 		createdAt: Date | null
+		published: boolean
+		publishedAt: Date | null
 	}> = {}
 ): Record<string, unknown> {
 	const id = overrides.id ?? `row-${String(idx).padStart(2, '0')}`
@@ -106,9 +141,9 @@ function makeRow(
 		description: 'desc',
 		showcaseType: 'quick',
 		featured: false,
-		published: true,
+		published: overrides.published ?? true,
 		displayOrder,
-		publishedAt: null,
+		publishedAt: overrides.publishedAt ?? null,
 		createdAt,
 		updatedAt: createdAt
 	}
@@ -130,15 +165,19 @@ describe('listShowcasesForAdmin: page-size + hasMore', () => {
 		const result = await listShowcasesForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -153,18 +192,26 @@ describe('listShowcasesForAdmin: page-size + hasMore', () => {
 
 		const result = await listShowcasesForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listShowcasesForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -174,17 +221,12 @@ describe('listShowcasesForAdmin: page-size + hasMore', () => {
 })
 
 describe('listShowcasesForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listShowcasesForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -225,11 +267,15 @@ describe('listShowcasesForAdmin: cursor + direction', () => {
 
 		const result = await listShowcasesForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -251,8 +297,12 @@ describe('listShowcasesForAdmin: cursor + direction', () => {
 
 		const result = await listShowcasesForAdmin({ cursor: beforeCursor })
 
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
 		// Rows must be reversed back into display order (ascending idx)
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `row-${String(i + 1).padStart(2, '0')}`
@@ -260,11 +310,11 @@ describe('listShowcasesForAdmin: cursor + direction', () => {
 		expect(ids).toEqual(expectedIds)
 
 		// prevCursor stays set because hasMore=true (more rows backward)
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
 		// nextCursor also set because we navigated backward (page exists forward)
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test("'after' cursor with PAGE_SIZE+1 result emits both prev (after navigation) and next cursor", async () => {
@@ -279,10 +329,14 @@ describe('listShowcasesForAdmin: cursor + direction', () => {
 
 		const result = await listShowcasesForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -303,10 +357,125 @@ describe('listShowcasesForAdmin: cursor + direction', () => {
 
 		const result = await listShowcasesForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
+	})
+})
+
+describe('getShowcaseById: 3-way detail result', () => {
+	test("returns 'found' with the row when it exists", async () => {
+		state.rowsToReturn = [makeRow(0)]
+
+		const result = await getShowcaseById('row-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect(result.data.id).toBe('row-00')
+	})
+
+	test("returns 'not-found' when no row exists", async () => {
+		state.rowsToReturn = []
+
+		const result = await getShowcaseById('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the query throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getShowcaseById('row-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('write helpers keep their null-on-absent contract after the get*ById migration', () => {
+	test('updateShowcase returns the updated row when the row exists', async () => {
+		state.rowsToReturn = [makeRow(0, { published: true })]
+		const updated = makeRow(0, { published: true })
+		state.updateRowsToReturn = [updated]
+
+		const row = await updateShowcase('row-00', {
+			title: 'Updated',
+			slug: 'updated',
+			description: 'desc',
+			showcaseType: 'quick',
+			featured: false,
+			published: true,
+			displayOrder: 0
+		} as Parameters<typeof updateShowcase>[1])
+
+		expect(row).not.toBeNull()
+		expect((row as { id: string }).id).toBe('row-00')
+	})
+
+	test('updateShowcase returns null when the row does not exist', async () => {
+		state.rowsToReturn = []
+
+		const row = await updateShowcase('missing', {
+			title: 'Updated',
+			slug: 'updated',
+			description: 'desc',
+			showcaseType: 'quick',
+			featured: false,
+			published: true,
+			displayOrder: 0
+		} as Parameters<typeof updateShowcase>[1])
+
+		expect(row).toBeNull()
+	})
+
+	test('updateShowcase returns null when the lookup query throws (error narrowed to null)', async () => {
+		state.shouldThrow = true
+
+		const row = await updateShowcase('row-00', {
+			title: 'Updated',
+			slug: 'updated',
+			description: 'desc',
+			showcaseType: 'quick',
+			featured: false,
+			published: true,
+			displayOrder: 0
+		} as Parameters<typeof updateShowcase>[1])
+
+		expect(row).toBeNull()
+	})
+
+	test('toggleShowcasePublished flips published + returns the updated row when it exists', async () => {
+		state.rowsToReturn = [makeRow(0, { published: false, publishedAt: null })]
+		const toggled = makeRow(0, { published: true })
+		state.updateRowsToReturn = [toggled]
+
+		const row = await toggleShowcasePublished('row-00')
+
+		expect(row).not.toBeNull()
+		expect((row as { id: string }).id).toBe('row-00')
+	})
+
+	test('toggleShowcasePublished returns null when the row does not exist', async () => {
+		state.rowsToReturn = []
+
+		const row = await toggleShowcasePublished('missing')
+
+		expect(row).toBeNull()
+	})
+
+	test('toggleShowcasePublished returns null when the lookup query throws (error narrowed to null)', async () => {
+		state.shouldThrow = true
+
+		const row = await toggleShowcasePublished('row-00')
+
+		expect(row).toBeNull()
 	})
 })

--- a/tests/unit/admin/testimonials-queries.test.ts
+++ b/tests/unit/admin/testimonials-queries.test.ts
@@ -1,17 +1,28 @@
 /**
- * Tests for `listTestimonialsForAdmin` after the Phase 10 Wave 2 rewrite.
+ * Tests for the testimonials admin read layer after the Phase 13 Wave 2
+ * migration.
  *
- * The helper now accepts an options object `{ q?, cursor?, direction? }`
- * and returns `{ rows, hasMore, prevCursor, nextCursor }`. We test the
- * CONTRACT and CONTROL FLOW here (PAGE_SIZE+1 read, hasMore detection,
- * cursor encoding, before-direction row reversal, malformed-cursor safety,
- * DB-error safe default, search-WHERE composition). The full SQL behavior
- * is exercised in the Wave 3 integration verification pass.
+ * `listTestimonialsForAdmin` now returns `AdminQueryResult<ListTestimonialsResult>`
+ * (the `catch` returns `err()`, zero rows return `ok({...})`), and
+ * `getTestimonialById` returns the 3-way `AdminDetailResult<TestimonialRow>`
+ * (`found` / `not-found` / `error`). The single internal write-helper caller
+ * (`toggleTestimonialPublished`) narrows the detail result locally and KEEPS
+ * its existing `null`-on-absent contract, which the write-helper cases below
+ * pin.
+ *
+ * We test the CONTRACT and CONTROL FLOW here (PAGE_SIZE+1 read, hasMore
+ * detection, cursor encoding, before-direction row reversal, malformed-cursor
+ * safety, DB-error variant, search-WHERE composition, 3-way detail, write-helper
+ * null contract). The full SQL behavior is exercised in the integration pass.
  *
  * Cursor shape: 2-part `[createdAt.toISOString(), id]`. Sort order is
  * `(createdAt DESC, id ASC)` for forward pages; flipped for backward.
  *
- * Mock pattern mirrors `tests/unit/admin/showcase-queries.test.ts`.
+ * Mock pattern mirrors `tests/unit/admin/showcase-queries.test.ts`: a thenable
+ * chainable mock for `db.select()` (the chain settles to `state.rowsToReturn`
+ * on whatever terminal method the query awaits) plus a stubbed `db.update()`
+ * chain that resolves to `state.updateRowsToReturn` so the write helper can run
+ * its full path against the mock.
  */
 import { beforeEach, describe, expect, mock, test } from 'bun:test'
 
@@ -23,6 +34,7 @@ interface MockState {
 	limitArg: number | undefined
 	rowsToReturn: unknown[]
 	shouldThrow: boolean
+	updateRowsToReturn: unknown[]
 }
 
 const state: MockState = {
@@ -30,7 +42,8 @@ const state: MockState = {
 	orderByArgs: [],
 	limitArg: undefined,
 	rowsToReturn: [],
-	shouldThrow: false
+	shouldThrow: false,
+	updateRowsToReturn: []
 }
 
 function resetState(): void {
@@ -39,9 +52,19 @@ function resetState(): void {
 	state.limitArg = undefined
 	state.rowsToReturn = []
 	state.shouldThrow = false
+	state.updateRowsToReturn = []
 }
 
+// Thenable chainable mock for SELECT: every builder method returns the chain,
+// and the chain itself is awaitable. This covers BOTH the list query
+// (terminates on `.limit()`) and `getTestimonialById` (terminates on
+// `.limit(1)`). Whatever terminal method the query awaits, the chain settles to
+// `state.rowsToReturn` (or rejects when `state.shouldThrow`).
 function buildSelectChain(): unknown {
+	const settle = (): Promise<unknown> =>
+		state.shouldThrow
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(state.rowsToReturn)
 	const chain = {
 		from: () => chain,
 		where: (arg: unknown) => {
@@ -54,11 +77,24 @@ function buildSelectChain(): unknown {
 		},
 		limit: (n: number) => {
 			state.limitArg = n
-			if (state.shouldThrow) {
-				return Promise.reject(new Error('db down'))
-			}
-			return Promise.resolve(state.rowsToReturn)
-		}
+			return settle()
+		},
+		then: (
+			onFulfilled?: (value: unknown) => unknown,
+			onRejected?: (reason: unknown) => unknown
+		) => settle().then(onFulfilled, onRejected)
+	}
+	return chain
+}
+
+// UPDATE chain used by `toggleTestimonialPublished`:
+// `db.update(t).set(v).where(c).returning()` resolves to
+// `state.updateRowsToReturn`.
+function buildUpdateChain(): unknown {
+	const chain = {
+		set: () => chain,
+		where: () => chain,
+		returning: () => Promise.resolve(state.updateRowsToReturn)
 	}
 	return chain
 }
@@ -66,7 +102,8 @@ function buildSelectChain(): unknown {
 function setupDbMock(): void {
 	mock.module('@/lib/db', () => ({
 		db: {
-			select: () => buildSelectChain()
+			select: () => buildSelectChain(),
+			update: () => buildUpdateChain()
 		}
 	}))
 }
@@ -78,7 +115,11 @@ setupDbMock()
 // passes them to mocked drizzle operators, which the chainable mock ignores.
 
 import { decodeCursor, encodeCursor, PAGE_SIZE } from '@/lib/admin/list-cursor'
-import { listTestimonialsForAdmin } from '@/lib/admin/testimonials-queries'
+import {
+	getTestimonialById,
+	listTestimonialsForAdmin,
+	toggleTestimonialPublished
+} from '@/lib/admin/testimonials-queries'
 import { logger } from '@/lib/logger'
 
 function makeRow(
@@ -89,6 +130,7 @@ function makeRow(
 		name: string
 		company: string | null
 		content: string
+		published: boolean
 	}> = {}
 ): Record<string, unknown> {
 	const id = overrides.id ?? `row-${String(idx).padStart(2, '0')}`
@@ -109,7 +151,7 @@ function makeRow(
 		imageUrl: null,
 		videoUrl: null,
 		featured: false,
-		published: true,
+		published: overrides.published ?? true,
 		createdAt,
 		updatedAt: createdAt
 	}
@@ -131,15 +173,19 @@ describe('listTestimonialsForAdmin: page-size + hasMore', () => {
 		const result = await listTestimonialsForAdmin()
 
 		expect(state.limitArg).toBe(PAGE_SIZE + 1)
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 
 		// nextCursor must encode the LAST RETURNED row (index PAGE_SIZE - 1),
 		// NOT the sentinel row that was dropped.
 		const lastReturned = allRows[PAGE_SIZE - 1] as ReturnType<typeof makeRow>
-		const decoded = decodeCursor(result.nextCursor ?? undefined)
+		const decoded = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decoded).not.toBeNull()
 		expect(decoded?.direction).toBe('after')
 		expect(decoded?.parts).toEqual([
@@ -153,18 +199,26 @@ describe('listTestimonialsForAdmin: page-size + hasMore', () => {
 
 		const result = await listTestimonialsForAdmin()
 
-		expect(result.rows.length).toBe(3)
-		expect(result.hasMore).toBe(false)
-		expect(result.nextCursor).toBeNull()
-		expect(result.prevCursor).toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(3)
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.nextCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
-	test('returns empty shape when DB yields zero rows', async () => {
+	test('returns ok with empty rows when DB yields zero rows (distinct from error)', async () => {
 		state.rowsToReturn = []
 
 		const result = await listTestimonialsForAdmin()
 
-		expect(result).toEqual({
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data).toEqual({
 			rows: [],
 			hasMore: false,
 			prevCursor: null,
@@ -174,17 +228,12 @@ describe('listTestimonialsForAdmin: page-size + hasMore', () => {
 })
 
 describe('listTestimonialsForAdmin: DB error safety', () => {
-	test('returns empty result + logs error when the query throws', async () => {
+	test('returns the error variant (not an empty result) + logs once when the query throws', async () => {
 		state.shouldThrow = true
 
 		const result = await listTestimonialsForAdmin()
 
-		expect(result).toEqual({
-			rows: [],
-			hasMore: false,
-			prevCursor: null,
-			nextCursor: null
-		})
+		expect(result).toEqual({ ok: false, error: true })
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })
@@ -225,11 +274,15 @@ describe('listTestimonialsForAdmin: cursor + direction', () => {
 
 		const result = await listTestimonialsForAdmin({ cursor: 'not-a-cursor' })
 
-		expect(result.rows.length).toBe(1)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(1)
 		// page 1 fall-back: WHERE is undefined (no cursor predicate)
 		expect(state.whereArg).toBeUndefined()
 		// prevCursor stays null because the malformed cursor was discarded
-		expect(result.prevCursor).toBeNull()
+		expect(result.data.prevCursor).toBeNull()
 	})
 
 	test("'before' cursor reverses ORDER BY and rows come back in display order", async () => {
@@ -248,17 +301,21 @@ describe('listTestimonialsForAdmin: cursor + direction', () => {
 
 		const result = await listTestimonialsForAdmin({ cursor: beforeCursor })
 
-		const ids = result.rows.map(r => (r as { id: string }).id)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		const ids = result.data.rows.map(r => (r as { id: string }).id)
 		const expectedIds = Array.from(
 			{ length: PAGE_SIZE },
 			(_, i) => `row-${String(i + 1).padStart(2, '0')}`
 		)
 		expect(ids).toEqual(expectedIds)
 
-		expect(result.prevCursor).not.toBeNull()
-		const decodedPrev = decodeCursor(result.prevCursor ?? undefined)
+		expect(result.data.prevCursor).not.toBeNull()
+		const decodedPrev = decodeCursor(result.data.prevCursor ?? undefined)
 		expect(decodedPrev?.direction).toBe('before')
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
 	})
 
 	test('emits nextCursor + nulls prevCursor when arriving on page 1 via backward navigation (direction=before, hasMore=false)', async () => {
@@ -275,10 +332,14 @@ describe('listTestimonialsForAdmin: cursor + direction', () => {
 
 		const result = await listTestimonialsForAdmin({ cursor: beforeCursor })
 
-		expect(result.hasMore).toBe(false)
-		expect(result.prevCursor).toBeNull()
-		expect(result.nextCursor).not.toBeNull()
-		const decodedNext = decodeCursor(result.nextCursor ?? undefined)
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.hasMore).toBe(false)
+		expect(result.data.prevCursor).toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+		const decodedNext = decodeCursor(result.data.nextCursor ?? undefined)
 		expect(decodedNext?.direction).toBe('after')
 	})
 
@@ -293,9 +354,73 @@ describe('listTestimonialsForAdmin: cursor + direction', () => {
 
 		const result = await listTestimonialsForAdmin({ cursor: afterCursor })
 
-		expect(result.rows.length).toBe(PAGE_SIZE)
-		expect(result.hasMore).toBe(true)
-		expect(result.prevCursor).not.toBeNull()
-		expect(result.nextCursor).not.toBeNull()
+		expect(result.ok).toBe(true)
+		if (!result.ok) {
+			throw new Error('expected ok result')
+		}
+		expect(result.data.rows.length).toBe(PAGE_SIZE)
+		expect(result.data.hasMore).toBe(true)
+		expect(result.data.prevCursor).not.toBeNull()
+		expect(result.data.nextCursor).not.toBeNull()
+	})
+})
+
+describe('getTestimonialById: 3-way detail result', () => {
+	test("returns 'found' with the row when it exists", async () => {
+		state.rowsToReturn = [makeRow(0)]
+
+		const result = await getTestimonialById('row-00')
+
+		expect(result.status).toBe('found')
+		if (result.status !== 'found') {
+			throw new Error('expected found result')
+		}
+		expect(result.data.id).toBe('row-00')
+	})
+
+	test("returns 'not-found' when no row exists", async () => {
+		state.rowsToReturn = []
+
+		const result = await getTestimonialById('missing')
+
+		expect(result.status).toBe('not-found')
+	})
+
+	test("returns 'error' + logs once when the query throws", async () => {
+		state.shouldThrow = true
+
+		const result = await getTestimonialById('row-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+})
+
+describe('toggleTestimonialPublished keeps its null-on-absent contract after the get*ById migration', () => {
+	test('flips published + returns the updated row when it exists', async () => {
+		state.rowsToReturn = [makeRow(0, { published: false })]
+		const toggled = makeRow(0, { published: true })
+		state.updateRowsToReturn = [toggled]
+
+		const row = await toggleTestimonialPublished('row-00')
+
+		expect(row).not.toBeNull()
+		expect((row as { id: string }).id).toBe('row-00')
+	})
+
+	test('returns null when the row does not exist', async () => {
+		state.rowsToReturn = []
+
+		const row = await toggleTestimonialPublished('missing')
+
+		expect(row).toBeNull()
+	})
+
+	test('returns null when the lookup query throws (error narrowed to null)', async () => {
+		state.shouldThrow = true
+
+		const row = await toggleTestimonialPublished('row-00')
+
+		expect(row).toBeNull()
 	})
 })


### PR DESCRIPTION
## What

Admin read surfaces now tell the operator the truth when a query fails, instead of silently showing an empty list, a healthy-looking zeroed queue, or a misleading 404.

Previously every admin query caught DB errors and returned `[]` / `null` / an all-zero count, so a real failure was indistinguishable from genuinely-empty data. This implements the v6 decision **"full error states everywhere"**, which supersedes the v4 "each query returns [] on failure" lock — while preserving the v4 resilience intent (one failing widget must not blank the page).

## How

- **New `src/lib/admin/query-result.ts`** — discriminated unions: `AdminQueryResult<T>` (`{ok:true,data} | {ok:false,error:true}`) for lists/widgets/queue, and a 3-way `AdminDetailResult<T>` (`found | not-found | error`) for `get*ById`. Queries **return** these (they never throw), so per-widget resilience is preserved (a `Promise.all` of widget queries never rejects).
- **New `src/components/admin/AdminErrorState.tsx`** on the shadcn `Alert` primitive (`role="alert"`, never renders the raw exception).
- All 8 `*-queries.ts` files migrated; `logger.error` retained on every catch.

## Per requirement

- **ADMINERR-01** — list pages render `AdminErrorState` on failure; empty-state only on genuine zero rows.
- **ADMINERR-02** — the 5 dashboard widgets each render their own inline error card; a failing widget does not blank the others or the page.
- **ADMINERR-03** — `getQueueCounts` returns the error variant (no more falsely-healthy zeros); `/admin/emails` shows one grid-spanning error state.
- **ADMINERR-04** — all 7 detail pages call `notFound()` only on `not-found` and render an error state on a DB error (a transient failure is never a 404); the `BUILD_PLACEHOLDER_ID` short-circuit is preserved (no PPR regression). The 6 internal write-helper callers of `get*ById` were migrated in lockstep.

## Verification

`bun run lint` clean - `bun run typecheck` clean - `bun run build` succeeds (all `/admin/**` routes still PPR with the `__build_placeholder__` param). Admin/query unit suite 252/0. Full suite has only the pre-existing, unrelated homepage/navigation RTL test-pollution failures (0 net-new). Invariants: zero `EMPTY_RESULT`/`return []` in admin queries; `query-result.ts` has no `server-only`; error states never leak the exception.

[hudsor01]