### PR TITLE
chore: gitignore service-account key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !.yarn/releases
 !.yarn/versions
 
+
 # testing
 /coverage
 
@@ -43,6 +44,15 @@ yarn-error.log*
 
 # direnv
 .envrc
+
+# Google Cloud service-account key files (private keys - NEVER commit).
+# GCP downloads them as <project-id>-<hex>.json; cover the projects in play
+# plus generic service-account naming.
+hds-website-*.json
+hudson-*-*.json
+*.gserviceaccount.json
+*service-account*.json
+*-sa-key.json
 
 # vercel
 .vercel


### PR DESCRIPTION
## What

Ignore Google Cloud service-account key-file name patterns so a downloaded private key can never be committed to this **public** repo.

```
hds-website-*.json
hudson-*-*.json
*.gserviceaccount.json
*service-account*.json
*-sa-key.json
```

## Why

Setting up the Google Ads Data Manager API conversion upload required downloading a GCP service-account JSON (a private key). It landed in the repo root **untracked** — one `git add .` from being committed to a public repo, which would have leaked the key. The key files themselves were deleted locally; this adds the standing ignore patterns so the same class of mistake can't recur for anyone working in the repo.

Verified the patterns match the GCP key filenames in play (`hudson-digital-website-*.json`, `hds-website-*.json`) and do **not** catch legit config (`package.json`, `tsconfig.json`, `components.json`, `biome.json`, `vercel.json`).

`.gitignore`-only change; no code or behavior impact.

[hudsor01]