### PR TITLE
feat: lead -> sale revenue-value reporting (Google Ads value-based bidding)

### DIFF
--- a/src/app/(admin)/admin/leads/[id]/page.tsx
+++ b/src/app/(admin)/admin/leads/[id]/page.tsx
@@ -31,10 +31,12 @@ import { BUILD_PLACEHOLDER_ID } from '@/lib/admin/build-placeholder'
 import { routeDetailResult } from '@/lib/admin/detail-result-routing'
 import { getLeadById } from '@/lib/admin/leads-queries'
 import { LEAD_STATUSES } from '@/lib/schemas/admin-leads'
+import { formatCurrency } from '@/lib/utils'
 import {
 	addLeadNoteAction,
 	deleteLeadAction,
 	deleteLeadNoteAction,
+	markLeadWonAction,
 	updateLeadStatusAction
 } from '../actions'
 
@@ -75,6 +77,10 @@ async function LeadDetailLoader({ params }: AdminLeadDetailPageProps) {
 		return <AdminErrorState resource="lead" />
 	}
 	const { lead, attribution, notes } = routing.data
+	const adAttributed = Boolean(
+		(lead.metadata as { attribution?: { gclid?: string } } | null)?.attribution
+			?.gclid
+	)
 
 	return (
 		<div className="space-y-6">
@@ -168,6 +174,71 @@ async function LeadDetailLoader({ params }: AdminLeadDetailPageProps) {
 							)
 						})}
 					</div>
+				</div>
+			</section>
+
+			<section>
+				<h2 className="text-lg font-semibold text-foreground">Revenue</h2>
+				<div className="rounded-xl border border-border bg-surface-raised p-4 mt-2 space-y-3">
+					{lead.dealValue ? (
+						<dl className="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2 text-sm">
+							<div>
+								<dt className="text-xs uppercase tracking-wider text-muted-foreground">
+									Deal value
+								</dt>
+								<dd className="text-foreground font-semibold">
+									{formatCurrency(Number(lead.dealValue))}
+								</dd>
+							</div>
+							{lead.wonAt && (
+								<div>
+									<dt className="text-xs uppercase tracking-wider text-muted-foreground">
+										Won
+									</dt>
+									<dd className="text-foreground">
+										{new Date(lead.wonAt).toLocaleDateString()}
+									</dd>
+								</div>
+							)}
+						</dl>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							Not marked as won yet.
+						</p>
+					)}
+
+					<form
+						action={markLeadWonAction}
+						className="flex flex-wrap items-end gap-2"
+					>
+						<input type="hidden" name="id" value={lead.id} />
+						<label className="flex flex-col gap-1 text-xs uppercase tracking-wider text-muted-foreground">
+							Deal value (USD)
+							<input
+								type="number"
+								name="dealValue"
+								step="0.01"
+								min="0"
+								required
+								defaultValue={lead.dealValue ?? ''}
+								className="rounded-md border border-border bg-surface-base px-3 py-1.5 text-sm text-foreground"
+							/>
+						</label>
+						<button
+							type="submit"
+							className={`${STATUS_BTN_BASE} ${STATUS_BTN_ACTIVE}`}
+						>
+							{lead.dealValue ? 'Update deal value' : 'Mark as won'}
+						</button>
+					</form>
+
+					<p className="text-xs text-muted-foreground">
+						{adAttributed
+							? lead.adConversionSentAt
+								? 'Ad-attributed (Google click id). Sale value reported to Google Ads.'
+								: 'Ad-attributed (Google click id). Sale value uploads to Google Ads on mark-won once the Sale conversion action is configured.'
+							: 'No Google click id on this lead (organic, direct, or other source); nothing is sent to Google Ads.'}
+					</p>
 				</div>
 			</section>
 

--- a/src/app/(admin)/admin/leads/actions.ts
+++ b/src/app/(admin)/admin/leads/actions.ts
@@ -42,19 +42,25 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { after } from 'next/server'
+import { sendSaleConversion } from '@/lib/ad-conversions'
 import { requireAdminSession } from '@/lib/admin/auth'
 import { formDataToObject } from '@/lib/admin/form-data'
 import {
 	addLeadNote,
 	deleteLead,
 	deleteLeadNote,
+	markLeadWon,
+	recordSaleConversionSent,
 	updateLeadStatus
 } from '@/lib/admin/leads-queries'
