### PR TITLE
test: lock env-gated no-op contracts (NOOP-02)

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -43,6 +43,16 @@ setupEnvMock()
 // transitively imported it — leading to flaky admin-auth tests in CI.
 require('@/lib/auth/admin')
 
+// Capture the genuine `@/lib/db` export (the createMockDb proxy, since TEST_ENV
+// omits POSTGRES_URL) at preload time, before any test file registers
+// `mock.module('@/lib/db', ...)`. Several suites (blog, showcase, api-*) stub
+// `@/lib/db`, and Bun's mock.module() registrations persist for the whole run
+// and are NOT cleared by mock.restore() (oven-sh/bun#7823) — so a later
+// `import { db } from '@/lib/db'` can never reach the real module once a
+// sibling has mocked it. Exposing the real reference here lets db.test.ts
+// assert the genuine no-op contract regardless of suite ordering.
+;(globalThis as { __REAL_DB__?: unknown }).__REAL_DB__ = require('@/lib/db').db
+
 // `server-only` throws on any import — that's its whole purpose, to fail
 // fast if a server module is reached from a client bundle. In tests we
 // run server modules under bun:test (a Node-like context) so the package

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -2,35 +2,63 @@
  * Regression test locking the db mock-proxy no-op (NOOP-02).
  *
  * TEST_ENV (tests/setup.ts) omits POSTGRES_URL, so `hasNoDatabase` is true at
