### PR TITLE
fix(17): root-cause test-suite mock.module pollution (order-independent, 0-fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check test mock leaks
+        run: bash scripts/check-test-mock-leaks.sh
+
       - name: Run Biome
         run: bun run lint
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"test:e2e:animations:quick": "playwright test animations-quick.spec.ts --grep '@critical'",
 		"test:e2e:report": "playwright show-report",
 		"test:e2e:install": "playwright install",
-		"test:unit": "bun test tests/",
+		"test:unit": "bash scripts/check-test-mock-leaks.sh && bun test tests/",
 		"test:unit:watch": "bun test --watch tests/",
 		"test:unit:coverage": "bun test --coverage tests/",
 		"test:all": "bun run lint && bun run typecheck && bun run test:unit && bun run test:e2e:fast",

--- a/scripts/check-test-mock-leaks.sh
+++ b/scripts/check-test-mock-leaks.sh
@@ -27,10 +27,13 @@ set -euo pipefail
 # Single or double quotes accepted. tests/setup.ts is the sanctioned exception.
 PATTERN="mock\.module\((['\"])@/lib/(utils|constants/)"
 
-# -R recursive, -E extended regex, -n line numbers. Restrict to TS/TSX test files.
-# grep exits 1 when no match -> that is the success case here, so guard with `|| true`.
-matches="$(grep -REn "$PATTERN" tests/ --include='*.ts' --include='*.tsx' 2>/dev/null \
-	| grep -v '^tests/setup\.ts:' || true)"
+# Use `command grep` to bypass any interactive alias (some dev shells alias grep
+# to ripgrep, which would silently change pipe/flag semantics). --exclude drops
+# the one sanctioned file in a single pass so no second filter stage is needed.
+# -R recursive, -E extended regex, -n line numbers. grep exits 1 when no match ->
+# that is the success case here, so guard with `|| true`.
+matches="$(command grep -REn "$PATTERN" tests/ \
+	--include='*.ts' --include='*.tsx' --exclude='setup.ts' 2>/dev/null || true)"
 
 if [ -n "$matches" ]; then
 	echo "ERROR: partial mock of a shared pure module detected in a per-file test:" >&2

--- a/scripts/check-test-mock-leaks.sh
+++ b/scripts/check-test-mock-leaks.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Guard against process-global mock leaks in the bun:test suite.
+#
+# bun's mock.module(specifier, factory) registers the mock in a process-global
+# module registry and is NOT undone by mock.restore() (oven-sh/bun#7823). A
+# per-file PARTIAL mock of a shared pure module therefore freezes that module's
+# exports for every later test file in the run. The proven case (Phase 17):
+# tests/unit/ttl-calculator-actions.test.ts partial-mocked @/lib/utils (dropping
+# cn) and @/lib/constants/business (dropping links.facebook), breaking ~21 later
+# homepage/navigation/Footer tests with "Export named 'cn' not found".
+#
+# This guard greps tests/ for mock.module() calls targeting the proven-pure
+# shared modules and fails if any appear OUTSIDE tests/setup.ts (the single
+# sanctioned place a COMPLETE shared mock may live). It is deterministic,
+# sub-second, and order-independent, unlike a last-running canary test.
+#
+# Denylist scope (see .planning/phases/17-test-suite-isolation/17-01-PLAN.md
+# guard_scope_note): @/lib/utils and @/lib/constants/* only. @/lib/schemas/* is
+# intentionally NOT banned -- blog.test.ts and newsletter-unsubscribe-route.test.ts
+# legitimately stub Drizzle table barrels as complete column-key objects.
+#
+# Usage: bash scripts/check-test-mock-leaks.sh   (run from project root)
+
+set -euo pipefail
+
+# Denylist pattern: mock.module('@/lib/utils'...) or mock.module('@/lib/constants/...')
+# Single or double quotes accepted. tests/setup.ts is the sanctioned exception.
+PATTERN="mock\.module\((['\"])@/lib/(utils|constants/)"
+
+# -R recursive, -E extended regex, -n line numbers. Restrict to TS/TSX test files.
+# grep exits 1 when no match -> that is the success case here, so guard with `|| true`.
+matches="$(grep -REn "$PATTERN" tests/ --include='*.ts' --include='*.tsx' 2>/dev/null \
+	| grep -v '^tests/setup\.ts:' || true)"
+
+if [ -n "$matches" ]; then
+	echo "ERROR: partial mock of a shared pure module detected in a per-file test:" >&2
+	echo "" >&2
+	echo "$matches" >&2
+	echo "" >&2
+	echo "bun mock.module() is process-global and is never cleared by mock.restore()" >&2
+	echo "(oven-sh/bun#7823). A partial mock of a shared pure module freezes its" >&2
+	echo "exports for every later test file, breaking unrelated suites." >&2
+	echo "" >&2
+	echo "Fix: use the REAL module (it is pure/deterministic), OR place a COMPLETE" >&2
+	echo "shared mock in tests/setup.ts. See the convention note at the top of" >&2
+	echo "tests/setup.ts." >&2
+	exit 1
+fi
+
+echo "OK: no partial shared-module mock leaks found in tests/"
+exit 0

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -53,6 +53,23 @@ require('@/lib/auth/admin')
 // assert the genuine no-op contract regardless of suite ordering.
 ;(globalThis as { __REAL_DB__?: unknown }).__REAL_DB__ = require('@/lib/db').db
 
+// ===================================================================
+// TESTING CONVENTION: shared-module mocks (read before adding a mock)
+// ===================================================================
+// bun's mock.module(specifier, factory) is PROCESS-GLOBAL and is NEVER
+// cleared by mock.restore() (oven-sh/bun#7823). A per-file PARTIAL mock of
+// a shared pure module therefore freezes that module's exports for every
+// later test file in the run, breaking unrelated suites (e.g. a partial
+// @/lib/utils mock that drops `cn` produces "Export named 'cn' not found"
+// in homepage/navigation/Footer tests — the Phase 17 root cause).
+//
+// RULE: NEVER partial-mock a shared pure module (@/lib/utils,
+// @/lib/constants/*) in a per-file test. Use the REAL module (these are
+// pure/deterministic), or place a COMPLETE shared mock HERE in tests/setup.ts
+// (the one sanctioned place). scripts/check-test-mock-leaks.sh enforces this
+// in CI and in the local `test:unit` script.
+// ===================================================================
+
 // `server-only` throws on any import — that's its whole purpose, to fail
 // fast if a server module is reached from a client bundle. In tests we
 // run server modules under bun:test (a Node-like context) so the package

--- a/tests/unit/ttl-calculator-actions.test.ts
+++ b/tests/unit/ttl-calculator-actions.test.ts
@@ -40,67 +40,18 @@ const validResults = {
  * test can control DB behaviour independently.
  */
 function setupCommonMocks(dbMock: Record<string, unknown>) {
-	mock.module('@/env', () => ({
-		env: {
-			NODE_ENV: 'test',
-			NEXT_PUBLIC_SITE_URL: 'https://hudsondigitalsolutions.com'
-		}
-	}))
-
-	mock.module('@/lib/logger', () => ({
-		logger: {
-			debug: mock(),
-			info: mock(),
-			warn: mock(),
-			error: mock(),
-			setContext: mock()
-		},
-		castError: (error: unknown) =>
-			error instanceof Error ? error : new Error(String(error))
-	}))
-
+	// Only the two REAL boundaries are mocked here. @/env and @/lib/logger are
+	// already mocked completely by tests/setup.ts (re-applied each beforeEach),
+	// so re-mocking them locally is redundant. @/lib/utils, @/lib/constants/business
+	// and @/lib/schemas/ttl are pure/deterministic — partial-mocking them here
+	// froze their exports process-globally for every later test file (bun#7823),
+	// causing "Export named 'cn' not found" and BUSINESS_INFO.links failures.
+	// The real modules work as-is for this action.
 	mock.module('@/lib/resend-client', () => ({
 		isResendConfigured: mock().mockReturnValue(false),
 		getResendClient: mock(() => ({
 			emails: { send: mock().mockResolvedValue({ data: { id: 'test-id' } }) }
 		}))
-	}))
-
-	mock.module('@/lib/constants/business', () => ({
-		BUSINESS_INFO: {
-			name: 'Hudson Digital Solutions',
-			email: 'hello@hudsondigitalsolutions.com',
-			phone: '(214) 843-0779',
-			location: {
-				streetAddress: '1301 Cherry Hill Ln',
-				city: 'Lewisville',
-				state: 'Texas',
-				stateCode: 'TX',
-				postalCode: '75067',
-				country: 'United States',
-				latitude: 33.0462,
-				longitude: -96.9942
-			}
-		}
-	}))
-
-	mock.module('@/lib/utils', () => ({
-		formatCurrency: (n: number) => `$${n.toFixed(2)}`
-	}))
-
-	mock.module('@/lib/schemas/ttl', () => ({
-		ttlCalculations: {
-			shareCode: 'shareCode',
-			inputs: 'inputs',
-			results: 'results',
-			name: 'name',
-			email: 'email',
-			county: 'county',
-			purchasePrice: 'purchasePrice',
-			viewCount: 'viewCount',
-			lastViewedAt: 'lastViewedAt',
-			createdAt: 'createdAt'
-		}
 	}))
 
 	// Do NOT mock drizzle-orm — it exports tagged template literals and many


### PR DESCRIPTION
## What

Make `bun test tests/` order-independent and 0-fail. Today the full suite is **1052 pass / 21 fail**; the 21 failures (homepage / navigation / Footer) appear ONLY under full-suite ordering and pass in isolation. This fixes the root cause so the suite is **1073 pass / 0 fail**, stable across runs.

## Root cause

`tests/unit/ttl-calculator-actions.test.ts::setupCommonMocks()` partial-mocked pure shared modules via bun `mock.module`, which is **process-global and never cleared by `mock.restore()`** (oven-sh/bun#7823). The partial `@/lib/utils` mock dropped `cn`, so every later test importing `cn` (Navbar/Footer) failed with `SyntaxError: Export named 'cn' not found`; the partial `@/lib/constants/business` mock dropped `links`, breaking `BUSINESS_INFO.links.facebook`.

## Fix (TEST-01)

Reduce `setupCommonMocks()` to mock ONLY the real boundaries `@/lib/db` + `@/lib/resend-client` (7 `mock.module` calls -> 2). The pure modules (`@/lib/utils`, `@/lib/constants/business`, `@/lib/schemas/ttl`) now use their real implementations; `@/env` + `@/lib/logger` were redundant (already mocked completely in `tests/setup.ts`). `drizzle-orm` stays real; the db mock still intercepts query execution. No `.skip`/`xfail`/deletion of any assertion; **no `src/**` runtime change**.

## Guard (TEST-02)

New `scripts/check-test-mock-leaks.sh` — a deterministic denylist grep that fails if any per-file test partial-mocks `@/lib/utils` or `@/lib/constants/*` outside `tests/setup.ts`. Wired into the local `test:unit` script and the CI Code Quality job, plus a bun#7823 convention note in `tests/setup.ts`. Verified to exit 1 on a reintroduced leak and 0 on the clean tree (the reintroduction was reverted; never committed).

## Verification

- Full suite: 1052/21 -> **1073 pass / 0 fail**, stable across consecutive runs
- Worst-case ordering (`ttl, homepage, navigation`): 45 pass / 0 fail (no `cn`/`links` errors)
- `ttl-calculator-actions` in isolation: 10 pass / 0 fail (real modules)
- `bun run lint` clean (413 files), `bun run typecheck` clean, guard exit 0

[hudsor01]