### PR TITLE
refactor(admin): remove misleading hardcoded Topbar pageTitle (ADMINUX-01)

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -43,8 +43,7 @@ export default async function AdminLayout({
 		<div className="min-h-screen flex bg-surface-base">
 			<Sidebar />
 			<div className="flex-1 flex flex-col min-w-0">
-				{/* pageTitle: per-page titles arrive in a later phase; hardcoded for now. */}
-				<Topbar email={session.user.email} pageTitle="Admin" />
+				<Topbar email={session.user.email} />
 				<main className="flex-1 p-6 lg:p-8">{children}</main>
 			</div>
 		</div>

--- a/src/components/admin/Topbar.tsx
+++ b/src/components/admin/Topbar.tsx
@@ -4,28 +4,20 @@
  * Server by default. Importing the client `<AccountMenu />` inside a server
  * component is the standard server-imports-client pattern in the App Router
  * and does not force this file to become a client component.
- *
- * Layout passes `pageTitle` for the current page so the topbar can label
- * which screen the operator is on without each page wiring its own header.
  */
 import { AccountMenu } from '@/components/auth/AccountMenu'
 
 interface TopbarProps {
 	email: string
-	pageTitle: string
 }
 
-export function Topbar({ email, pageTitle }: TopbarProps) {
+export function Topbar({ email }: TopbarProps) {
 	return (
 		<header className="flex items-center justify-between h-14 px-6 border-b border-border bg-surface-raised">
 			<div className="flex items-center">
 				<span className="text-sm font-semibold text-foreground">
 					Hudson Digital
 				</span>
-				<span className="mx-3 text-border" aria-hidden="true">
-					/
-				</span>
-				<span className="text-sm text-muted-foreground">{pageTitle}</span>
 			</div>
 			<AccountMenu email={email} />
 		</header>


### PR DESCRIPTION
## What

The admin route-group layout passed `pageTitle="Admin"` to `Topbar`, which rendered it as a visible heading on **every** admin route - a prop that looks per-page but is a hardcoded constant (the code even admitted it: `// per-page titles arrive in a later phase; hardcoded for now`).

## Why removal is the fix

Research against the Next.js 16 layout docs confirmed a layout structurally cannot read the active child's title, and that **per-page titles already exist** here: all 18 admin routes render their own `<h1>` and export `metadata.title`. The Topbar's constant span was a redundant, always-wrong duplicate. The canonical, most-performant fix is therefore pure subtraction - no new mechanism, context, `usePathname`, or client JS.

## Changes (2 files)

- `src/components/admin/Topbar.tsx` - removed `pageTitle` from the props type + destructure + the rendering span (and the orphaned separator). Renders the wordmark + `AccountMenu`. **Stays a server component.**
- `src/app/(admin)/admin/layout.tsx` - `<Topbar email={...} />` (dropped the `pageTitle` arg) + removed the stale comment. Auth guard byte-unchanged.

No admin `page.tsx` touched; each page keeps its own title.

## Verification

`bun run lint` clean - `bun run typecheck` clean (proves the single consumer is updated) - `bun run build` green (all admin routes still Partial-Prerender). `grep pageTitle` on both files returns nothing. Unit suite: 0 net-new failures.

[hudsor01]