- * module load and `db` is the createMockDb() proxy. The documented contract:
- * every chained query resolves to [] and never throws (CI / preview builds
- * without a database still render). This test asserts that contract so a future
- * change that makes db throw or do real work without POSTGRES_URL is caught.
+ * module load and the real `@/lib/db` export is the createMockDb() proxy. The
+ * documented contract: every chained query resolves to [] and never throws
+ * (CI / preview builds without a database still render). This test asserts that
+ * contract so a future change that makes db throw or do real work without
+ * POSTGRES_URL is caught.
+ *
+ * NOTE: it asserts against `globalThis.__REAL_DB__`, the genuine `@/lib/db`
+ * export captured at preload in tests/setup.ts. A plain `import { db } from
+ * '@/lib/db'` would be intercepted by sibling suites that register
+ * `mock.module('@/lib/db', ...)` (blog, showcase, api-*) — those registrations
+ * persist for the whole run and are never cleared by mock.restore()
+ * (oven-sh/bun#7823), so the import cannot reach the real module under
+ * full-suite ordering. The preload capture is the only pollution-immune handle
+ * on the genuine proxy under test.
  */
 import { describe, expect, it } from 'bun:test'
-import { db } from '@/lib/db'
+
+// The real createMockDb proxy captured before any sibling mock.module('@/lib/db').
+// Shapes are the chainable query-builder surface the proxy exposes; the proxy
+// resolves every chain to [] regardless of args. The cast to `unknown` on each
+// awaited value asserts the runtime contract without `any` (the proxy IS the
+// behavior under test).
+interface MockDbProxy {
+	select: () => {
+		from: (table: unknown) => { where: (clause: unknown) => unknown }
+	}
+	insert: (table: unknown) => { values: (rows: unknown) => unknown }
+}
+
+function getRealDb(): MockDbProxy {
+	const captured = (globalThis as { __REAL_DB__?: MockDbProxy }).__REAL_DB__
+	if (!captured) {
+		throw new Error(
+			'__REAL_DB__ was not captured by tests/setup.ts preload — cannot assert the db no-op contract'
+		)
+	}
+	return captured
+}
 
 describe('db mock proxy (no-op when POSTGRES_URL unset)', () => {
-	// The mock proxy resolves every chain to []; its static type is still
-	// Drizzle's typed query result, so the awaited value is cast through
-	// `unknown` to assert the runtime contract (the proxy IS the behavior
-	// under test). No `any`.
+	it('exposes the genuine createMockDb proxy via the preload capture', () => {
+		expect(getRealDb()).toBeDefined()
+	})
+
 	it('resolves a bare select() to []', async () => {
-		const result = (await db.select()) as unknown
+		const result = (await getRealDb().select()) as unknown
 		expect(result).toEqual([])
 	})
 
 	it('resolves a chained select().from().where() to [] (args ignored)', async () => {
 		// The mock proxy ignores args; {} stands in for a table reference.
-		const result = (await db
-			.select()
-			.from({} as never)
-			.where({} as never)) as unknown
+		const result = (await getRealDb().select().from({}).where({})) as unknown
 		expect(result).toEqual([])
 	})
 
 	it('does not throw for an insert chain', async () => {
-		const result = (await db.insert({} as never).values({} as never)) as unknown
+		const result = (await getRealDb().insert({}).values({})) as unknown
 		expect(result).toEqual([])
 	})
 })

--- a/tests/unit/db.test.ts
+++ b/tests/unit/db.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Regression test locking the db mock-proxy no-op (NOOP-02).
+ *
+ * TEST_ENV (tests/setup.ts) omits POSTGRES_URL, so `hasNoDatabase` is true at
+ * module load and `db` is the createMockDb() proxy. The documented contract:
+ * every chained query resolves to [] and never throws (CI / preview builds
+ * without a database still render). This test asserts that contract so a future
+ * change that makes db throw or do real work without POSTGRES_URL is caught.
+ */
+import { describe, expect, it } from 'bun:test'
+import { db } from '@/lib/db'
+
+describe('db mock proxy (no-op when POSTGRES_URL unset)', () => {
+	// The mock proxy resolves every chain to []; its static type is still
+	// Drizzle's typed query result, so the awaited value is cast through
+	// `unknown` to assert the runtime contract (the proxy IS the behavior
+	// under test). No `any`.
+	it('resolves a bare select() to []', async () => {
+		const result = (await db.select()) as unknown
+		expect(result).toEqual([])
+	})
+
+	it('resolves a chained select().from().where() to [] (args ignored)', async () => {
+		// The mock proxy ignores args; {} stands in for a table reference.
+		const result = (await db
+			.select()
+			.from({} as never)
+			.where({} as never)) as unknown
+		expect(result).toEqual([])
+	})
+
+	it('does not throw for an insert chain', async () => {
+		const result = (await db.insert({} as never).values({} as never)) as unknown
+		expect(result).toEqual([])
+	})
+})

--- a/tests/unit/error-tracking.test.ts
+++ b/tests/unit/error-tracking.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Regression test locking the reportError no-op (NOOP-02).
+ *
+ * TEST_ENV (tests/setup.ts) omits SENTRY_DSN, so reportError's `if (!env.SENTRY_DSN) return`
+ * early-return fires before Sentry.captureException. The DSN gate exists because
+ * captureException calls crypto.randomUUID() synchronously, which Next.js 16 Cache
+ * Components forbid during prerender. This test asserts the no-op contract: no
+ * Sentry.captureException call and no throw when SENTRY_DSN is unset.
+ */
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// setup.ts's beforeEach calls mock.restore(), which clears this mock.module()
+// registration between tests. Re-register it inside this file's own beforeEach
+// (which runs AFTER setup's) and lazily import reportError so it binds to the
+// live mock rather than the real @sentry/nextjs module.
+let captureException: ReturnType<typeof mock>
+
+beforeEach(() => {
+	captureException = mock(() => 'event-id')
+	mock.module('@sentry/nextjs', () => ({ captureException }))
+})
+
+describe('reportError (no-op when SENTRY_DSN unset)', () => {
+	it('does not call Sentry.captureException and does not throw', async () => {
+		const { reportError } = await import('@/lib/error-tracking')
+		expect(() => reportError(new Error('boom'), { route: '/x' })).not.toThrow()
+		expect(captureException).not.toHaveBeenCalled()
+	})
+
+	it('returns undefined for any error/tags shape', async () => {
+		const { reportError } = await import('@/lib/error-tracking')
+		expect(reportError('string-error', {})).toBeUndefined()
+		expect(captureException).not.toHaveBeenCalled()
+	})
+})

--- a/tests/unit/notifications.test.ts
+++ b/tests/unit/notifications.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test locking the notification webhook no-ops (NOOP-02).
+ *
+ * TEST_ENV (tests/setup.ts) omits SLACK_WEBHOOK_URL and DISCORD_WEBHOOK_URL.
+ * Driven only through the PUBLIC seam notifyHighValueLead (sendSlackNotification /
+ * sendDiscordNotification are module-private and stay private). Two no-op paths:
+ *   1. High score (>= NOTIFICATION_MINIMUM_THRESHOLD = 70): reaches the send path,
+ *      but each private fn early-returns false before any fetch when its webhook is unset.
+ *   2. Low score (< threshold): notifyHighValueLead early-returns before the send path.
+ * Both resolve to undefined with no fetch. A local fetch spy (the ad-conversions idiom)
+ * asserts the no-network contract; assertions live outside any mocked callback.
+ */
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { notifyHighValueLead } from '@/lib/notifications'
+
+type FetchFn = typeof globalThis.fetch
+
+const BASE_LEAD = {
+	leadId: 'lead-1',
+	firstName: 'Ada',
+	lastName: 'Lovelace',
+	email: 'ada@example.com',
+	leadQuality: 'hot',
+	source: 'contact-form'
+}
+
+describe('notifyHighValueLead (no-op when webhooks unset)', () => {
+	let originalFetch: FetchFn
+	let fetchSpy: ReturnType<typeof mock>
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+		fetchSpy = mock(() => Promise.resolve(new Response(null, { status: 204 })))
+		globalThis.fetch = fetchSpy as unknown as FetchFn
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+	})
+
+	it('resolves without any fetch for a high-score lead when webhooks unset', async () => {
+		const result = await notifyHighValueLead({ ...BASE_LEAD, leadScore: 100 })
+		expect(result).toBeUndefined()
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it('early-returns (no fetch) for a low-score lead below the threshold', async () => {
+		const result = await notifyHighValueLead({ ...BASE_LEAD, leadScore: 0 })
+		expect(result).toBeUndefined()
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
## What

Regression tests that lock the intentional, env-gated no-op behaviors by contract - so a future change that accidentally makes them throw or do real work without config is caught, and so the next audit recognizes them as intentional-by-contract. The v6 audit-remediation finale (NOOP-02). No production source or behavior change.

## Tests added

- `tests/unit/db.test.ts` - the `createMockDb` proxy resolves bare/chained/insert query chains to `[]` when `POSTGRES_URL` is unset (asserted against the genuine `@/lib/db` export via a `globalThis.__REAL_DB__` setup-preload capture, immune to other suites' `mock.module('@/lib/db')` pollution).
- `tests/unit/error-tracking.test.ts` - `reportError(...)` does NOT call `Sentry.captureException` and does not throw when `SENTRY_DSN` is unset.
- `tests/unit/notifications.test.ts` - `notifyHighValueLead(...)` resolves with no `fetch` when the Slack/Discord webhooks are unset (driven only through the public seam; the private `sendSlack`/`sendDiscord` are NOT exported - no source export added for testing).
- `tests/unit/ad-conversions.test.ts` already covers `sendAdConversion`'s no-creds no-op - verified + cited, not duplicated.

## Infra

- `tests/setup.ts` gains an additive `__REAL_DB__` preload capture (same precedent as the existing admin preload) so the db no-op test survives full-suite mock.module ordering. Test-infra only.

## Verification

`bun run typecheck` clean. New tests 8/0 against current `main`. `TEST_ENV` already omits the gating vars, so the no-op path is the default. Zero production source change (`git diff` for the 4 lib modules is empty).

[hudsor01]