### PR TITLE
fix: resolve residual low-severity issues (rss escape, csp guard, testimonial back-link)

### DIFF
--- a/src/app/api/csp-reports/route.ts
+++ b/src/app/api/csp-reports/route.ts
@@ -44,6 +44,12 @@ async function handleCspReport(request: NextRequest) {
 
 		// Sanitize and log only the needed fields
 		const cspReport = isCspReport ? body['csp-report'] : body
+		// `body['csp-report']` may be a string/number/null even when the key is
+		// present; guard before indexing so a malformed payload is a clean 400
+		// instead of a thrown read on a non-object.
+		if (!cspReport || typeof cspReport !== 'object') {
+			return new NextResponse(null, { status: 400 })
+		}
 		const sanitizedReport = {
 			blockedUri: cspReport['blocked-uri'],
 			violatedDirective: cspReport['violated-directive'],

--- a/src/app/api/rss/feed/route.ts
+++ b/src/app/api/rss/feed/route.ts
@@ -7,7 +7,7 @@
 import { NextResponse } from 'next/server'
 import { getPosts } from '@/lib/blog'
 import { logger } from '@/lib/logger'
-import { escapeCdata } from '@/lib/xml-escape'
+import { escapeCdata, escapeXml } from '@/lib/xml-escape'
 
 const SITE_URL = 'https://hudsondigitalsolutions.com'
 const FEED_TITLE = 'Hudson Digital Solutions Blog'
@@ -23,8 +23,8 @@ export async function GET() {
 				post => `
     <item>
       <title><![CDATA[${escapeCdata(post.title)}]]></title>
-      <link>${SITE_URL}/blog/${post.slug}</link>
-      <guid isPermaLink="true">${SITE_URL}/blog/${post.slug}</guid>
+      <link>${SITE_URL}/blog/${escapeXml(post.slug)}</link>
+      <guid isPermaLink="true">${SITE_URL}/blog/${escapeXml(post.slug)}</guid>
       <description><![CDATA[${escapeCdata(post.excerpt ?? '')}]]></description>
       <pubDate>${new Date(post.published_at).toUTCString()}</pubDate>
     </item>`

--- a/src/app/api/testimonials/submit/route.tsx
+++ b/src/app/api/testimonials/submit/route.tsx
@@ -53,7 +53,6 @@ async function handleTestimonialSubmit(request: NextRequest) {
 		}
 
 		const testimonial = await submitTestimonial({
-			request_id: testimonialRequest.id,
 			client_name: body.client_name,
 			company: body.company,
 			role: body.role,
@@ -69,7 +68,9 @@ async function handleTestimonialSubmit(request: NextRequest) {
 		}
 
 		// Hard-purge cache so subsequent requests see `submitted: true`.
-		const marked = await markRequestSubmitted(body.token)
+		// Pass the new testimonial id so the request -> testimonial back-link
+		// (testimonial_requests.testimonial_id) is recorded.
+		const marked = await markRequestSubmitted(body.token, testimonial.id)
 		if (!marked) {
 			logger.error(
 				'Failed to mark testimonial request as submitted; cache not invalidated',

--- a/src/lib/testimonials.ts
+++ b/src/lib/testimonials.ts
@@ -164,15 +164,22 @@ export async function getTestimonialRequests(): Promise<TestimonialRequest[]> {
 }
 
 /**
- * Mark a testimonial request as submitted
+ * Mark a testimonial request as submitted, linking it to the testimonial it
+ * produced. Passing `testimonialId` populates `testimonial_requests.testimonial_id`
+ * so the request -> testimonial back-link (read by `mapTestimonialRequest`) is
+ * recorded; omit it to only flip the status.
  */
-export async function markRequestSubmitted(token: string): Promise<boolean> {
+export async function markRequestSubmitted(
+	token: string,
+	testimonialId?: string
+): Promise<boolean> {
 	try {
 		await db
 			.update(testimonialRequests)
 			.set({
 				status: 'submitted',
-				submittedAt: new Date()
+				submittedAt: new Date(),
+				...(testimonialId ? { testimonialId } : {})
 			})
 			.where(eq(testimonialRequests.token, token))
 		return true
@@ -192,7 +199,6 @@ export async function markRequestSubmitted(token: string): Promise<boolean> {
  * Submit a testimonial
  */
 export async function submitTestimonial(testimonial: {
-	request_id?: string
 	client_name: string
 	company?: string
 	role?: string

--- a/src/lib/xml-escape.ts
+++ b/src/lib/xml-escape.ts
@@ -15,3 +15,21 @@
 export function escapeCdata(value: string): string {
 	return value.replace(/]]>/g, ']]]]><![CDATA[>')
 }
+
+/**
+ * Escape the five XML predefined entities for use in element text / attribute
+ * values that are NOT wrapped in CDATA (e.g. an RSS `<link>` or `<guid>` whose
+ * content is interpolated directly).
+ *
+ * Blog slugs are constrained to `[a-z0-9-]` today, so this is defense in depth:
+ * if that constraint ever loosens, an `&`/`<`/`>` in a slug would otherwise
+ * produce invalid XML that breaks feed parsers.
+ */
+export function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+}

--- a/tests/unit/api-csp-reports.test.ts
+++ b/tests/unit/api-csp-reports.test.ts
@@ -53,4 +53,12 @@ describe('POST /api/csp-reports', () => {
 		const res = await POST(makeRequest({ unrelated: 'payload' }))
 		expect(res.status).toBe(400)
 	})
+
+	it('returns 400 when the csp-report value is not an object', async () => {
+		// The `csp-report` key is present (so the report-shape gate passes) but
+		// its value is a string; indexing it would throw without the guard.
+		const { POST } = await import('@/app/api/csp-reports/route')
+		const res = await POST(makeRequest({ 'csp-report': 'not-an-object' }))
+		expect(res.status).toBe(400)
+	})
 })

--- a/tests/unit/rss-feed-route.test.ts
+++ b/tests/unit/rss-feed-route.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, test } from 'bun:test'
-import { escapeCdata } from '@/lib/xml-escape'
+import { escapeCdata, escapeXml } from '@/lib/xml-escape'
 
 describe('escapeCdata', () => {
 	test('passes plain text through unchanged', () => {
@@ -50,5 +50,24 @@ describe('escapeCdata', () => {
 		const wrapped = `<![CDATA[${escapeCdata('a ]]> b ]]> c')}]]>`
 		const stripped = wrapped.replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
 		expect(stripped).toBe('')
+	})
+})
+
+describe('escapeXml', () => {
+	test('passes a normal blog slug through unchanged', () => {
+		expect(escapeXml('my-first-post')).toBe('my-first-post')
+		expect(escapeXml('')).toBe('')
+	})
+
+	test('escapes the five XML predefined entities', () => {
+		expect(escapeXml('a & b')).toBe('a &amp; b')
+		expect(escapeXml('a < b > c')).toBe('a &lt; b &gt; c')
+		expect(escapeXml(`"quote" 'apos'`)).toBe('&quot;quote&quot; &apos;apos&apos;')
+	})
+
+	test('escapes & before producing entities (no double-escape)', () => {
+		// & must be escaped first so the < it precedes does not yield &amp;lt;
+		expect(escapeXml('<tag>')).toBe('&lt;tag&gt;')
+		expect(escapeXml('&amp;')).toBe('&amp;amp;')
 	})
 })

--- a/tests/unit/testimonials-back-link.test.ts
+++ b/tests/unit/testimonials-back-link.test.ts
@@ -1,0 +1,80 @@
+/**
+ * markRequestSubmitted must record the request -> testimonial back-link.
+ *
+ * When a testimonialId is passed, it has to land in the UPDATE .set() payload
+ * (testimonial_requests.testimonial_id) alongside the status flip; when omitted,
+ * the column is left untouched.
+ *
+ * Uses a COMPLETE @/lib/db mock (a real boundary, not a shared pure module) that
+ * mirrors setupApiMocks' chainable shape so the process-global mock (bun#7823)
+ * stays compatible with sibling suites, while capturing the .set() argument.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { cleanupMocks } from '../test-utils'
+
+// Load testimonials.ts by absolute path + a unique query each call so we always
+// get a FRESH module instance bound to the @/lib/db mock registered just below
+// (a sibling suite may have already cached @/lib/testimonials against a different
+// db mock; bun#7823 mock.module re-registration does not rebind a cached import).
+const TESTIMONIALS_SPECIFIER = new URL(
+	'../../src/lib/testimonials.ts',
+	import.meta.url
+).pathname
+
+async function importTestimonialsFresh() {
+	return import(`${TESTIMONIALS_SPECIFIER}?fresh=${Date.now()}-${Math.random()}`)
+}
+
+let capturedSet: Record<string, unknown> | undefined
+
+function mockDb(): void {
+	capturedSet = undefined
+	mock.module('@/lib/db', () => ({
+		db: {
+			select: mock().mockReturnValue({
+				from: mock().mockReturnValue({
+					where: mock().mockReturnValue({ limit: mock().mockResolvedValue([]) }),
+					orderBy: mock().mockResolvedValue([]),
+					limit: mock().mockResolvedValue([])
+				})
+			}),
+			insert: mock().mockReturnValue({
+				values: mock().mockReturnValue({ returning: mock().mockResolvedValue([]) })
+			}),
+			update: mock().mockReturnValue({
+				set: mock((payload: Record<string, unknown>) => {
+					capturedSet = payload
+					return { where: mock().mockResolvedValue([]) }
+				})
+			}),
+			delete: mock().mockReturnValue({ where: mock().mockResolvedValue([]) })
+		}
+	}))
+}
+
+describe('markRequestSubmitted back-link', () => {
+	beforeEach(() => {
+		mockDb()
+	})
+
+	afterEach(() => {
+		cleanupMocks()
+	})
+
+	it('records testimonialId in the UPDATE when one is provided', async () => {
+		const { markRequestSubmitted } = await importTestimonialsFresh()
+		const ok = await markRequestSubmitted('token-123', 'testimonial-abc')
+		expect(ok).toBe(true)
+		expect(capturedSet?.status).toBe('submitted')
+		expect(capturedSet?.testimonialId).toBe('testimonial-abc')
+	})
+
+	it('omits testimonialId from the UPDATE when none is provided', async () => {
+		const { markRequestSubmitted } = await importTestimonialsFresh()
+		const ok = await markRequestSubmitted('token-123')
+		expect(ok).toBe(true)
+		expect(capturedSet?.status).toBe('submitted')
+		expect('testimonialId' in (capturedSet ?? {})).toBe(false)
+	})
+})


### PR DESCRIPTION
## What

Fixes the three genuine remaining LOW issues from the post-v7 review (the rest were intentional/false-positives or judgment-deferred). Each with a regression test; full suite 1090 -> **1096 / 0 fail**.

- **RSS slug XML escaping (defense in depth):** `<link>`/`<guid>` interpolated `post.slug` as raw element text while title/excerpt used `escapeCdata`. Added `escapeXml()` (the five XML entities) and applied it to the slug. Slugs are constrained to `[a-z0-9-]` today, so this guards against a future constraint loosening producing invalid feed XML.
- **csp-reports object guard:** `body['csp-report']` can be a string/number/null even when the key is present; indexing it would throw or read undefined. Added an explicit object guard -> clean 400 on a malformed report.
- **Testimonial request -> testimonial back-link:** `testimonial_requests.testimonial_id` is read by `mapTestimonialRequest` but was never written. `submitTestimonial` took an unused `request_id` param and `markRequestSubmitted` only flipped status. Now `markRequestSubmitted(token, testimonialId)` records the link, the submit route passes the new testimonial id, and the dead param is removed. (The client's body field was already stripped by the Zod schema; left as-is.)

## Verification
- `tsc --noEmit` clean; `biome check src/` clean (415 files); `bun run build` compiled.
- full `bun test tests/` **1096 / 0 fail** (+6 tests), stable across 2 consecutive runs; mock-leak guard green. The back-link test uses a fresh-import + complete `@/lib/db` mock so it is order-independent (bun#7823).

[hudsor01]