+import type { Attribution } from '@/lib/attribution'
 import { logger } from '@/lib/logger'
 import {
 	addLeadNoteSchema,
 	deleteLeadNoteSchema,
 	deleteLeadSchema,
+	markLeadWonSchema,
 	updateLeadStatusSchema
 } from '@/lib/schemas/admin-leads'
 
@@ -79,6 +85,58 @@ export async function updateLeadStatusAction(
 		logger.error('updateLeadStatusAction failed', e)
 		return
 	}
+	revalidatePath('/admin/leads')
+	revalidatePath(`/admin/leads/${parsed.data.id}`)
+}
+
+/**
+ * Mark a lead as won with the closed-deal value, and (after the response, once,
+ * if the lead carries a Google click id and the creds are set) upload that value
+ * to the Google Ads "Sale" conversion action so the campaign optimizes toward
+ * revenue. The upload is idempotent: it only fires when `adConversionSentAt` is
+ * still null, and only stamps "sent" on a confirmed upload.
+ */
+export async function markLeadWonAction(formData: FormData): Promise<void> {
+	await requireAdminSession()
+	const parsed = markLeadWonSchema.safeParse(formDataToObject(formData))
+	if (!parsed.success) {
+		logger.error('markLeadWonAction invalid input', parsed.error)
+		return
+	}
+
+	let lead: Awaited<ReturnType<typeof markLeadWon>>
+	try {
+		lead = await markLeadWon(parsed.data.id, parsed.data.dealValue)
+	} catch (e) {
+		logger.error('markLeadWonAction failed', e)
+		return
+	}
+	if (!lead) {
+		logger.error('markLeadWonAction lead not found', { id: parsed.data.id })
+		return
+	}
+
+	const attribution =
+		(lead.metadata as { attribution?: Attribution } | null)?.attribution ?? null
+	if (!lead.adConversionSentAt && attribution?.gclid) {
+		const leadId = lead.id
+		const email = lead.email
+		const phone = lead.phone
+		const value = parsed.data.dealValue
+		after(async () => {
+			const result = await sendSaleConversion({
+				leadId,
+				email,
+				phone,
+				attribution,
+				value
+			})
+			if (result.status === 'uploaded') {
+				await recordSaleConversionSent(leadId, result.requestId)
+			}
+		})
+	}
+
 	revalidatePath('/admin/leads')
 	revalidatePath(`/admin/leads/${parsed.data.id}`)
 }

--- a/src/app/(admin)/admin/leads/page.tsx
+++ b/src/app/(admin)/admin/leads/page.tsx
@@ -55,9 +55,13 @@ import {
 	TableHeader,
 	TableRow
 } from '@/components/ui/table'
-import { listLeadsForAdmin } from '@/lib/admin/leads-queries'
+import {
+	getLeadsRevenueSummary,
+	listLeadsForAdmin
+} from '@/lib/admin/leads-queries'
 import { buildPaginationHref } from '@/lib/admin/list-cursor'
 import { LEAD_STATUSES, type LeadStatus } from '@/lib/schemas/admin-leads'
