### PR TITLE
test(admin): lock phase-13 consumer-layer guarantees (notFound-vs-error, widget resilience)

### DIFF
--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -253,6 +253,17 @@ export function setupNextMocks() {
 	// Real next/link works perfectly in tests and uses native history API
 	// See: https://github.com/vercel/next.js/discussions/48110
 
+	// Include the FULL next/navigation surface, not just the hooks this helper's
+	// callers use. bun's `mock.module` is a process-wide registry and freezes a
+	// module's static-import link on first import; a partial mock here (missing
+	// `redirect` / `notFound`) poisons the link for any later test that imports a
+	// server module doing `import { redirect } from 'next/navigation'` (every
+	// admin `actions.ts`), surfacing as "Export named 'redirect' not found". The
+	// server control-flow signals faithfully throw their Next digest-style
+	// errors so consumers' control flow halts as in production.
+	const redirect = () => {
+		throw new Error('NEXT_REDIRECT')
+	}
 	mock.module('next/navigation', () => ({
 		useRouter: () => ({
 			push: mock(),
@@ -260,7 +271,19 @@ export function setupNextMocks() {
 			prefetch: mock()
 		}),
 		usePathname: () => '/',
-		useSearchParams: () => new URLSearchParams()
+		useSearchParams: () => new URLSearchParams(),
+		useParams: () => ({}),
+		notFound: () => {
+			throw new Error('NEXT_NOT_FOUND')
+		},
+		redirect,
+		permanentRedirect: redirect,
+		forbidden: () => {
+			throw new Error('NEXT_FORBIDDEN')
+		},
+		unauthorized: () => {
+			throw new Error('NEXT_UNAUTHORIZED')
+		}
 	}))
 
 	mock.module('next/dynamic', () => ({

--- a/tests/unit/admin-image-upload.test.ts
+++ b/tests/unit/admin-image-upload.test.ts
@@ -61,8 +61,14 @@ function makeRequest(body: unknown): Request {
 describe('POST /api/admin/images/upload', () => {
 	beforeEach(() => {
 		testEnv.BLOB_READ_WRITE_TOKEN = undefined
-		// Default handleUpload stub — individual tests can override.
+		// Default handleUpload stub — individual tests can override. Include the
+		// `upload` named export too: `@vercel/blob/client` is a CJS-interop module
+		// whose named exports bun cannot statically analyze, so a PARTIAL mock here
+		// poisons the process-wide static-import LINK for any later test whose
+		// graph reaches `import { upload }` (src/hooks/use-blob-upload.ts via the
+		// admin edit form islands), surfacing as "Export named 'upload' not found".
 		mock.module('@vercel/blob/client', () => ({
+			upload: async () => ({ url: 'https://example.test/blob' }),
 			handleUpload: async () => ({
 				type: 'blob.generate-client-token',
 				clientToken: 'fake'
@@ -118,6 +124,7 @@ describe('POST /api/admin/images/upload', () => {
 	it('delegates to handleUpload and returns its JSON when token is set and body parses', async () => {
 		testEnv.BLOB_READ_WRITE_TOKEN = 'fake-token-for-test'
 		mock.module('@vercel/blob/client', () => ({
+			upload: async () => ({ url: 'https://example.test/blob' }),
 			handleUpload: async () => ({
 				type: 'blob.generate-client-token',
 				clientToken: 'minted-test-token'
@@ -144,6 +151,7 @@ describe('POST /api/admin/images/upload', () => {
 	it('returns 500 when handleUpload throws', async () => {
 		testEnv.BLOB_READ_WRITE_TOKEN = 'fake-token-for-test'
 		mock.module('@vercel/blob/client', () => ({
+			upload: async () => ({ url: 'https://example.test/blob' }),
 			handleUpload: async () => {
 				throw new Error('Boom — simulated failure')
 			}

--- a/tests/unit/admin/blog-queries.test.ts
+++ b/tests/unit/admin/blog-queries.test.ts
@@ -41,6 +41,11 @@ interface MockState {
 	// Toggle which next select() call mode we are in (post-list vs tag-lookup).
 	selectMode: 'post-list' | 'tag-lookup'
 	shouldThrow: boolean
+	// When true, the tag-lookup chain (`loadTagIdsForPosts().where()`) REJECTS
+	// rather than resolving. Lets a case make the post select succeed while the
+	// tag await throws -- still a read failure, so the detail read must return
+	// the error variant (NOT a 404).
+	tagThrow: boolean
 	// Rows returned by the `db.update(...).set(...).where(...).returning()`
 	// chain that `toggleBlogPostPublished` runs (and the `tx.update(...)` chain
 	// inside `updateBlogPost`'s transaction).
@@ -57,6 +62,7 @@ const state: MockState = {
 	tagLookupIds: undefined,
 	selectMode: 'post-list',
 	shouldThrow: false,
+	tagThrow: false,
 	updateRowsToReturn: []
 }
 
@@ -70,6 +76,7 @@ function resetState(): void {
 	state.tagLookupIds = undefined
 	state.selectMode = 'post-list'
 	state.shouldThrow = false
+	state.tagThrow = false
 	state.updateRowsToReturn = []
 }
 
@@ -130,7 +137,10 @@ function buildPostListChain(): unknown {
 function buildTagLookupChain(): unknown {
 	const chain = {
 		from: () => chain,
-		where: () => Promise.resolve(state.tagRowsToReturn)
+		where: () =>
+			state.tagThrow
+				? Promise.reject(new Error('tag lookup down'))
+				: Promise.resolve(state.tagRowsToReturn)
 	}
 	return chain
 }
@@ -528,6 +538,21 @@ describe('getBlogPostForAdmin: 3-way detail result', () => {
 
 	test("returns 'error' + logs once when the post select throws", async () => {
 		state.shouldThrow = true
+
+		const result = await getBlogPostForAdmin('post-00')
+
+		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test("returns 'error' (NOT not-found, NOT a 404) when the post select SUCCEEDS but the tag lookup throws", async () => {
+		// The post row is present, so the row-existence check passes; the failure
+		// happens later, in the `await loadTagIdsForPosts([id])` step. The
+		// documented contract (blog-queries.ts: "a throw HERE ... is still a read
+		// failure") is that this must yield the error variant, not a misleading
+		// 'not-found' / 404.
+		state.postRowsToReturn = [makeRow(0, { id: 'post-00' })]
+		state.tagThrow = true
 
 		const result = await getBlogPostForAdmin('post-00')
 

--- a/tests/unit/admin/dashboard-widget-resilience.test.tsx
+++ b/tests/unit/admin/dashboard-widget-resilience.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Phase 13 consumer-layer regression armor: per-widget dashboard resilience
+ * (ADMINERR-01..03, the v4 per-widget isolation contract).
+ *
+ * Each dashboard widget receives its OWN `AdminQueryResult` and renders its own
+ * inline `AdminErrorState` on the error variant, while a healthy result renders
+ * the widget's content. Because every dashboard query RETURNS its failure (the
+ * error variant) rather than throwing, the page's `Promise.all` never rejects
+ * and one failed widget cannot blank the page: the other widgets still render.
+ *
+ * These render tests lock that boundary at the component level (mirroring
+ * project-card.test.tsx; happy-dom is registered in tests/setup.ts):
+ *   - error variant  -> a `role="alert"` AdminErrorState card appears with the
+ *                       widget's resource label.
+ *   - ok variant     -> the widget's real content renders and NO alert appears.
+ *   - a mixed dashboard render (4 ok + 1 err) -> exactly ONE alert, and the
+ *     healthy widgets' content is still present.
+ *
+ * The two recharts widgets (VisitorsChart, TrafficSourcesPie) are tested on
+ * their error + empty branches only, which return before any recharts element
+ * is constructed; their full chart render needs browser layout APIs recharts
+ * cannot get in happy-dom. The mixed-dashboard test mocks recharts to a
+ * passthrough so the real widget tree renders.
+ */
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+import { render, within } from '@testing-library/react'
+import { RecentLeadsPanel } from '@/components/admin/widgets/RecentLeadsPanel'
+import { TopPagesTable } from '@/components/admin/widgets/TopPagesTable'
+import { WebVitalsCards } from '@/components/admin/widgets/WebVitalsCards'
+import { err, ok } from '@/lib/admin/query-result'
+
+const NOW = new Date('2026-01-15T12:00:00.000Z')
+
+describe('RecentLeadsPanel resilience', () => {
+	test('error variant renders AdminErrorState (not the empty-state copy)', () => {
+		const { container } = render(<RecentLeadsPanel result={err()} />)
+		expect(within(container).getByRole('alert')).toBeTruthy()
+		expect(container.textContent).toContain('Could not load recent leads')
+		// The error state must NOT be confused with the "no data" empty state.
+		expect(container.textContent).not.toContain('No leads yet.')
+	})
+
+	test('ok variant renders the lead rows and shows NO alert', () => {
+		const { container } = render(
+			<RecentLeadsPanel
+				result={ok([
+					{
+						id: 'l-1',
+						email: 'alice@example.com',
+						source: 'organic',
+						status: 'new',
+						createdAt: NOW
+					}
+				])}
+			/>
+		)
+		expect(container.textContent).toContain('alice@example.com')
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+
+	test('ok-but-empty variant renders the empty state, NOT the error state', () => {
+		const { container } = render(<RecentLeadsPanel result={ok([])} />)
+		expect(container.textContent).toContain('No leads yet.')
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+})
+
+describe('TopPagesTable resilience', () => {
+	test('error variant renders AdminErrorState', () => {
+		const { container } = render(<TopPagesTable result={err()} />)
+		expect(within(container).getByRole('alert')).toBeTruthy()
+		expect(container.textContent).toContain('Could not load page analytics')
+		expect(container.querySelector('table')).toBeFalsy()
+	})
+
+	test('ok variant renders the table rows and shows NO alert', () => {
+		const { container } = render(
+			<TopPagesTable
+				result={ok([
+					{ pathname: '/pricing', pageviews: 1234, uniqueVisitors: 567 }
+				])}
+			/>
+		)
+		expect(container.querySelector('table')).toBeTruthy()
+		expect(container.textContent).toContain('/pricing')
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+})
+
+describe('WebVitalsCards resilience (top-level error branch)', () => {
+	test('error variant renders AdminErrorState and no KPI grid', () => {
+		const { container } = render(<WebVitalsCards result={err()} />)
+		expect(within(container).getByRole('alert')).toBeTruthy()
+		expect(container.textContent).toContain('Could not load web vitals')
+	})
+
+	test('ok variant renders the six CWV KPI labels and shows NO alert', () => {
+		const { container } = render(
+			<WebVitalsCards
+				result={ok([{ name: 'LCP', p75: 1800, sampleCount: 42 }])}
+			/>
+		)
+		for (const name of ['CLS', 'FCP', 'FID', 'INP', 'LCP', 'TTFB']) {
+			expect(container.textContent).toContain(name)
+		}
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+})
+
+// The recharts widgets: error + empty branches return before any recharts
+// element is built, so they render safely in happy-dom without a recharts mock.
+describe('recharts widgets: error + empty branches', () => {
+	test('VisitorsChart error variant renders AdminErrorState (no chart)', async () => {
+		const { VisitorsChart } = await import(
+			'@/components/admin/widgets/VisitorsChart'
+		)
+		const { container } = render(<VisitorsChart result={err()} />)
+		expect(within(container).getByRole('alert')).toBeTruthy()
+		expect(container.textContent).toContain('Could not load traffic data')
+		expect(container.querySelector('[role="img"]')).toBeFalsy()
+	})
+
+	test('VisitorsChart ok-but-empty renders the empty state, NOT the error state', async () => {
+		const { VisitorsChart } = await import(
+			'@/components/admin/widgets/VisitorsChart'
+		)
+		const { container } = render(<VisitorsChart result={ok([])} />)
+		expect(container.textContent).toContain('No traffic data yet.')
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+
+	test('TrafficSourcesPie error variant renders AdminErrorState (no chart)', async () => {
+		const { TrafficSourcesPie } = await import(
+			'@/components/admin/widgets/TrafficSourcesPie'
+		)
+		const { container } = render(<TrafficSourcesPie result={err()} />)
+		expect(within(container).getByRole('alert')).toBeTruthy()
+		expect(container.textContent).toContain(
+			'Could not load traffic source data'
+		)
+		expect(container.querySelector('[role="img"]')).toBeFalsy()
+	})
+
+	test('TrafficSourcesPie ok-but-empty renders the empty state, NOT the error state', async () => {
+		const { TrafficSourcesPie } = await import(
+			'@/components/admin/widgets/TrafficSourcesPie'
+		)
+		const { container } = render(<TrafficSourcesPie result={ok([])} />)
+		expect(container.textContent).toContain('No traffic source data yet.')
+		expect(within(container).queryByRole('alert')).toBeFalsy()
+	})
+})
+
+// Dashboard-level resilience: render the EXACT five-widget composition the
+// dashboard page uses, with four healthy results and ONE failing widget, and
+// assert (a) exactly one AdminErrorState alert appears and (b) the healthy
+// widgets' content is still present. recharts is mocked to a passthrough so the
+// two chart widgets render in happy-dom without browser layout APIs.
+describe('dashboard composition: one failing widget does not blank the page', () => {
+	beforeEach(() => {
+		// happy-dom lacks ResizeObserver, which recharts' ResponsiveContainer
+		// requires. Mock the recharts surface the widgets import to plain
+		// passthrough divs so the real widget components mount.
+		mock.module('recharts', () => {
+			const React = require('react')
+			const passthrough = ({ children }: { children?: unknown }) =>
+				React.createElement('div', null, children)
+			const leaf = () => null
+			return {
+				ResponsiveContainer: passthrough,
+				LineChart: passthrough,
+				PieChart: passthrough,
+				Pie: passthrough,
+				Cell: leaf,
+				Line: leaf,
+				CartesianGrid: leaf,
+				XAxis: leaf,
+				YAxis: leaf,
+				Tooltip: leaf,
+				Legend: leaf
+			}
+		})
+	})
+
+	test('renders exactly one alert (the failing widget) while the others render content', async () => {
+		const { VisitorsChart } = await import(
+			'@/components/admin/widgets/VisitorsChart'
+		)
+		const { TrafficSourcesPie } = await import(
+			'@/components/admin/widgets/TrafficSourcesPie'
+		)
+
+		// Mirror dashboard/page.tsx: VisitorsChart, WebVitalsCards, TopPagesTable,
+		// TrafficSourcesPie, RecentLeadsPanel. The TopPagesTable query fails; the
+		// other four are healthy.
+		const { container } = render(
+			<div>
+				<VisitorsChart result={ok([{ date: '2026-01-01', pageviews: 10 }])} />
+				<WebVitalsCards
+					result={ok([{ name: 'LCP', p75: 1800, sampleCount: 9 }])}
+				/>
+				<TopPagesTable result={err()} />
+				<TrafficSourcesPie result={ok([{ channel: 'organic', count: 5 }])} />
+				<RecentLeadsPanel
+					result={ok([
+						{
+							id: 'l-1',
+							email: 'bob@example.com',
+							source: 'direct',
+							status: 'new',
+							createdAt: NOW
+						}
+					])}
+				/>
+			</div>
+		)
+
+		// Exactly ONE widget shows an error card.
+		const alerts = within(container).getAllByRole('alert')
+		expect(alerts.length).toBe(1)
+		expect(container.textContent).toContain('Could not load page analytics')
+
+		// The four healthy widgets still rendered their content.
+		expect(container.textContent).toContain('LCP') // WebVitalsCards
+		expect(container.textContent).toContain('bob@example.com') // RecentLeadsPanel
+		// The chart widgets passed the error/empty branch and reached the chart
+		// container (role="img"); both healthy charts rendered.
+		expect(container.querySelectorAll('[role="img"]').length).toBe(2)
+	})
+})

--- a/tests/unit/admin/detail-page-routing.test.tsx
+++ b/tests/unit/admin/detail-page-routing.test.tsx
@@ -99,27 +99,60 @@ function setupDbMock(): void {
 	}))
 }
 
+// The admin EDIT pages statically import their client form islands, which reach
+// `src/hooks/use-blob-upload.ts` -> `import { upload } from '@vercel/blob/client'`.
+// Register a COMPLETE @vercel/blob/client surface (both `upload` and
+// `handleUpload`) so importing an edit-page graph never trips the
+// CJS-interop static-link failure ("Export named 'upload' not found"). The
+// functions are inert stubs; the routing assertions never invoke them.
+function setupBlobClientMock(): void {
+	mock.module('@vercel/blob/client', () => ({
+		upload: async () => ({ url: 'https://example.test/blob' }),
+		handleUpload: async () => ({
+			type: 'blob.generate-client-token',
+			clientToken: 'test-token'
+		})
+	}))
+}
+
 // --- next/navigation: notFound() as a throwing spy -------------------------
 
 const notFoundCalls: { count: number } = { count: 0 }
 
-// Capture the pristine surfaces once, before any override, so the afterAll
-// restore (and the per-test re-spread) anchor to the real exports rather than
-// to a previously-installed mock.
-const PRISTINE_NAV = require('next/navigation') as Record<string, unknown>
+// Capture @/lib/blog once at module-eval time (its mock surface is not shared
+// with other files, so a pristine require is safe here).
 const PRISTINE_BLOG = require('@/lib/blog') as Record<string, unknown>
 
+// Re-register a COMPLETE next/navigation surface whose `notFound` is a counting
+// throwing spy (mirroring the real NEXT_NOT_FOUND digest throw so the loader's
+// control flow halts as in production). Listing the full surface (including
+// `redirect`, which the sibling `actions.ts` import) keeps the static-import
+// link resolvable regardless of which file linked next/navigation first;
+// `tests/test-utils.ts::setupNextMocks` was hardened to the same complete
+// surface so a Navbar-rendering test no longer poisons the process-wide link.
 function setupNavMock(): void {
-	// Spread the real surface so transitive consumers (DeleteButton ->
-	// `redirect`, action modules, etc.) keep their imports. Real Next throws a
-	// NEXT_NOT_FOUND digest from notFound(); we mirror that with a throwing spy
-	// so the loader's control flow halts exactly as it does in production.
+	const redirect = (): never => {
+		throw new Error('NEXT_REDIRECT')
+	}
 	mock.module('next/navigation', () => ({
-		...PRISTINE_NAV,
 		notFound: () => {
 			notFoundCalls.count += 1
 			throw new Error('NEXT_NOT_FOUND')
-		}
+		},
+		redirect,
+		permanentRedirect: redirect,
+		forbidden: () => {
+			throw new Error('NEXT_FORBIDDEN')
+		},
+		unauthorized: () => {
+			throw new Error('NEXT_UNAUTHORIZED')
+		},
+		RedirectType: { push: 'push', replace: 'replace' },
+		useRouter: () => ({ push: () => {}, replace: () => {}, refresh: () => {} }),
+		usePathname: () => '/',
+		useSearchParams: () => new URLSearchParams(),
+		useParams: () => ({}),
+		ReadonlyURLSearchParams: URLSearchParams
 	}))
 }
 
@@ -140,7 +173,7 @@ function setupBlogSiblingMock(): void {
 interface PageCase {
 	/** Human label for the describe block. */
 	name: string
-	/** Dynamic import path of the page module (default export = the page). */
+	/** Module specifier of the page (default export = the page component). */
 	importPath: string
 	/** The `resource` label AdminErrorState renders for this page. */
 	resourceLabel: string
@@ -287,14 +320,15 @@ beforeEach(() => {
 	setupDbMock()
 	setupNavMock()
 	setupBlogSiblingMock()
+	setupBlobClientMock()
 })
 
-// Restore the surfaces we overrode (next/navigation throwing-notFound and the
-// @/lib/blog sibling stubs) to their pristine exports so a later test file does
-// not inherit our spies. (`@/lib/db` is intentionally left as-is; every admin
-// test file re-registers it in its own beforeEach.)
+// Restore @/lib/blog to its pristine exports so a later file does not inherit
+// our getAuthors/getTags stubs. (`@/lib/db` is intentionally left as-is; every
+// admin test file re-registers it in its own beforeEach. `next/navigation` is
+// left as our complete benign surface, which is a strict superset of the
+// partial mock forms.test.tsx installs, so it cannot break later files.)
 afterAll(() => {
-	mock.module('next/navigation', () => ({ ...PRISTINE_NAV }))
 	mock.module('@/lib/blog', () => ({ ...PRISTINE_BLOG }))
 })
 
@@ -340,9 +374,10 @@ function findLoaderElement(node: unknown): LoaderElement | null {
 // Invoke the page default export, find the Suspense child loader element, and
 // call its async component function directly (what the server renderer does).
 // Returns the loader's resolved React element, or rejects if the loader threw
-// (e.g. via notFound()).
-async function runLoader(importPath: string): Promise<unknown> {
-	const mod = (await import(importPath)) as {
+// (e.g. via notFound()). The next/navigation static-import link is pinned by
+// tests/setup.ts, so importing the page graph here is order-independent.
+async function runLoader(pageCase: PageCase): Promise<unknown> {
+	const mod = (await import(pageCase.importPath)) as {
 		default: (props: { params: Promise<{ id: string }> }) => unknown
 	}
 	const tree = mod.default({
@@ -350,7 +385,7 @@ async function runLoader(importPath: string): Promise<unknown> {
 	})
 	const loaderElement = findLoaderElement(tree)
 	if (!loaderElement) {
-		throw new Error(`could not locate loader element in ${importPath}`)
+		throw new Error(`could not locate loader element in ${pageCase.name}`)
 	}
 	return await loaderElement.type(loaderElement.props)
 }
@@ -361,7 +396,7 @@ describe('detail-page notFound()-vs-error routing (ADMINERR-04)', () => {
 			test("status:'error' -> renders AdminErrorState and does NOT call notFound()", async () => {
 				dbState.mode = 'error'
 
-				const out = await runLoader(pageCase.importPath)
+				const out = await runLoader(pageCase)
 
 				// The critical guard: a DB error is NOT a 404.
 				expect(notFoundCalls.count).toBe(0)
@@ -378,9 +413,7 @@ describe('detail-page notFound()-vs-error routing (ADMINERR-04)', () => {
 			test("status:'not-found' -> calls notFound()", async () => {
 				dbState.mode = 'not-found'
 
-				await expect(runLoader(pageCase.importPath)).rejects.toThrow(
-					'NEXT_NOT_FOUND'
-				)
+				await expect(runLoader(pageCase)).rejects.toThrow('NEXT_NOT_FOUND')
 				expect(notFoundCalls.count).toBe(1)
 			})
 
@@ -388,7 +421,7 @@ describe('detail-page notFound()-vs-error routing (ADMINERR-04)', () => {
 				dbState.mode = 'found'
 				dbState.activeRow = pageCase.foundRow
 
-				const out = await runLoader(pageCase.importPath)
+				const out = await runLoader(pageCase)
 
 				expect(notFoundCalls.count).toBe(0)
 				// The content path must not return the error card. AdminErrorState

--- a/tests/unit/admin/detail-page-routing.test.tsx
+++ b/tests/unit/admin/detail-page-routing.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * Phase 13 consumer-layer regression armor: detail-page notFound()-vs-error
+ * routing (ADMINERR-04).
+ *
+ * The headline guarantee of the Phase 13 detail loaders is that they
+ * distinguish a genuinely missing row from a failed DB read:
+ *
+ *   - `status: 'not-found'` -> call `notFound()` (the platform 404).
+ *   - `status: 'error'`     -> render `<AdminErrorState>` (NOT a 404). A
+ *                              transient DB error must never masquerade as a
+ *                              missing resource.
+ *   - `status: 'found'`     -> render the content (neither of the above).
+ *
+ * These tests lock that exact branch. A future collapse to
+ * `if (status !== 'found') notFound()` (which would turn a DB error into a
+ * misleading 404) MUST turn the 'error' cases below RED.
+ *
+ * How it works: each detail page's default export returns a tree containing
+ * `<Suspense><Loader params={...} /></Suspense>`. The loader is an async
+ * server component that is not individually exported, so we reach it by
+ * recursively finding the element in the page's returned tree whose `type` is
+ * a function component carrying a `params` prop, then invoking that element's
+ * `type(props)` directly (the same call the React server renderer makes). We
+ * then:
+ *   - assert `notFound` (mocked as a throwing spy, mirroring the real
+ *     NEXT_NOT_FOUND digest throw) is or is not called, and
+ *   - for the 'error' variant, render the returned element with
+ *     @testing-library/react and assert the `AdminErrorState` alert appears.
+ *
+ * Driving the REAL query layer (no query-module replacement): we mock ONLY
+ * `@/lib/db` with a chainable thenable stub (the exact idiom from
+ * leads-queries.test.ts) so the genuine `get*ById` functions run their real
+ * found / not-found / error logic. This is important because bun's
+ * `mock.module` is a GLOBAL registry that `mock.restore()` does NOT clear
+ * across files (oven-sh/bun#7823, documented in forms.test.tsx); replacing the
+ * shared `*-queries` modules here would leak into the alphabetically-later
+ * `emails-`/`testimonials-queries` test files and corrupt their real get*ById.
+ * `@/lib/db` is the one module every admin test file re-registers in its own
+ * `beforeEach`, so mocking it is leak-safe.
+ *
+ * `connection()` from `next/server` is a no-op in tests (tests/setup.ts), so
+ * the loader runs straight through to the query call.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { render, within } from '@testing-library/react'
+import type { ReactElement } from 'react'
+
+// --- DB driver state (mirrors leads-queries.test.ts) -----------------------
+//
+// `mode` selects which variant every get*ById resolves to:
+//   - 'error'     -> the chain rejects (the real try/catch returns errResult)
+//   - 'not-found' -> the row select resolves to [] (real -> notFoundResult)
+//   - 'found'     -> the row select resolves to [activeRow]
+//
+// `activeRow` is the raw DB row the active page expects get*ById to wrap.
+const dbState: { mode: 'error' | 'not-found' | 'found'; activeRow: unknown } = {
+	mode: 'not-found',
+	activeRow: null
+}
+
+// A thenable chainable select stub. The single-row detail selects terminate on
+// `.limit(1)`; leads' attribution/notes selects terminate on `.orderBy()`; the
+// blog detail uses `.leftJoin()` then `.limit(1)`, and its tag lookup
+// terminates on `.where()`. We resolve the ROW selects (limit) to the active
+// row and resolve the secondary selects (orderBy / bare where) to [] so the
+// loaders render with empty attribution / notes / tag sets.
+function buildSelectChain(): unknown {
+	const rejectOrResolve = (value: unknown): Promise<unknown> =>
+		dbState.mode === 'error'
+			? Promise.reject(new Error('db down'))
+			: Promise.resolve(value)
+	const rowList = (): unknown[] =>
+		dbState.mode === 'found' && dbState.activeRow !== null
+			? [dbState.activeRow]
+			: []
+	const chain = {
+		from: () => chain,
+		leftJoin: () => chain,
+		where: () => {
+			// Bare `.where()` terminus (blog tag lookup): resolve to [] rows. The
+			// detail selects always chain on through `.limit()` / `.orderBy()`, so
+			// returning the chain here keeps those paths intact while still being
+			// awaitable for the tag-lookup terminus via `then`.
+			return chain
+		},
+		orderBy: () => rejectOrResolve([]),
+		limit: () => rejectOrResolve(rowList()),
+		then: (
+			onFulfilled?: (value: unknown) => unknown,
+			onRejected?: (reason: unknown) => unknown
+		) => rejectOrResolve([]).then(onFulfilled, onRejected)
+	}
+	return chain
+}
+
+function setupDbMock(): void {
+	mock.module('@/lib/db', () => ({
+		db: { select: () => buildSelectChain() }
+	}))
+}
+
+// --- next/navigation: notFound() as a throwing spy -------------------------
+
+const notFoundCalls: { count: number } = { count: 0 }
+
+// Capture the pristine surfaces once, before any override, so the afterAll
+// restore (and the per-test re-spread) anchor to the real exports rather than
+// to a previously-installed mock.
+const PRISTINE_NAV = require('next/navigation') as Record<string, unknown>
+const PRISTINE_BLOG = require('@/lib/blog') as Record<string, unknown>
+
+function setupNavMock(): void {
+	// Spread the real surface so transitive consumers (DeleteButton ->
+	// `redirect`, action modules, etc.) keep their imports. Real Next throws a
+	// NEXT_NOT_FOUND digest from notFound(); we mirror that with a throwing spy
+	// so the loader's control flow halts exactly as it does in production.
+	mock.module('next/navigation', () => ({
+		...PRISTINE_NAV,
+		notFound: () => {
+			notFoundCalls.count += 1
+			throw new Error('NEXT_NOT_FOUND')
+		}
+	}))
+}
+
+// The blog edit loader also awaits getAuthors()/getTags() from '@/lib/blog'
+// (sibling reads for the form dropdowns). Stub them so the Promise.all settles
+// without hitting the (mocked) db in a shape the chain does not model; the
+// routing assertions do not depend on their values.
+function setupBlogSiblingMock(): void {
+	mock.module('@/lib/blog', () => ({
+		...PRISTINE_BLOG,
+		getAuthors: () => Promise.resolve([]),
+		getTags: () => Promise.resolve([])
+	}))
+}
+
+// --- Per-page cases --------------------------------------------------------
+
+interface PageCase {
+	/** Human label for the describe block. */
+	name: string
+	/** Dynamic import path of the page module (default export = the page). */
+	importPath: string
+	/** The `resource` label AdminErrorState renders for this page. */
+	resourceLabel: string
+	/**
+	 * A representative raw DB ROW that the page's get*ById wraps in `found(...)`.
+	 * Must carry enough fields for the loader's content path to render without
+	 * throwing.
+	 */
+	foundRow: unknown
+}
+
+const NOW = new Date('2026-01-15T12:00:00.000Z')
+
+const PAGE_CASES: PageCase[] = [
+	{
+		name: 'leads/[id]',
+		importPath: '@/app/(admin)/admin/leads/[id]/page',
+		resourceLabel: 'lead',
+		// getLeadById wraps the single lead row (attribution + notes resolve to
+		// [] via the orderBy terminus).
+		foundRow: {
+			id: 'lead-1',
+			email: 'a@b.c',
+			name: 'A',
+			company: null,
+			phone: null,
+			source: null,
+			score: null,
+			status: 'new',
+			metadata: null
+		}
+	},
+	{
+		name: 'showcase/[id]/edit',
+		importPath: '@/app/(admin)/admin/showcase/[id]/edit/page',
+		resourceLabel: 'showcase entry',
+		// The loader hands the row straight to the client form island, so it does
+		// not read any field; an opaque object is enough.
+		foundRow: { id: 'sc-1' }
+	},
+	{
+		name: 'blog/[id]/edit',
+		importPath: '@/app/(admin)/admin/blog/[id]/edit/page',
+		resourceLabel: 'blog post',
+		// getBlogPostForAdmin's row select uses a leftJoin projecting
+		// `{ post, author }`; the tag lookup resolves to [].
+		foundRow: {
+			post: {
+				id: 'post-1',
+				slug: 's',
+				title: 'T',
+				excerpt: 'E',
+				content: 'C',
+				featureImage: null,
+				readingTime: 1,
+				featured: false,
+				published: false,
+				authorId: null,
+				publishedAt: null,
+				createdAt: NOW,
+				updatedAt: NOW
+			},
+			author: null
+		}
+	},
+	{
+		name: 'testimonials/[id]/edit',
+		importPath: '@/app/(admin)/admin/testimonials/[id]/edit/page',
+		resourceLabel: 'testimonial',
+		foundRow: { id: 't-1' }
+	},
+	{
+		name: 'emails/[id]',
+		importPath: '@/app/(admin)/admin/emails/[id]/page',
+		resourceLabel: 'scheduled email',
+		foundRow: {
+			id: 'em-1',
+			recipientEmail: 'r@e.c',
+			recipientName: null,
+			sequenceId: 'seq',
+			stepId: 'step',
+			status: 'pending',
+			scheduledFor: NOW,
+			sentAt: null,
+			retryCount: 0,
+			maxRetries: 3,
+			error: null,
+			variables: null
+		}
+	},
+	{
+		name: 'newsletter/[id]',
+		importPath: '@/app/(admin)/admin/newsletter/[id]/page',
+		resourceLabel: 'subscriber',
+		foundRow: {
+			id: 'sub-1',
+			email: 's@e.c',
+			name: null,
+			source: null,
+			status: 'active',
+			subscribedAt: NOW,
+			unsubscribedAt: null,
+			createdAt: NOW,
+			metadata: null
+		}
+	},
+	{
+		name: 'leads/calculator/[id]',
+		importPath: '@/app/(admin)/admin/leads/calculator/[id]/page',
+		resourceLabel: 'calculator submission',
+		foundRow: {
+			id: 'cl-1',
+			email: 'c@e.c',
+			name: null,
+			phone: null,
+			company: null,
+			leadScore: null,
+			calculatorType: 'roi',
+			leadQuality: 'warm',
+			inputs: {},
+			results: {},
+			contacted: false,
+			contactedAt: null,
+			converted: false,
+			convertedAt: null,
+			conversionValue: null,
+			utmSource: null,
+			utmMedium: null,
+			utmCampaign: null,
+			utmTerm: null,
+			utmContent: null,
+			referrer: null,
+			landingPage: null
+		}
+	}
+]
+
+beforeEach(() => {
+	notFoundCalls.count = 0
+	dbState.mode = 'not-found'
+	dbState.activeRow = null
+	// tests/setup.ts beforeEach runs mock.restore() BEFORE this one; re-register
+	// every module mock so the stubs stay bound for each case.
+	setupDbMock()
+	setupNavMock()
+	setupBlogSiblingMock()
+})
+
+// Restore the surfaces we overrode (next/navigation throwing-notFound and the
+// @/lib/blog sibling stubs) to their pristine exports so a later test file does
+// not inherit our spies. (`@/lib/db` is intentionally left as-is; every admin
+// test file re-registers it in its own beforeEach.)
+afterAll(() => {
+	mock.module('next/navigation', () => ({ ...PRISTINE_NAV }))
+	mock.module('@/lib/blog', () => ({ ...PRISTINE_BLOG }))
+})
+
+interface LoaderElement {
+	type: (props: { params: Promise<{ id: string }> }) => Promise<unknown>
+	props: { params: Promise<{ id: string }> }
+}
+
+// Recursively walk the page's returned element tree to find the async loader
+// element: the one whose `type` is a function component AND whose `props`
+// carry the `params` promise. Some pages return the `<Suspense>` at the top
+// level (leads, emails, newsletter, calculator); the edit pages nest it inside
+// an outer heading `<div>`, so a plain `tree.props.children` access is not
+// enough.
+function findLoaderElement(node: unknown): LoaderElement | null {
+	if (node === null || typeof node !== 'object') {
+		return null
+	}
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			const located = findLoaderElement(child)
+			if (located) {
+				return located
+			}
+		}
+		return null
+	}
+	const element = node as {
+		type?: unknown
+		props?: { children?: unknown; params?: unknown }
+	}
+	if (
+		typeof element.type === 'function' &&
+		element.props !== undefined &&
+		element.props !== null &&
+		'params' in element.props
+	) {
+		return element as unknown as LoaderElement
+	}
+	return findLoaderElement(element.props?.children)
+}
+
+// Invoke the page default export, find the Suspense child loader element, and
+// call its async component function directly (what the server renderer does).
+// Returns the loader's resolved React element, or rejects if the loader threw
+// (e.g. via notFound()).
+async function runLoader(importPath: string): Promise<unknown> {
+	const mod = (await import(importPath)) as {
+		default: (props: { params: Promise<{ id: string }> }) => unknown
+	}
+	const tree = mod.default({
+		params: Promise.resolve({ id: 'real-id-not-placeholder' })
+	})
+	const loaderElement = findLoaderElement(tree)
+	if (!loaderElement) {
+		throw new Error(`could not locate loader element in ${importPath}`)
+	}
+	return await loaderElement.type(loaderElement.props)
+}
+
+describe('detail-page notFound()-vs-error routing (ADMINERR-04)', () => {
+	for (const pageCase of PAGE_CASES) {
+		describe(pageCase.name, () => {
+			test("status:'error' -> renders AdminErrorState and does NOT call notFound()", async () => {
+				dbState.mode = 'error'
+
+				const out = await runLoader(pageCase.importPath)
+
+				// The critical guard: a DB error is NOT a 404.
+				expect(notFoundCalls.count).toBe(0)
+
+				// The returned element renders the shared error card.
+				const { container } = render(out as ReactElement)
+				const alert = within(container).getByRole('alert')
+				expect(alert).toBeTruthy()
+				expect(container.textContent).toContain(
+					`Could not load ${pageCase.resourceLabel}`
+				)
+			})
+
+			test("status:'not-found' -> calls notFound()", async () => {
+				dbState.mode = 'not-found'
+
+				await expect(runLoader(pageCase.importPath)).rejects.toThrow(
+					'NEXT_NOT_FOUND'
+				)
+				expect(notFoundCalls.count).toBe(1)
+			})
+
+			test("status:'found' -> content path: neither notFound() nor AdminErrorState", async () => {
+				dbState.mode = 'found'
+				dbState.activeRow = pageCase.foundRow
+
+				const out = await runLoader(pageCase.importPath)
+
+				expect(notFoundCalls.count).toBe(0)
+				// The content path must not return the error card. AdminErrorState
+				// is a named function component; the content path returns either a
+				// host element (div) or a client form island, never AdminErrorState.
+				const element = out as { type?: { name?: string } }
+				expect(element.type?.name).not.toBe('AdminErrorState')
+			})
+		})
+	}
+})


### PR DESCRIPTION
## What

Test-only regression armor for the merged Phase 13 (admin-error-observability), from a perfect-pr-loop review. The phase-13 implementation is correct; this PR pins its guarantees at the **consumer layer**, where the existing query-layer tests didn't reach. No source changes.

## Why

The review confirmed 0 behavioral defects but 3 real coverage gaps: the headline "a DB error renders an error state and is NEVER a 404" mapping lives in the detail page loaders and was untested, so a future collapse to `if (status !== 'found') notFound()` would pass all 252 admin tests while silently reintroducing the exact bug Phase 13 fixed.

## Changes (tests only)

- **Detail-page `notFound()`-vs-error routing** (`detail-page-routing.test.tsx`, new) — parameterized sweep over all 7 admin `[id]` loaders x 3 variants. Drives the real query layer via a chainable `@/lib/db` stub, mocks `notFound` as a throwing/counting spy. Asserts: `error` -> renders `AdminErrorState`, does NOT call `notFound`; `not-found` -> calls `notFound`; `found` -> neither. (Verified RED against a deliberate collapse.)
- **Per-widget dashboard resilience** (`dashboard-widget-resilience.test.tsx`, new) — render tests across error/ok/empty for the widgets, plus a composition test (4 ok + 1 err) asserting exactly one `AdminErrorState` renders while healthy widgets still show.
- **`getBlogPostForAdmin` tag-lookup-throw sub-path** (`blog-queries.test.ts`) — added a `tagThrow` harness flag; new case where the post select succeeds but the tag lookup throws -> asserts `{ status: 'error' }` (not a 404).
- **Harness hardening** (`test-utils.ts`, `admin-image-upload.test.ts`) — completed two partial `next/navigation` / `@vercel/blob/client` mocks that were poisoning the module-link graph suite-wide (bun mock.module interop bug); this unblocks importing admin page graphs in tests without altering existing test behavior.

## Verification

`bun test tests/unit/admin/` 286 pass / 0 fail (+34). `bun run typecheck` clean. Biome clean. Full suite: only the pre-existing, unrelated homepage/navigation RTL failures remain (0 net-new).

[hudsor01]