### PR TITLE
test(admin): make phase-13 detail no-404-on-error guarantee unit-testable (pure routing helper)

### DIFF
--- a/src/app/(admin)/admin/blog/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/blog/[id]/edit/page.tsx
@@ -20,6 +20,7 @@ import { Suspense } from 'react'
 import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { getBlogPostForAdmin } from '@/lib/admin/blog-queries'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getAuthors, getTags } from '@/lib/blog'
 import { EditBlogForm } from './EditBlogForm'
 
@@ -51,13 +52,14 @@ async function EditLoader({ params }: EditBlogPostPageProps) {
 		getAuthors(),
 		getTags()
 	])
-	if (postResult.status === 'not-found') {
+	const routing = routeDetailResult(postResult)
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (postResult.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="blog post" />
 	}
-	const post = postResult.data
+	const post = routing.data
 	return (
 		<EditBlogForm
 			row={post}

--- a/src/app/(admin)/admin/emails/[id]/page.tsx
+++ b/src/app/(admin)/admin/emails/[id]/page.tsx
@@ -30,6 +30,7 @@ import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getScheduledEmailById } from '@/lib/admin/emails-queries'
 import {
 	cancelScheduledEmailAction,
@@ -76,14 +77,14 @@ async function EmailDetailLoader({ params }: EmailDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const result = await getScheduledEmailById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getScheduledEmailById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="scheduled email" />
 	}
-	const row = result.data
+	const row = routing.data
 
 	const max = row.maxRetries ?? 3
 	const canRetry = row.retryCount < max

--- a/src/app/(admin)/admin/leads/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/[id]/page.tsx
@@ -28,6 +28,7 @@ import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getLeadById } from '@/lib/admin/leads-queries'
 import { LEAD_STATUSES } from '@/lib/schemas/admin-leads'
 import {
@@ -66,14 +67,14 @@ async function LeadDetailLoader({ params }: AdminLeadDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const result = await getLeadById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getLeadById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="lead" />
 	}
-	const { lead, attribution, notes } = result.data
+	const { lead, attribution, notes } = routing.data
 
 	return (
 		<div className="space-y-6">

--- a/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/calculator/[id]/page.tsx
@@ -23,6 +23,7 @@ import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { getCalculatorLeadById } from '@/lib/admin/calculator-leads-queries'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import {
 	deleteCalculatorLeadAction,
 	markCalculatorLeadContactedAction,
@@ -93,14 +94,14 @@ async function CalculatorLeadDetail({
 		notFound()
 	}
 	await connection()
-	const result = await getCalculatorLeadById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getCalculatorLeadById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="calculator submission" />
 	}
-	const row = result.data
+	const row = routing.data
 
 	const leadEntries: Array<[string, React.ReactNode]> = []
 	if (row.name) {

--- a/src/app/(admin)/admin/newsletter/[id]/page.tsx
+++ b/src/app/(admin)/admin/newsletter/[id]/page.tsx
@@ -24,6 +24,7 @@ import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { DeleteButton } from '@/components/admin/DeleteButton'
 import { StatusBadge } from '@/components/admin/StatusBadge'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getSubscriberById } from '@/lib/admin/newsletter-queries'
 import {
 	deleteSubscriberAction,
@@ -75,14 +76,14 @@ async function SubscriberLoader({ params }: SubscriberDetailPageProps) {
 		notFound()
 	}
 	await connection()
-	const result = await getSubscriberById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getSubscriberById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="subscriber" />
 	}
-	const row = result.data
+	const row = routing.data
 	return (
 		<div className="space-y-8">
 			<div>

--- a/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/showcase/[id]/edit/page.tsx
@@ -17,6 +17,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getShowcaseById } from '@/lib/admin/showcase-queries'
 import { EditShowcaseForm } from './EditShowcaseForm'
 
@@ -43,14 +44,14 @@ async function EditLoader({ params }: EditShowcasePageProps) {
 		notFound()
 	}
 	await connection()
-	const result = await getShowcaseById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getShowcaseById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="showcase entry" />
 	}
-	return <EditShowcaseForm row={result.data} />
+	return <EditShowcaseForm row={routing.data} />
 }
 
 export default function EditShowcasePage({ params }: EditShowcasePageProps) {

--- a/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
+++ b/src/app/(admin)/admin/testimonials/[id]/edit/page.tsx
@@ -18,6 +18,7 @@ import { connection } from 'next/server'
 import { Suspense } from 'react'
 import { AdminErrorState } from '@/components/admin/AdminErrorState'
 import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getTestimonialById } from '@/lib/admin/testimonials-queries'
 import { EditTestimonialForm } from './EditTestimonialForm'
 
@@ -44,14 +45,14 @@ async function EditLoader({ params }: EditTestimonialPageProps) {
 		notFound()
 	}
 	await connection()
-	const result = await getTestimonialById(id)
-	if (result.status === 'not-found') {
+	const routing = routeDetailResult(await getTestimonialById(id))
+	if (routing.kind === 'not-found') {
 		notFound()
 	}
-	if (result.status === 'error') {
+	if (routing.kind === 'error') {
 		return <AdminErrorState resource="testimonial" />
 	}
-	return <EditTestimonialForm row={result.data} />
+	return <EditTestimonialForm row={routing.data} />
 }
 
 export default function EditTestimonialPage({

--- a/src/lib/admin/detail-result-routing.ts
+++ b/src/lib/admin/detail-result-routing.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure routing helper for admin detail-page loaders (Phase 13, ADMINERR-04).
+ *
+ * Each `[id]` detail server component reads its row via a `get*ById` query that
+ * returns the 3-way `AdminDetailResult` union (`found` / `not-found` / `error`).
+ * The loader must map that union onto exactly one of three render outcomes:
+ *   - a genuinely missing row -> `notFound()` (404)
+ *   - a caught DB failure      -> a visible `<AdminErrorState>` (NEVER a 404)
+ *   - a found row              -> render the data
+ *
+ * The CRITICAL guarantee this helper locks down is that a DB `'error'` is
+ * routed to `{ kind: 'error' }` and never collapses into `{ kind: 'not-found' }`
+ * (which would render a misleading 404 on a transient failure). Extracting the
+ * mapping into a side-effect-free function lets us unit-test that guarantee with
+ * pure input -> output assertions, without rendering a React server component or
+ * mocking `next/navigation`.
+ *
+ * Tier-agnostic by design (no server-only guard, no I/O): it only switches on a
+ * plain discriminated union and returns a plain discriminated union.
+ */
+import type { AdminDetailResult } from './query-result'
+
+/**
+ * The render outcome a detail loader should take, derived purely from the
+ * query result. `'render'` carries the row data; the other two carry nothing.
+ */
+export type DetailRouting<T> =
+	| { kind: 'not-found' }
+	| { kind: 'error' }
+	| { kind: 'render'; data: T }
+
+/**
+ * Map an `AdminDetailResult` onto the loader's render outcome. Exhaustive over
+ * the three statuses; `'error'` maps to `{ kind: 'error' }` so a DB failure can
+ * never be mistaken for a 404.
+ */
+export function routeDetailResult<T>(
+	result: AdminDetailResult<T>
+): DetailRouting<T> {
+	switch (result.status) {
+		case 'not-found':
+			return { kind: 'not-found' }
+		case 'error':
+			return { kind: 'error' }
+		case 'found':
+			return { kind: 'render', data: result.data }
+		default:
+			return assertNever(result)
+	}
+}
+
+// Compile-time exhaustiveness guard: if a future `AdminDetailResult` variant is
+// added without a matching case above, this fails to typecheck.
+function assertNever(value: never): never {
+	throw new Error(`unexpected detail result variant: ${JSON.stringify(value)}`)
+}

--- a/tests/unit/admin/blog-queries.test.ts
+++ b/tests/unit/admin/blog-queries.test.ts
@@ -41,6 +41,10 @@ interface MockState {
 	// Toggle which next select() call mode we are in (post-list vs tag-lookup).
 	selectMode: 'post-list' | 'tag-lookup'
 	shouldThrow: boolean
+	// Independent throw switch for the tag-lookup chain (second select()), so a
+	// case can simulate the post select succeeding but `loadTagIdsForPosts`
+	// throwing. `shouldThrow` only rejects the post-list chain.
+	tagThrow: boolean
 	// Rows returned by the `db.update(...).set(...).where(...).returning()`
 	// chain that `toggleBlogPostPublished` runs (and the `tx.update(...)` chain
 	// inside `updateBlogPost`'s transaction).
@@ -57,6 +61,7 @@ const state: MockState = {
 	tagLookupIds: undefined,
 	selectMode: 'post-list',
 	shouldThrow: false,
+	tagThrow: false,
 	updateRowsToReturn: []
 }
 
@@ -70,6 +75,7 @@ function resetState(): void {
 	state.tagLookupIds = undefined
 	state.selectMode = 'post-list'
 	state.shouldThrow = false
+	state.tagThrow = false
 	state.updateRowsToReturn = []
 }
 
@@ -130,7 +136,12 @@ function buildPostListChain(): unknown {
 function buildTagLookupChain(): unknown {
 	const chain = {
 		from: () => chain,
-		where: () => Promise.resolve(state.tagRowsToReturn)
+		where: () => {
+			if (state.tagThrow) {
+				return Promise.reject(new Error('tag lookup db down'))
+			}
+			return Promise.resolve(state.tagRowsToReturn)
+		}
 	}
 	return chain
 }
@@ -532,6 +543,20 @@ describe('getBlogPostForAdmin: 3-way detail result', () => {
 		const result = await getBlogPostForAdmin('post-00')
 
 		expect(result.status).toBe('error')
+		expect(logger.error).toHaveBeenCalledTimes(1)
+	})
+
+	test("returns 'error' (not not-found/404) when the post select succeeds but the tag lookup throws", async () => {
+		// The tag-id lookup is part of the detail read: the post row is found,
+		// but `loadTagIdsForPosts` throws. This must still yield the error
+		// variant -- a partial read failure is never a misleading 404.
+		state.postRowsToReturn = [makeRow(0, { id: 'post-00' })]
+		state.tagThrow = true
+
+		const result = await getBlogPostForAdmin('post-00')
+
+		expect(result.status).toBe('error')
+		expect(result.status).not.toBe('not-found')
 		expect(logger.error).toHaveBeenCalledTimes(1)
 	})
 })

--- a/tests/unit/admin/detail-result-routing.test.ts
+++ b/tests/unit/admin/detail-result-routing.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the pure detail-page routing helper (Phase 13, ADMINERR-04).
+ *
+ * `routeDetailResult` is the single mapping every admin `[id]` detail loader
+ * applies to its `AdminDetailResult` before deciding whether to `notFound()`,
+ * render `<AdminErrorState>`, or render the row. The mapping is pure (no DB, no
+ * React, no `next/navigation`), so it is asserted here with plain input ->
+ * output checks -- NO `mock.module`, NO JSX, NO page-module imports. This keeps
+ * the global module registry clean (a prior attempt poisoned unrelated tests by
+ * mocking `next/navigation` / `@/lib/constants/business` from a detail-page
+ * test) while still locking the behavior down.
+ *
+ * The load-bearing assertion is the regression guard: `errResult()` (a caught
+ * DB failure) must route to `{ kind: 'error' }` and NEVER to
+ * `{ kind: 'not-found' }`. A DB error is never a 404 -- this test pins that
+ * contract so the mapping cannot silently regress.
+ */
+import { describe, expect, test } from 'bun:test'
+import { routeDetailResult } from '@/lib/admin/detail-result-routing'
+import { errResult, found, notFoundResult } from '@/lib/admin/query-result'
+
+describe('routeDetailResult: DB error is never a 404', () => {
+	test("errResult() routes to { kind: 'error' } (NOT 'not-found')", () => {
+		const routing = routeDetailResult(errResult())
+		expect(routing).toEqual({ kind: 'error' })
+		// Explicit regression guard: a caught DB failure must not collapse into a
+		// 404, which would render a misleading "not found" on a transient error.
+		expect(routing.kind).not.toBe('not-found')
+	})
+
+	test("notFoundResult() routes to { kind: 'not-found' }", () => {
+		const routing = routeDetailResult(notFoundResult())
+		expect(routing).toEqual({ kind: 'not-found' })
+	})
+
+	test("found(data) routes to { kind: 'render', data } carrying the row", () => {
+		const data = { id: 'abc', title: 'Example' }
+		const routing = routeDetailResult(found(data))
+		expect(routing).toEqual({ kind: 'render', data })
+		// The data is reachable only on the render branch.
+		if (routing.kind === 'render') {
+			expect(routing.data).toBe(data)
+		} else {
+			throw new Error('expected render variant')
+		}
+	})
+})
+
+describe('routeDetailResult: the three outcomes are mutually exclusive', () => {
+	test('each status maps to exactly one distinct kind', () => {
+		expect(routeDetailResult(notFoundResult()).kind).toBe('not-found')
+		expect(routeDetailResult(errResult()).kind).toBe('error')
+		expect(routeDetailResult(found(1)).kind).toBe('render')
+	})
+})


### PR DESCRIPTION
## What

Locks Phase 13's headline guarantee - **a detail-page DB error renders an error state and is NEVER a 404** - behind a unit test, by extracting the routing decision into a pure, testable helper. Replaces an earlier attempt (#335) whose `.tsx` page-import + `mock.module` tests poisoned bun's process-global module registry (froze `@/lib/constants/business`, breaking Footer/HomePage tests suite-wide on CI).

## Why a helper

bun's `mock.module` is a process-wide registry that cannot be un-registered, so any test that imports a detail-page loader (to assert its `notFound()`-vs-error routing) and mocks `next/navigation` poisons unrelated tests. Extracting the `status -> {not-found | error | render}` mapping into a pure function makes the regressable decision testable with plain input/output assertions - no mocks, no render, no poison.

## Changes

- **New `src/lib/admin/detail-result-routing.ts`** - pure `routeDetailResult<T>(result): { kind: 'not-found' } | { kind: 'error' } | { kind: 'render'; data: T }` (exhaustive switch, no `any`).
- **7 detail loaders migrated** to `routeDetailResult` (leads, leads/calculator, newsletter, showcase edit, testimonials edit, blog edit, emails detail). Behaviour identical: each keeps its `BUILD_PLACEHOLDER_ID` short-circuit, `connection()`, `getXById` call, and `AdminErrorState resource="..."` label byte-unchanged - only the status-branch lines now read `routing.kind`.
- **New `tests/unit/admin/detail-result-routing.test.ts`** (pure) - asserts `error -> 'error'` (NOT 'not-found'; the regression guard), `not-found -> 'not-found'`, `found -> 'render' + data`.
- **`tests/unit/admin/blog-queries.test.ts`** - added a `tagThrow` harness flag + a case: post select succeeds but the tag lookup throws -> `getBlogPostForAdmin` returns `status:'error'` (not a 404). Locks a documented sub-path.

## Verification

`bun run typecheck` clean - `bun run lint` clean - `bun run build` succeeds (all 7 detail pages still Partial-Prerender with the `__build_placeholder__` markers). Admin suite 257/0. The new tests are pure (no `mock.module`, no render, no page imports) so they cannot poison the suite.

[hudsor01]