+import { formatCurrency } from '@/lib/utils'
 
 export const metadata: Metadata = {
 	title: 'Admin: Leads',
@@ -74,6 +78,45 @@ const FILTER_OPTIONS: StatusFilterOption[] = [
 
 interface AdminLeadsPageProps {
 	searchParams: Promise<{ status?: string; q?: string; cursor?: string }>
+}
+
+/**
+ * Revenue rollup of won leads: total closed value + the ad-attributed subset
+ * (won leads carrying a Google click id) -- the "did the ad generate revenue"
+ * number. Renders nothing until at least one lead is marked won.
+ */
+async function RevenueSummary() {
+	await connection()
+	const s = await getLeadsRevenueSummary()
+	if (s.wonCount === 0) {
+		return null
+	}
+	const cards: { label: string; value: string }[] = [
+		{ label: 'Won leads', value: String(s.wonCount) },
+		{ label: 'Total revenue', value: formatCurrency(s.totalValue) },
+		{ label: 'Ad-attributed leads', value: String(s.adAttributedCount) },
+		{
+			label: 'Ad-attributed revenue',
+			value: formatCurrency(s.adAttributedValue)
+		}
+	]
+	return (
+		<dl className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+			{cards.map(c => (
+				<div
+					key={c.label}
+					className="rounded-xl border border-border bg-surface-raised p-4"
+				>
+					<dt className="text-xs uppercase tracking-wider text-muted-foreground">
+						{c.label}
+					</dt>
+					<dd className="mt-1 text-xl font-semibold text-foreground">
+						{c.value}
+					</dd>
+				</div>
+			))}
+		</dl>
+	)
 }
 
 async function LeadsList({ searchParams }: AdminLeadsPageProps) {
@@ -228,6 +271,9 @@ export default function AdminLeadsPage({ searchParams }: AdminLeadsPageProps) {
 					Calculator leads
 				</Link>
 			</div>
+			<Suspense fallback={null}>
+				<RevenueSummary />
+			</Suspense>
 			<Suspense
 				fallback={
 					<div className="text-sm text-muted-foreground">Loading leads...</div>

--- a/src/components/admin/StatusBadge.tsx
+++ b/src/components/admin/StatusBadge.tsx
@@ -26,6 +26,7 @@ const STATUS_CLASSES: Record<string, string> = {
 	new: 'text-info-text bg-info-light border-border',
 	contacted: 'text-accent-text bg-surface-base border-border',
 	qualified: 'text-success-text bg-success-light border-border',
+	won: 'text-success-text bg-success-light border-success-text',
 	closed: 'text-muted-foreground bg-surface-raised border-border',
 	// newsletter
 	active: 'text-success-text bg-success-light border-border',

--- a/src/env.ts
+++ b/src/env.ts
@@ -138,6 +138,10 @@ export const env = createEnv({
 		// is only needed when calling through a manager (MCC) account.
 		GOOGLE_ADS_CUSTOMER_ID: z.string().optional(),
 		GOOGLE_ADS_CONVERSION_ACTION_ID: z.string().optional(),
+		// Separate conversion action for closed-deal (sale) value uploads, so
+		// leads bid on volume and sales on revenue. Optional;
+		// sendSaleConversion() no-ops until it is set.
+		GOOGLE_ADS_SALE_CONVERSION_ACTION_ID: z.string().optional(),
 		GOOGLE_ADS_LOGIN_CUSTOMER_ID: z.string().optional(),
 		GOOGLE_ADS_SA_JSON: z.string().optional()
 	},
@@ -191,6 +195,8 @@ export const env = createEnv({
 		GOOGLE_ADS_CUSTOMER_ID: process.env.GOOGLE_ADS_CUSTOMER_ID,
 		GOOGLE_ADS_CONVERSION_ACTION_ID:
 			process.env.GOOGLE_ADS_CONVERSION_ACTION_ID,
+		GOOGLE_ADS_SALE_CONVERSION_ACTION_ID:
+			process.env.GOOGLE_ADS_SALE_CONVERSION_ACTION_ID,
 		GOOGLE_ADS_LOGIN_CUSTOMER_ID: process.env.GOOGLE_ADS_LOGIN_CUSTOMER_ID,
 		GOOGLE_ADS_SA_JSON: process.env.GOOGLE_ADS_SA_JSON,
 

--- a/src/lib/ad-conversions.ts
+++ b/src/lib/ad-conversions.ts
@@ -35,6 +35,21 @@ const INGEST_ENDPOINT = 'https://datamanager.googleapis.com/v1/events:ingest'
 const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token'
 const DATA_MANAGER_SCOPE = 'https://www.googleapis.com/auth/datamanager'
 
+/**
+ * Which conversion action the event targets:
+ *  - `lead`: the form-fill conversion (count-based), fired at submit.
+ *  - `sale`: the closed-deal conversion (value-based), fired when a lead is
+ *    marked won. Uses a SEPARATE Google Ads conversion action so the campaign
+ *    can bid leads on volume and sales on revenue.
+ */
+export type ConversionKind = 'lead' | 'sale'
+
+/** Result of an offline-conversion upload (used by the sale path for idempotency). */
+export type ConversionUploadResult =
+	| { status: 'uploaded'; requestId?: string }
+	| { status: 'skipped' } // no creds, or the lead carries no Google click id
+	| { status: 'error' }
+
 // ---------------------------------------------------------------------------
 // Types (mirrors the Data Manager API IngestEventsRequest shape)
 // ---------------------------------------------------------------------------
@@ -124,9 +139,12 @@ export function isGoogleAdsConfigured(): boolean {
 	)
 }
 
-function getConfig(): GoogleAdsConfig | null {
+function getConfig(kind: ConversionKind = 'lead'): GoogleAdsConfig | null {
 	const customerId = env.GOOGLE_ADS_CUSTOMER_ID
-	const conversionActionId = env.GOOGLE_ADS_CONVERSION_ACTION_ID
+	const conversionActionId =
+		kind === 'sale'
+			? env.GOOGLE_ADS_SALE_CONVERSION_ACTION_ID
+			: env.GOOGLE_ADS_CONVERSION_ACTION_ID
 	const saJson = env.GOOGLE_ADS_SA_JSON
 
 	if (!customerId || !conversionActionId || !saJson) {
@@ -248,7 +266,8 @@ function extractClickIds(
  */
 export function buildIngestPayload(
 	params: AdConversionParams,
-	config: GoogleAdsConfig
+	config: GoogleAdsConfig,
+	reference: ConversionKind = 'lead'
 ): IngestPayload | null {
 	const adIdentifiers = extractClickIds(params.attribution)
 	if (!adIdentifiers.gclid && !adIdentifiers.wbraid && !adIdentifiers.gbraid) {
@@ -267,7 +286,7 @@ export function buildIngestPayload(
 	}
 
 	const event: IngestEvent = {
-		destinationReferences: ['lead'],
+		destinationReferences: [reference],
 		transactionId: params.leadId ?? randomUUID(),
 		eventTimestamp: (params.occurredAt ?? new Date()).toISOString(),
 		eventSource: 'WEB',
@@ -282,7 +301,7 @@ export function buildIngestPayload(
 	}
 
 	const destination: Destination = {
-		reference: 'lead',
+		reference,
 		operatingAccount: { product: 'GOOGLE_ADS', accountId: config.customerId },
 		productDestinationId: config.conversionActionId
 	}
@@ -363,23 +382,24 @@ async function mintAccessToken(sa: ServiceAccount): Promise<string> {
 // ---------------------------------------------------------------------------
 
 /**
- * Upload a lead conversion to Google Ads. No-op (and never throws) when creds
- * are unset or the lead has no Google click ID. Safe to call unconditionally
- * from the contact route's `after()` block.
+ * Core upload: mint a token, POST the events:ingest payload, classify the
+ * outcome. No-op (`skipped`) when creds for `kind` are unset or the lead has
+ * no Google click id; never throws (returns `error` instead).
  */
-export async function sendAdConversion(
-	params: AdConversionParams
-): Promise<void> {
+async function uploadConversion(
+	params: AdConversionParams,
+	kind: ConversionKind
+): Promise<ConversionUploadResult> {
 	try {
-		const config = getConfig()
+		const config = getConfig(kind)
 		if (!config) {
-			return
+			return { status: 'skipped' }
 		}
 
-		const payload = buildIngestPayload(params, config)
+		const payload = buildIngestPayload(params, config, kind)
 		if (!payload) {
 			// No Google click ID -> not a Google Ads lead; nothing to report.
-			return
+			return { status: 'skipped' }
 		}
 
 		const token = await mintAccessToken(config.serviceAccount)
@@ -394,21 +414,48 @@ export async function sendAdConversion(
 
 		if (!res.ok) {
 			logger.error(
-				'Google Ads conversion upload failed',
+				`Google Ads ${kind} conversion upload failed`,
 				new Error(`Data Manager API ${res.status}: ${await res.text()}`),
 				{ metadata: { leadId: params.leadId } }
 			)
-			return
+			return { status: 'error' }
 		}
 
 		const body = (await res.json().catch(() => ({}))) as { requestId?: string }
-		logger.info('Google Ads conversion uploaded', {
+		logger.info(`Google Ads ${kind} conversion uploaded`, {
 			leadId: params.leadId,
 			requestId: body.requestId
 		})
+		return { status: 'uploaded', requestId: body.requestId }
 	} catch (error) {
-		logger.error('Google Ads conversion upload threw', error, {
+		logger.error(`Google Ads ${kind} conversion upload threw`, error, {
 			metadata: { leadId: params.leadId }
 		})
+		return { status: 'error' }
 	}
+}
+
+/**
+ * Upload a lead (form-fill) conversion to Google Ads. No-op (and never throws)
+ * when creds are unset or the lead has no Google click ID. Safe to call
+ * unconditionally from the contact route's `after()` block.
+ */
+export async function sendAdConversion(
+	params: AdConversionParams
+): Promise<void> {
+	await uploadConversion(params, 'lead')
+}
+
+/**
+ * Upload a closed-deal (sale) conversion VALUE to the Google Ads "Sale"
+ * conversion action (`GOOGLE_ADS_SALE_CONVERSION_ACTION_ID`), keyed on the
+ * gclid captured at click time. Returns the upload outcome so the caller can
+ * record idempotency (only `uploaded` should be persisted as "sent"). No-op
+ * (`skipped`) when the sale action / creds are unset or the lead carries no
+ * Google click ID; never throws.
+ */
+export async function sendSaleConversion(
+	params: AdConversionParams & { value: number }
+): Promise<ConversionUploadResult> {
+	return uploadConversion(params, 'sale')
 }

--- a/src/lib/admin/leads-queries.ts
+++ b/src/lib/admin/leads-queries.ts
@@ -25,7 +25,18 @@
  */
 import 'server-only'
 
-import { and, asc, desc, eq, gt, ilike, lt, or, type SQL } from 'drizzle-orm'
+import {
+	and,
+	asc,
+	desc,
+	eq,
+	gt,
+	ilike,
+	lt,
+	or,
+	type SQL,
+	sql
+} from 'drizzle-orm'
 import {
 	type Direction,
 	decodeCursor,
@@ -252,6 +263,93 @@ export async function updateLeadStatus(
 		.where(eq(leads.id, id))
 		.returning()
 	return row ?? null
+}
+
+/**
+ * Mark a lead as won with the closed-deal value: sets `status='won'`,
+ * `deal_value`, `won_at`, bumps `updated_at`. Returns the updated row (incl.
+ * `metadata` for the sale-conversion gclid and the `adConversionSentAt`
+ * idempotency stamp), or null when the lead does not exist. `numeric` maps to
+ * a string in Drizzle, so the value is stored as its string form.
+ */
+export async function markLeadWon(
+	id: string,
+	dealValue: number
+): Promise<Lead | null> {
+	const [row] = await db
+		.update(leads)
+		.set({
+			status: 'won',
+			dealValue: dealValue.toString(),
+			wonAt: new Date(),
+			updatedAt: new Date()
+		})
+		.where(eq(leads.id, id))
+		.returning()
+	return row ?? null
+}
+
+/**
+ * Stamp that the Google Ads "Sale" conversion-value upload succeeded so it is
+ * never sent twice. Best-effort: a failure is logged, not thrown (the sale is
+ * already recorded; the action also guards on the stamp before re-uploading).
+ */
+export async function recordSaleConversionSent(
+	id: string,
+	requestId?: string
+): Promise<void> {
+	try {
+		await db
+			.update(leads)
+			.set({
+				adConversionSentAt: new Date(),
+				adConversionRequestId: requestId ?? null
+			})
+			.where(eq(leads.id, id))
+	} catch (error) {
+		logger.error('leads-queries.recordSaleConversionSent failed', error, {
+			metadata: { id }
+		})
+	}
+}
+
+export interface LeadsRevenueSummary {
+	wonCount: number
+	totalValue: number
+	adAttributedCount: number
+	adAttributedValue: number
+}
+
+/**
+ * Revenue rollup for the `/admin/leads` header: count + summed `deal_value` of
+ * won leads, plus the ad-attributed subset (won leads whose stored attribution
+ * carries a Google click id at `metadata->attribution->gclid`). The
+ * ad-attributed value is the real "revenue this campaign generated" number.
+ * Returns zeros on a query blip rather than crashing the list page.
+ */
+export async function getLeadsRevenueSummary(): Promise<LeadsRevenueSummary> {
+	const zero: LeadsRevenueSummary = {
+		wonCount: 0,
+		totalValue: 0,
+		adAttributedCount: 0,
+		adAttributedValue: 0
+	}
+	try {
+		const gclidPresent = sql`${leads.metadata} #>> '{attribution,gclid}' is not null`
+		const [row] = await db
+			.select({
+				wonCount: sql<number>`count(*)::int`,
+				totalValue: sql<number>`coalesce(sum(${leads.dealValue}), 0)::float8`,
+				adAttributedCount: sql<number>`count(*) filter (where ${gclidPresent})::int`,
+				adAttributedValue: sql<number>`coalesce(sum(${leads.dealValue}) filter (where ${gclidPresent}), 0)::float8`
+			})
+			.from(leads)
+			.where(eq(leads.status, 'won'))
+		return row ?? zero
+	} catch (error) {
+		logger.error('leads-queries.getLeadsRevenueSummary failed', error)
+		return zero
+	}
 }
 
 /**

--- a/src/lib/schemas/admin-leads.ts
+++ b/src/lib/schemas/admin-leads.ts
@@ -25,6 +25,7 @@ export const LEAD_STATUSES = [
 	'new',
 	'contacted',
 	'qualified',
+	'won',
 	'closed'
 ] as const
 export type LeadStatus = (typeof LEAD_STATUSES)[number]
@@ -32,6 +33,16 @@ export type LeadStatus = (typeof LEAD_STATUSES)[number]
 export const updateLeadStatusSchema = z.object({
 	id: z.string().uuid({ message: 'Invalid lead id.' }),
 	status: z.enum(LEAD_STATUSES, { message: 'Pick a valid status.' })
+})
+
+// Mark a lead as won with the closed-deal value. The value feeds both internal
+// revenue reporting and the Google Ads "Sale" offline-conversion upload.
+export const markLeadWonSchema = z.object({
+	id: z.string().uuid({ message: 'Invalid lead id.' }),
+	dealValue: z.coerce
+		.number({ message: 'Enter the deal value.' })
+		.positive('Deal value must be greater than 0.')
+		.max(100_000_000, 'Deal value is unreasonably large.')
 })
 
 export const addLeadNoteSchema = z.object({

--- a/src/lib/schemas/leads.ts
+++ b/src/lib/schemas/leads.ts
@@ -63,6 +63,14 @@ export const leads = pgTable('leads', {
 	status: text('status').default('new'),
 	score: integer('score'),
 	metadata: jsonb('metadata'),
+	// Revenue reporting: set when a lead is marked won (status='won').
+	dealValue: numeric('deal_value'),
+	wonAt: timestamp('won_at', { withTimezone: true }),
+	// Idempotency for the Google Ads "Sale" offline-conversion value upload.
+	adConversionSentAt: timestamp('ad_conversion_sent_at', {
+		withTimezone: true
+	}),
+	adConversionRequestId: text('ad_conversion_request_id'),
 	createdAt: timestamp('created_at', { withTimezone: true })
 		.defaultNow()
 		.notNull(),

--- a/tests/unit/ad-conversions.test.ts
+++ b/tests/unit/ad-conversions.test.ts
@@ -15,7 +15,8 @@ import {
 	hashPhone,
 	normalizeEmail,
 	normalizePhone,
-	sendAdConversion
+	sendAdConversion,
+	sendSaleConversion
 } from '@/lib/ad-conversions'
 
 // Pinned SHA-256 hex vectors (computed independently) to lock the algorithm.
@@ -162,6 +163,22 @@ describe('buildIngestPayload', () => {
 		)
 		expect(withValue?.events[0]?.conversionValue).toBe(1500)
 		expect(withValue?.events[0]?.currency).toBe('USD')
+	})
+
+	it("targets the 'sale' conversion action + value when reference is 'sale'", () => {
+		const payload = buildIngestPayload(
+			{
+				leadId: 'lead-9',
+				attribution: { gclid: 'G' } as Attribution,
+				value: 5000
+			},
+			TEST_CONFIG,
+			'sale'
+		)
+		expect(payload?.destinations[0]?.reference).toBe('sale')
+		expect(payload?.events[0]?.destinationReferences).toEqual(['sale'])
+		expect(payload?.events[0]?.conversionValue).toBe(5000)
+		expect(payload?.events[0]?.currency).toBe('USD')
 	})
 
 	it('includes loginAccount when a manager (MCC) id is configured', () => {
@@ -396,5 +413,69 @@ describe('sendAdConversion (live upload path)', () => {
 				attribution: { gclid: 'GCLID_LIVE' } as Attribution
 			})
 		).resolves.toBeUndefined()
+	})
+})
+
+describe('sendSaleConversion (separate Sale conversion action)', () => {
+	const env = (globalThis as { __TEST_ENV?: Record<string, unknown> }).__TEST_ENV
+	let originalFetch: typeof globalThis.fetch
+	let fetchSpy: ReturnType<typeof mock>
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+		fetchSpy = mock(() =>
+			Promise.resolve(
+				new Response(JSON.stringify({ requestId: 'r1' }), { status: 200 })
+			)
+		)
+		globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+		if (env) {
+			delete env.GOOGLE_ADS_CUSTOMER_ID
+			delete env.GOOGLE_ADS_CONVERSION_ACTION_ID
+			delete env.GOOGLE_ADS_SALE_CONVERSION_ACTION_ID
+			delete env.GOOGLE_ADS_SA_JSON
+		}
+	})
+
+	it('is skipped (no upload) when the Sale action is unset, even with the Lead action configured', async () => {
+		if (env) {
+			env.GOOGLE_ADS_CUSTOMER_ID = '1234567890'
+			env.GOOGLE_ADS_CONVERSION_ACTION_ID = '987654321' // lead action only
+			env.GOOGLE_ADS_SA_JSON = JSON.stringify({
+				client_email: 'svc@example.iam.gserviceaccount.com',
+				private_key: 'pk'
+			})
+		}
+		const result = await sendSaleConversion({
+			leadId: 'l1',
+			email: 'test@example.com',
+			attribution: { gclid: 'G' } as Attribution,
+			value: 5000
+		})
+		expect(result.status).toBe('skipped')
+		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it('is skipped when the Sale action is set but the lead carries no Google click id', async () => {
+		if (env) {
+			env.GOOGLE_ADS_CUSTOMER_ID = '1234567890'
+			env.GOOGLE_ADS_SALE_CONVERSION_ACTION_ID = '555000'
+			env.GOOGLE_ADS_SA_JSON = JSON.stringify({
+				client_email: 'svc@example.iam.gserviceaccount.com',
+				private_key: 'pk'
+			})
+		}
+		const result = await sendSaleConversion({
+			leadId: 'l1',
+			email: 'test@example.com',
+			attribution: { fbclid: 'FB' } as Attribution,
+			value: 5000
+		})
+		expect(result.status).toBe('skipped')
+		expect(fetchSpy).not.toHaveBeenCalled()
 	})
 })

--- a/tests/unit/leads-revenue.test.ts
+++ b/tests/unit/leads-revenue.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Lead -> sale revenue reporting.
+ *  - markLeadWonSchema: coerces + validates the closed-deal value (pure).
+ *  - markLeadWon: writes status='won' + deal_value (numeric->string) + won_at.
+ *
+ * markLeadWon loads leads-queries by absolute path + a unique query so it binds
+ * to the COMPLETE @/lib/db mock registered here (db is a real boundary; bun#7823
+ * means a sibling suite may have cached the module against a different db mock).
+ */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { markLeadWonSchema } from '@/lib/schemas/admin-leads'
+import { cleanupMocks } from '../test-utils'
+
+const UUID = '11111111-1111-4111-8111-111111111111'
+
+describe('markLeadWonSchema', () => {
+	it('coerces a numeric-string deal value and accepts a positive amount', () => {
+		const r = markLeadWonSchema.safeParse({ id: UUID, dealValue: '4500' })
+		expect(r.success).toBe(true)
+		if (r.success) {
+			expect(r.data.dealValue).toBe(4500)
+		}
+	})
+
+	it('rejects zero / negative / non-numeric deal values', () => {
+		expect(markLeadWonSchema.safeParse({ id: UUID, dealValue: '0' }).success).toBe(
+			false
+		)
+		expect(
+			markLeadWonSchema.safeParse({ id: UUID, dealValue: '-10' }).success
+		).toBe(false)
+		expect(
+			markLeadWonSchema.safeParse({ id: UUID, dealValue: 'abc' }).success
+		).toBe(false)
+	})
+
+	it('rejects a malformed lead id', () => {
+		expect(
+			markLeadWonSchema.safeParse({ id: 'not-a-uuid', dealValue: '100' }).success
+		).toBe(false)
+	})
+})
+
+const LEADS_QUERIES_SPECIFIER = new URL(
+	'../../src/lib/admin/leads-queries.ts',
+	import.meta.url
+).pathname
+
+async function importLeadsQueriesFresh() {
+	return import(
+		`${LEADS_QUERIES_SPECIFIER}?fresh=${Date.now()}-${Math.random()}`
+	)
+}
+
+let capturedSet: Record<string, unknown> | undefined
+
+function mockDb(returnedRow: unknown): void {
+	capturedSet = undefined
+	mock.module('@/lib/db', () => ({
+		db: {
+			select: mock().mockReturnValue({
+				from: mock().mockReturnValue({
+					where: mock().mockReturnValue({ limit: mock().mockResolvedValue([]) }),
+					orderBy: mock().mockResolvedValue([]),
+					limit: mock().mockResolvedValue([])
+				})
+			}),
+			insert: mock().mockReturnValue({
+				values: mock().mockReturnValue({ returning: mock().mockResolvedValue([]) })
+			}),
+			update: mock().mockReturnValue({
+				set: mock((payload: Record<string, unknown>) => {
+					capturedSet = payload
+					return {
+						where: mock().mockReturnValue({
+							returning: mock().mockResolvedValue(
+								returnedRow ? [returnedRow] : []
+							)
+						})
+					}
+				})
+			}),
+			delete: mock().mockReturnValue({ where: mock().mockResolvedValue([]) })
+		}
+	}))
+}
+
+describe('markLeadWon', () => {
+	afterEach(() => {
+		cleanupMocks()
+	})
+
+	it("sets status='won', stringified deal_value, and won_at; returns the row", async () => {
+		const row = { id: 'lead-1', status: 'won', dealValue: '4500' }
+		mockDb(row)
+		const { markLeadWon } = await importLeadsQueriesFresh()
+		const result = await markLeadWon('lead-1', 4500)
+		expect(result).toEqual(row)
+		expect(capturedSet?.status).toBe('won')
+		// numeric column maps to a string in Drizzle
+		expect(capturedSet?.dealValue).toBe('4500')
+		expect(capturedSet?.wonAt).toBeInstanceOf(Date)
+	})
+
+	it('returns null when no row matches (lead not found)', async () => {
+		mockDb(null)
+		const { markLeadWon } = await importLeadsQueriesFresh()
+		const result = await markLeadWon('missing', 100)
+		expect(result).toBeNull()
+	})
+})


### PR DESCRIPTION
## What

Closes the funnel from "lead captured" to "revenue reported": an admin marks a lead **won** with a deal value, which (1) records it for internal revenue reporting and (2) uploads that value to a separate Google Ads **Sale** conversion action keyed on the lead's gclid, so the campaign can bid toward revenue, not just lead volume.

## Pieces

- **Data** (`leads`): `deal_value`, `won_at`, `ad_conversion_sent_at`, `ad_conversion_request_id` (additive columns applied to prod via Neon `ADD COLUMN IF NOT EXISTS`). `LEAD_STATUSES` gains `won`.
- **Upload** (`ad-conversions.ts`): the conversion action is now parameterized (lead vs sale); `sendSaleConversion()` uploads the closed-deal value to `GOOGLE_ADS_SALE_CONVERSION_ACTION_ID` and returns a result for idempotency. No-op (never throws) when the Sale action / creds are unset or the lead has no Google click id.
- **Admin action** (`markLeadWonAction`): sets `status=won` + value + `won_at`, then fires `sendSaleConversion` **once** (after the response, only if the lead carries a gclid and `ad_conversion_sent_at` is still null) and stamps the idempotency marker on a confirmed upload.
- **Admin UI**: lead detail "Revenue" section (deal value, won date, mark-won form, ad-attributed + reported-to-Google status); leads list **revenue summary** (won count, total revenue, ad-attributed count + revenue) -- the actual "did the ad generate revenue" number.

## Activation (external, code no-ops until then)

Create a "Sale/Qualified" conversion action in Google Ads -> set `GOOGLE_ADS_SALE_CONVERSION_ACTION_ID` (+ the existing `GOOGLE_ADS_*` creds). The internal revenue reporting works immediately regardless.

## Verification

- `tsc --noEmit` clean; `biome check src/` clean (415 files); `bun run build` compiled (`/admin/leads` + `[id]`).
- full `bun test tests/` **1104 / 0** (+8: sale-reference payload, sendSaleConversion no-op gating, markLeadWonSchema, markLeadWon write), stable across 2 runs; mock-leak guard green. The db-backed test uses a leak-safe fresh-import + complete `@/lib/db` mock (bun#7823).
- Prod DDL applied + verified (4 columns present on `leads`).

[hudsor01]