### PR TITLE
refactor: remove dead code (dangling stub, phantom field, unused logger no-ops, vestigial ttl field)

### DIFF
--- a/src/app/(public)/actions/ttl-calculator.tsx
+++ b/src/app/(public)/actions/ttl-calculator.tsx
@@ -37,7 +37,6 @@ const calculationResultsSchema = z.object({
 		salesTax: z.number(),
 		titleFee: z.number(),
 		registrationFees: z.number(),
-		processingFees: z.number().optional(),
 		evFee: z.number().optional(),
 		emissions: z.number().optional(),
 		totalTTL: z.number()

--- a/src/components/calculators/Calculator.tsx
+++ b/src/components/calculators/Calculator.tsx
@@ -143,7 +143,6 @@ export function Calculator() {
 					titleFee: calculationResults?.ttlResults?.titleFee ?? 0,
 					registrationFees:
 						calculationResults?.ttlResults?.registrationFees ?? 0,
-					processingFees: calculationResults?.ttlResults?.processingFees ?? 0,
 					evFee: calculationResults?.ttlResults?.evFee ?? 0,
 					emissions: calculationResults?.ttlResults?.emissions ?? 0,
 					totalTTL: calculationResults?.ttlResults?.totalTTL ?? 0

--- a/src/emails/contact-welcome.tsx
+++ b/src/emails/contact-welcome.tsx
@@ -16,12 +16,14 @@ interface ContactWelcomeProps {
 	content: string
 }
 
-// `whiteSpace: pre-wrap` preserves soft `\n` line breaks within a single
-// paragraph. No current sequence template in src/data/email-templates.json
-// uses intra-paragraph newlines (paragraphs are separated by `\n\n`), so
-// this is a no-op today. Kept for future templates that may need it; some
-// email clients (notably Outlook desktop) normalize whitespace and may
-// ignore this property — do not rely on it for critical layout.
+// Intentional defensive styling, currently inert. `whiteSpace: pre-wrap`
+// preserves soft `\n` line breaks within a single paragraph. No current
+// sequence template in src/data/email-templates.json uses intra-paragraph
+// newlines (paragraphs are separated by `\n\n`), so this property does
+// nothing today. It is deliberately retained for future templates that may
+// add intra-paragraph soft breaks; do not remove it. Caveat: some email
+// clients (notably Outlook desktop) normalize whitespace and may ignore
+// this property, so do not rely on it for critical layout.
 const PARAGRAPH_STYLE = {
 	fontSize: '14px',
 	lineHeight: 1.6,

--- a/src/lib/help-articles.ts
+++ b/src/lib/help-articles.ts
@@ -20,7 +20,6 @@ export interface HelpArticle {
 	title: string
 	content: string
 	excerpt: string | null
-	order_index: number
 	published: boolean
 	created_at: string
 	updated_at: string
@@ -85,7 +84,6 @@ const mapHelpArticle = (row: HelpArticleRow): HelpArticle => ({
 	title: row.title,
 	content: row.content,
 	excerpt: row.excerpt,
-	order_index: 0,
 	published: row.published ?? false,
 	created_at: row.createdAt?.toISOString() ?? new Date().toISOString(),
 	updated_at: row.updatedAt?.toISOString() ?? new Date().toISOString()

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -317,20 +317,6 @@ class BaseLogger implements Logger {
 			}
 		}
 	}
-
-	group(_label: string): void {
-		// No-op - console.group not allowed by ESLint rules
-		// Could implement custom grouping if needed
-	}
-
-	groupEnd(): void {
-		// No-op - console.groupEnd not allowed by ESLint rules
-	}
-
-	table(_data: unknown): void {
-		// No-op - console.table not allowed by ESLint rules
-		// Could implement custom table display if needed
-	}
 }
 
 /**

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -384,7 +384,3 @@ export async function notifyHighValueLead(
 		})
 	}
 }
-
-/**
- * Test notification endpoints
- */

--- a/src/lib/ttl-calculator/calculator.ts
+++ b/src/lib/ttl-calculator/calculator.ts
@@ -95,9 +95,6 @@ export function calculateTTL(input: VehicleInputs): TTLResults {
 		input.vehicleWeight
 	)
 
-	// Processing fees (already included in registration calculation)
-	const processingFees = 0
-
 	// EV fee (if electric vehicle)
 	const evFee = input.isElectric ? EV_FEE_ANNUAL : 0
 
@@ -111,7 +108,6 @@ export function calculateTTL(input: VehicleInputs): TTLResults {
 		salesTax,
 		titleFee,
 		registrationFees,
-		processingFees,
 		evFee,
 		emissions,
 		totalTTL

--- a/src/types/logger.ts
+++ b/src/types/logger.ts
@@ -67,13 +67,6 @@ export interface Logger {
 	// Performance timing
 	time(label: string): void
 	timeEnd(label: string): void
-
-	// Grouping (for development)
-	group(label: string): void
-	groupEnd(): void
-
-	// Table display (for development)
-	table(data: unknown): void
 }
 
 export interface ServerLogger extends Logger {

--- a/src/types/ttl-types.ts
+++ b/src/types/ttl-types.ts
@@ -3,7 +3,6 @@ export interface TTLResults {
 	salesTax: number
 	titleFee: number
 	registrationFees: number
-	processingFees: number
 	evFee: number
 	emissions: number
 	totalTTL: number

--- a/tests/unit/calculator-store.test.ts
+++ b/tests/unit/calculator-store.test.ts
@@ -49,7 +49,6 @@ describe('Calculator Store', () => {
 				salesTax: 2100,
 				titleFee: 33,
 				registrationFees: 75,
-				processingFees: 50,
 				evFee: 0,
 				emissions: 25,
 				totalTTL: 2283


### PR DESCRIPTION
## What

Audit cleanup (CLEAN-01..03) - removes genuinely dead/dangling code and documents the one intentionally-retained item. No behavior change.

## Changes

- **CLEAN-01** - delete the dangling `/** Test notification endpoints */` JSDoc at the end of `notifications.ts` (no function under it, no callers).
- **CLEAN-02** - delete the phantom `HelpArticle.order_index` field from the interface + `mapHelpArticle` (hardcoded `0`, no backing column; queries order by `createdAt`; zero readers).
- **CLEAN-03a** - delete the unused no-op `group`/`groupEnd`/`table` logger methods from **both** `src/lib/logger.ts` and the `Logger` interface in `src/types/logger.ts` (zero callers; both files required or `BaseLogger implements Logger` breaks with TS2420).
- **CLEAN-03b** - **kept** `contact-welcome` `PARAGRAPH_STYLE.whiteSpace` (it is applied defensive styling for soft line breaks); only tightened the comment to mark it intentional-but-currently-inert.
- **CLEAN-03c** - removed the vestigial `processingFees` field (always `0`, **read but never rendered**) across `ttl-calculator/calculator.ts`, `ttl-types.ts`, the ttl action schema, and `Calculator.tsx`, plus the stale assertion in `calculator-store.test.ts`. The real `PROCESSING_FEE` is already folded into `registrationFees`; zero user-visible effect.

## Verification

`bun run lint` clean - `bun run typecheck` clean (proves no TS2420; no dangling `processingFees`/`order_index` reference) - `bun run build` clean. `grep -rn "processingFees|order_index|Test notification endpoints"` returns nothing. Unit suite: 0 net-new failures.

[hudsor01]