### PR TITLE
chore(21): code hygiene (em-dash, dead exports, flattenZod dedup, casts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@
 - Call `toast.success(...)`, `toast.error(...)` directly — no custom provider
 
 **Error Handling:**
-- Two independent `castError` helpers exist: `src/lib/errors.ts` returns `Error`, `src/lib/logger.ts` returns `ErrorLogData`. Pick the one whose return type matches the call site.
+- `src/lib/logger.ts` has a private `castError` that normalizes `unknown` to `ErrorLogData`. `logger.error(message, error?)` already accepts `Error | unknown` and normalizes internally, so pass the caught `error` directly. Do NOT cast (`error as Error`) before logging, and do NOT add a separate `instanceof Error ? ... : new Error(...)` re-cast for the logger.
 - Wrap async ops in try/catch
 - Log via `logger.error` — never `console.*`
 - Return user-friendly messages; never expose internals

--- a/src/app/(admin)/admin/blog/actions.ts
+++ b/src/app/(admin)/admin/blog/actions.ts
@@ -18,7 +18,6 @@
  */
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import {
 	createBlogPost,
@@ -28,6 +27,7 @@ import {
 } from '@/lib/admin/blog-queries'
 import { isUniqueViolation } from '@/lib/admin/db-errors'
 import { formDataToObject } from '@/lib/admin/form-data'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	createAdminBlogPostSchema,
@@ -37,17 +37,6 @@ import {
 export type ActionResult =
 	| { ok: true; id: string }
 	| { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const key = issue.path.length > 0 ? issue.path.join('.') : '_form'
-		if (!(key in out)) {
-			out[key] = issue.message
-		}
-	}
-	return out
-}
 
 export async function createBlogPostAction(
 	formData: FormData

--- a/src/app/(admin)/admin/emails/actions.ts
+++ b/src/app/(admin)/admin/emails/actions.ts
@@ -24,7 +24,6 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import {
 	cancelScheduledEmail,
@@ -32,6 +31,7 @@ import {
 	retryScheduledEmail
 } from '@/lib/admin/emails-queries'
 import { formDataToObject } from '@/lib/admin/form-data'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	cancelEmailSchema,
@@ -40,17 +40,6 @@ import {
 } from '@/lib/schemas/admin-emails'
 
 type ActionResult = { ok: true } | { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const path = issue.path.join('.') || '_form'
-		if (!(path in out)) {
-			out[path] = issue.message
-		}
-	}
-	return out
-}
 
 /**
  * Reset a scheduled email so the cron picks it up again. Refuses when

--- a/src/app/(admin)/admin/leads/calculator/actions.ts
+++ b/src/app/(admin)/admin/leads/calculator/actions.ts
@@ -27,7 +27,6 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import {
 	deleteCalculatorLead,
@@ -35,6 +34,7 @@ import {
 	markCalculatorLeadConverted
 } from '@/lib/admin/calculator-leads-queries'
 import { formDataToObject } from '@/lib/admin/form-data'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	deleteCalculatorLeadSchema,
@@ -43,17 +43,6 @@ import {
 } from '@/lib/schemas/admin-calculator-leads'
 
 type ActionResult = { ok: true } | { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const path = issue.path.join('.') || '_form'
-		if (!(path in out)) {
-			out[path] = issue.message
-		}
-	}
-	return out
-}
 
 export async function markCalculatorLeadContactedAction(
 	formData: FormData

--- a/src/app/(admin)/admin/newsletter/actions.ts
+++ b/src/app/(admin)/admin/newsletter/actions.ts
@@ -27,13 +27,13 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import { formDataToObject } from '@/lib/admin/form-data'
 import {
 	deleteSubscriber,
 	setSubscriberStatus
 } from '@/lib/admin/newsletter-queries'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	deleteSubscriberSchema,
@@ -41,17 +41,6 @@ import {
 } from '@/lib/schemas/admin-newsletter'
 
 type ActionResult = { ok: true } | { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const path = issue.path.join('.') || '_form'
-		if (!(path in out)) {
-			out[path] = issue.message
-		}
-	}
-	return out
-}
 
 export async function unsubscribeSubscriberAction(
 	formData: FormData

--- a/src/app/(admin)/admin/showcase/actions.ts
+++ b/src/app/(admin)/admin/showcase/actions.ts
@@ -23,7 +23,6 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import { isUniqueViolation } from '@/lib/admin/db-errors'
 import { formDataToObject } from '@/lib/admin/form-data'
@@ -33,6 +32,7 @@ import {
 	toggleShowcasePublished,
 	updateShowcase
 } from '@/lib/admin/showcase-queries'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	createShowcaseSchema,
@@ -42,17 +42,6 @@ import {
 export type ActionResult =
 	| { ok: true; id?: string }
 	| { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const path = issue.path.join('.') || '_form'
-		if (!(path in out)) {
-			out[path] = issue.message
-		}
-	}
-	return out
-}
 
 /**
  * Translate the raw FormData (everything-is-a-string) into a shape Zod can

--- a/src/app/(admin)/admin/testimonials/actions.ts
+++ b/src/app/(admin)/admin/testimonials/actions.ts
@@ -25,7 +25,6 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
-import type { ZodError } from 'zod'
 import { requireAdminSession } from '@/lib/admin/auth'
 import { formDataToObject } from '@/lib/admin/form-data'
 import {
@@ -34,6 +33,7 @@ import {
 	toggleTestimonialPublished,
 	updateTestimonial
 } from '@/lib/admin/testimonials-queries'
+import { flattenZod } from '@/lib/admin/zod-errors'
 import { logger } from '@/lib/logger'
 import {
 	createAdminTestimonialSchema,
@@ -43,17 +43,6 @@ import {
 export type ActionResult =
 	| { ok: true; id?: string }
 	| { ok: false; errors: Record<string, string> }
-
-function flattenZod(error: ZodError): Record<string, string> {
-	const out: Record<string, string> = {}
-	for (const issue of error.issues) {
-		const path = issue.path.join('.') || '_form'
-		if (!(path in out)) {
-			out[path] = issue.message
-		}
-	}
-	return out
-}
 
 export async function createTestimonialAction(
 	formData: FormData

--- a/src/app/api/pagespeed/route.ts
+++ b/src/app/api/pagespeed/route.ts
@@ -214,7 +214,7 @@ async function handlePageSpeed(request: NextRequest) {
 		// tool honest when the upstream is simply slow (audit #236).
 		if (err.name === 'TimeoutError' || err.name === 'AbortError') {
 			return errorResponse(
-				'PageSpeed took too long to analyze that URL. Slow sites can exceed our budget — try again, or run a Lighthouse audit in your browser DevTools instead.',
+				'PageSpeed took too long to analyze that URL. Slow sites can exceed our budget. Try again, or run a Lighthouse audit in your browser DevTools instead.',
 				504
 			)
 		}

--- a/src/components/admin/FormFieldSet.tsx
+++ b/src/components/admin/FormFieldSet.tsx
@@ -24,7 +24,7 @@
  */
 import type { ReactNode } from 'react'
 
-export type FieldRenderProps = {
+type FieldRenderProps = {
 	id: string
 	'aria-describedby'?: string
 	'aria-invalid'?: 'true'

--- a/src/components/calculators/Calculator.tsx
+++ b/src/components/calculators/Calculator.tsx
@@ -53,7 +53,7 @@ export function Calculator() {
 			setSaveSuccess(true)
 			setTimeout(() => setSaveSuccess(false), TIMEOUTS.SAVE_SUCCESS)
 		} catch (error) {
-			logger.error('Failed to save calculation', error as Error)
+			logger.error('Failed to save calculation', error)
 		}
 	}
 

--- a/src/hooks/use-contact-form-submit.ts
+++ b/src/hooks/use-contact-form-submit.ts
@@ -8,7 +8,7 @@ import type { ContactFormData } from '@/lib/schemas/contact'
 
 export type { ContactFormData } from '@/lib/schemas/contact'
 
-export interface ContactFormResponse {
+interface ContactFormResponse {
 	success: boolean
 	message?: string
 	error?: string

--- a/src/hooks/use-paystub-calculator.ts
+++ b/src/hooks/use-paystub-calculator.ts
@@ -75,7 +75,7 @@ export function usePaystubCalculator(params: PaystubCalculationParams) {
 
 			return calculatePaystubTotals(stableParams)
 		} catch (error) {
-			logger.error('Paystub calculation error:', error as Error)
+			logger.error('Paystub calculation error:', error)
 			return null
 		}
 	}, [stableParams])

--- a/src/lib/ad-conversions.ts
+++ b/src/lib/ad-conversions.ts
@@ -114,6 +114,8 @@ const serviceAccountSchema = z.object({
 })
 
 /** Cheap presence check - does not parse the SA JSON. */
+// Part of the deferred ad-conversions surface (wired when paid-ad budget exists);
+// intentionally exported as public API even though no caller exists yet.
 export function isGoogleAdsConfigured(): boolean {
 	return Boolean(
 		env.GOOGLE_ADS_CUSTOMER_ID &&

--- a/src/lib/admin/zod-errors.ts
+++ b/src/lib/admin/zod-errors.ts
@@ -1,0 +1,21 @@
+import type { ZodError } from 'zod'
+
+/**
+ * Flatten a ZodError into a field-keyed message map for the admin form
+ * `{ ok: false, errors }` envelope. Nested paths join with '.'; issues with no
+ * path collapse to the form-level '_form' key. The first message per key wins.
+ *
+ * Shared by every admin Server Action (showcase / blog / testimonials /
+ * leads / emails / newsletter) so the flattening stays identical across the
+ * CRUD surfaces.
+ */
+export function flattenZod(error: ZodError): Record<string, string> {
+	const out: Record<string, string> = {}
+	for (const issue of error.issues) {
+		const path = issue.path.join('.') || '_form'
+		if (!(path in out)) {
+			out[path] = issue.message
+		}
+	}
+	return out
+}

--- a/src/lib/paystub-calculator/storage.ts
+++ b/src/lib/paystub-calculator/storage.ts
@@ -30,7 +30,7 @@ export function saveFormData(data: PaystubFormData): void {
 		}
 		localStorage.setItem(PAYSTUB_STORAGE_KEY, JSON.stringify(payload))
 	} catch (error) {
-		logger.error('Error saving paystub form data:', error as Error)
+		logger.error('Error saving paystub form data:', error)
 	}
 }
 
@@ -54,7 +54,7 @@ export function loadFormData(): PaystubFormData | null {
 
 		return parsed
 	} catch (error) {
-		logger.error('Error loading paystub form data:', error as Error)
+		logger.error('Error loading paystub form data:', error)
 		return null
 	}
 }
@@ -68,6 +68,6 @@ export function clearFormData(): void {
 	try {
 		localStorage.removeItem(PAYSTUB_STORAGE_KEY)
 	} catch (error) {
-		logger.error('Error clearing paystub form data:', error as Error)
+		logger.error('Error clearing paystub form data:', error)
 	}
 }

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -47,23 +47,6 @@ export function getClientIp(request: NextRequest): string {
 }
 
 /**
- * Extract client IP from a raw Headers object (Server Actions).
- *
- * @example
- * 'use server'
- * import { headers } from 'next/headers'
- * import { getClientIpFromHeaders } from '@/lib/request'
- *
- * export async function submitForm() {
- *   const headersList = await headers()
- *   const ip = getClientIpFromHeaders(headersList)
- * }
- */
-export function getClientIpFromHeaders(headers: Headers): string {
-	return readClientIp(headers)
-}
-
-/**
  * Verify the request originated from this site (or an explicitly allowed
  * origin). Defends against cross-origin form-encoded POSTs that bypass
  * SameSite cookies and CORS preflight.

--- a/src/lib/ttl-calculator/storage.ts
+++ b/src/lib/ttl-calculator/storage.ts
@@ -25,7 +25,7 @@ export function getSavedCalculations(): SavedCalculation[] {
 		const saved = localStorage.getItem(STORAGE_KEY)
 		return saved ? JSON.parse(saved) : []
 	} catch (error) {
-		logger.error('Error loading saved calculations:', error as Error)
+		logger.error('Error loading saved calculations:', error)
 		return []
 	}
 }
@@ -88,7 +88,7 @@ export function saveCalculation(
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed))
 		return id
 	} catch (error) {
-		logger.error('Error saving calculation:', error as Error)
+		logger.error('Error saving calculation:', error)
 		throw new Error('Failed to save calculation')
 	}
 }
@@ -108,7 +108,7 @@ export function deleteCalculation(id: string): void {
 		const filtered = calculations.filter(calc => calc.id !== id)
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered))
 	} catch (error) {
-		logger.error('Error deleting calculation:', error as Error)
+		logger.error('Error deleting calculation:', error)
 	}
 }
 
@@ -125,6 +125,6 @@ export function clearAllCalculations(): void {
 	try {
 		localStorage.removeItem(STORAGE_KEY)
 	} catch (error) {
-		logger.error('Error clearing calculations:', error as Error)
+		logger.error('Error clearing calculations:', error)
 	}
 }


### PR DESCRIPTION
## What

Final v8 hardening phase: mechanical cleanup from the post-v7 review (fallow + reviewer agents). Net -60 lines. No behavior change.

- **CLEAN-01:** `pagespeed` 504 error message em-dash -> period (the only user-facing dash violation; now dash-free).
- **CLEAN-02 (dead code):** delete genuinely-dead `getClientIpFromHeaders` (no src/test consumer); un-export `ContactFormResponse` + `FieldRenderProps` (used in-file only); justify-keep `isGoogleAdsConfigured` (deferred ad-conversions API) + `getCsrfTokenFromRequest` (has a test). `ContactFormData`/`ErrorReport` kept (actually consumed - fallow false-positive).
- **CLEAN-03 (dedup):** extract the copy-pasted `flattenZod` (ZodError -> field map) from all 6 admin `actions.ts` into `src/lib/admin/zod-errors.ts`. `ActionResult` left per-file (only 3 define it; blog's `id` is required, not optional - sharing would wrongly widen the type). NewsletterSignup self-dup kept by decision (two independently-styled variant branches; deduping risks visual regressions with no visual test).
- **CLEAN-04:** drop 9 unsound `error as Error` casts feeding `logger.error` (it accepts `Error | unknown` and normalizes).
- **CLEAN-05:** `CLAUDE.md` no longer references the deleted `src/lib/errors.ts`. Favicons (`icon0`/`icon1`) confirmed serving (build emits `/icon`, `/icon0`, `/icon1` - fallow's "unused files" was a false-positive). `BASE_URL` is `optional().default(localhost)` -> operator should confirm it is set in the prod Vercel env (the `request.ts` same-origin check depends on it); left unchanged (security-sensitive, out of scope for hygiene).

## Verification
- `bun run lint` clean (415 files), `bun run typecheck` clean, full `bun test tests/` **1090/0**, `bun run build` compiled.
- `fallow dead-code`: unused type exports 4 -> 2 (remaining are used; false-positives); `getClientIpFromHeaders` gone.

CLEAN-01..05.

[hudsor01]