### PR TITLE
ci: code-health gate + visual-baseline bootstrap + e2e seed (follow-ups)

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,48 @@
+{
+	"$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+	"entry": [
+		"src/app/**/page.{ts,tsx}",
+		"src/app/**/layout.{ts,tsx}",
+		"src/app/**/error.{ts,tsx}",
+		"src/app/**/global-error.{ts,tsx}",
+		"src/app/**/loading.{ts,tsx}",
+		"src/app/**/not-found.{ts,tsx}",
+		"src/app/**/route.{ts,tsx}",
+		"src/app/**/template.{ts,tsx}",
+		"src/app/**/default.{ts,tsx}",
+		"src/app/**/icon{,0,1,2,3,4,5,6,7,8,9}.{ts,tsx}",
+		"src/app/**/apple-icon{,0,1,2}.{ts,tsx}",
+		"src/app/**/opengraph-image{,0,1,2}.{ts,tsx}",
+		"src/app/**/twitter-image{,0,1,2}.{ts,tsx}",
+		"src/app/**/sitemap.{ts,tsx}",
+		"src/app/**/robots.{ts,tsx}",
+		"src/app/**/manifest.{ts,tsx}",
+		"proxy.ts",
+		"next.config.ts",
+		"drizzle.config.ts",
+		"playwright.config.ts",
+		"scripts/**/*.ts",
+		"tests/**/*.{test,spec}.ts",
+		"e2e/**/*.spec.ts"
+	],
+	"ignorePatterns": ["src/lib/_generated/**"],
+	"ignoreDependencies": ["tailwindcss"],
+	"ignoreExports": [
+		{
+			"file": "src/lib/schemas/content.ts",
+			"exports": ["Testimonial", "TestimonialRequest"]
+		},
+		{ "file": "src/lib/admin/testimonials-queries.ts", "exports": ["deleteTestimonial"] }
+	],
+	"rules": {
+		"unused-files": "error",
+		"unresolved-imports": "error",
+		"unlisted-dependencies": "error",
+		"unused-dependencies": "error",
+		"circular-dependencies": "error",
+		"unused-exports": "warn",
+		"unused-types": "warn",
+		"duplicate-exports": "warn",
+		"unused-class-members": "off"
+	}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Run TypeScript type checking
         run: bun run typecheck
 
+      # Code-health gate (fallow). Errors on structural rot (dead files,
+      # unresolved/unlisted imports, unused deps, circular deps); unused
+      # exports/types are warn-only because Next.js framework exports
+      # (metadata/runtime) and intentional API surface trip them. Config:
+      # .fallowrc.json. Exit 1 only on error-severity findings.
+      - name: Run fallow (code health)
+        run: bunx fallow@2.94.0 dead-code --quiet
+
   test:
     name: Test
     # macOS runner: bun's native test-runner ESM loader on Linux fails to

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -1,0 +1,67 @@
+name: Update Visual Baselines
+
+# Manually-triggered bootstrap for the @visual Playwright suite. The
+# committed baselines are macOS (`-darwin.png`); CI runs on Linux, so the
+# `@visual` tests are excluded from the normal CI lane (see ci.yml e2e job /
+# `test:e2e:ci`). Run this workflow once on a branch to generate and commit
+# Linux (`-linux.png`) baselines on the SAME runner image CI uses, then drop
+# the `@visual` exclusion so visual regression runs on every push.
+#
+# Generating baselines on the runner (not locally / not in a mismatched
+# container) is deliberate: it guarantees the baselines match the pixels CI
+# will compare against, avoiding font/AA-driven flakiness.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch to generate and commit baselines onto
+        required: true
+        default: main
+
+permissions:
+  contents: write
+
+jobs:
+  update-baselines:
+    name: Update Linux visual baselines
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright (chromium)
+        run: bunx playwright install --with-deps chromium
+
+      - name: Generate Linux baselines for @visual
+        run: bunx playwright test --project=chromium --grep @visual --update-snapshots
+        env:
+          SKIP_ENV_VALIDATION: true
+          NEON_AUTH_BASE_URL: https://ci-e2e-placeholder.neon.tech
+
+      - name: Commit updated baselines
+        env:
+          TARGET_REF: ${{ inputs.ref }}
+        run: |
+          if git diff --quiet -- 'e2e/**/*-snapshots/**'; then
+            echo "No baseline changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add 'e2e/**/*-snapshots/**'
+          git commit -m "test: add Linux visual-regression baselines [skip ci]
+
+          [hudsor01]"
+          git push origin "HEAD:$TARGET_REF"

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -1,0 +1,81 @@
+/**
+ * E2E seed script.
+ *
+ * Inserts the minimum fixtures the data-dependent e2e specs assert against,
+ * so they can run in CI (gated behind E2E_LIVE_BACKEND) against an ephemeral
+ * seeded database instead of skipping:
+ *   - blog.spec.ts            -> >= 1 published, non-placeholder blog post
+ *   - content-pages.spec.ts   -> a published testimonial ("What Our Clients Say")
+ *
+ * Idempotent: safe to re-run. Posts upsert by unique slug; the seeded
+ * testimonial is keyed by a sentinel company name and replaced.
+ *
+ * Run with POSTGRES_URL pointing at the target database:
+ *   POSTGRES_URL=... bun run scripts/seed-e2e.ts
+ */
+
+import { eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { blogAuthors, blogPosts } from '@/lib/schemas/blog'
+import { testimonials } from '@/lib/schemas/content'
+
+const SEED_AUTHOR_SLUG = 'e2e-seed-author'
+const SEED_POST_SLUG = 'e2e-seed-welcome'
+const SEED_TESTIMONIAL_COMPANY = 'E2E Seed Co'
+
+async function seed(): Promise<void> {
+	// Author (FK target for the post).
+	const [author] = await db
+		.insert(blogAuthors)
+		.values({ slug: SEED_AUTHOR_SLUG, name: 'E2E Seed Author' })
+		.onConflictDoNothing({ target: blogAuthors.slug })
+		.returning({ id: blogAuthors.id })
+
+	const authorId =
+		author?.id ??
+		(
+			await db
+				.select({ id: blogAuthors.id })
+				.from(blogAuthors)
+				.where(eq(blogAuthors.slug, SEED_AUTHOR_SLUG))
+		)[0]?.id
+
+	// Published, non-placeholder post (blog.spec.ts asserts >= 1 real post).
+	await db
+		.insert(blogPosts)
+		.values({
+			slug: SEED_POST_SLUG,
+			title: 'Welcome to the E2E Seed Post',
+			excerpt: 'A published fixture post so the blog journey specs have data.',
+			content:
+				'This post exists only to give the e2e blog journey real, renderable content. It is seeded for CI and is safe to ignore.',
+			published: true,
+			publishedAt: new Date(),
+			readingTime: 3,
+			authorId
+		})
+		.onConflictDoNothing({ target: blogPosts.slug })
+
+	// Published testimonial (content-pages "What Our Clients Say").
+	await db
+		.delete(testimonials)
+		.where(eq(testimonials.company, SEED_TESTIMONIAL_COMPANY))
+	await db.insert(testimonials).values({
+		name: 'E2E Seed Client',
+		role: 'Owner',
+		company: SEED_TESTIMONIAL_COMPANY,
+		content: 'Seeded testimonial so the testimonials section renders in e2e.',
+		rating: 5,
+		published: true,
+		featured: true
+	})
+
+	console.warn('[seed-e2e] seeded blog post + testimonial')
+}
+
+seed()
+	.then(() => process.exit(0))
+	.catch((error: unknown) => {
+		console.error('[seed-e2e] failed', error)
+		process.exit(1)
+	})


### PR DESCRIPTION
Follow-ups from the e2e/CI cleanup. Three independent repo items; the dotfile + upstream follow-ups were handled separately (see bottom).

## 1. fallow code-health gate (ready)

Adopts **fallow** (replacing the removed knip) as a CI check in the quality job. `.fallowrc.json` restores the Next.js entry globs (icon/og/twitter/not-found/route/etc.) so framework files aren't false-flagged, and `ignoreExports` the intentional `Testimonial`/`deleteTestimonial` dupes. Rules: **error** on structural rot (unused files, unresolved/unlisted imports, unused deps, circular deps — all currently zero); **warn** on unused exports/types/dupes (legit framework `metadata`/`runtime` + API-surface exceptions). The step fails only on error-severity. Validated locally: `bunx fallow dead-code` exits 0.

## 2. Visual-regression Linux baselines (run-once, then enable)

`@visual` is excluded from CI because the committed baselines are macOS (`-darwin.png`). New **`workflow_dispatch`** workflow (`update-visual-baselines.yml`) regenerates them on the `ubuntu-latest` runner (the image CI compares against, avoiding font/AA flakiness) with `--update-snapshots` and commits the `-linux.png` baselines back to the chosen branch.

**To enable:** run the workflow once on a branch → baselines land → drop the `@visual` exclusion from `test:e2e:ci` (`--grep-invert=@visual`) so visual regression gates every push.

## 3. E2E_LIVE_BACKEND seed (foundation + de-risk finding)

`scripts/seed-e2e.ts` inserts the fixtures the data-dependent specs need (a published non-placeholder blog post + a published testimonial; idempotent) so `blog.spec.ts` / `content-pages.spec.ts` can run in CI instead of skipping.

**Key finding that de-risks the whole thing:** with **no `RESEND_API_KEY`**, the contact route returns success in "test mode" (`route.ts`) and newsletter's email is `isResendConfigured()`-guarded — so the gated tests pass on DB alone with **zero emails sent**. The earlier "real emails in CI" worry is moot.

**Remaining CI wiring** (documented, not wired blindly — it provisions a real Neon branch and can only be validated by a CI run with the `NEON_API_KEY` secret): in the e2e job, before tests — create an ephemeral Neon branch (mirror `neon-branch.yml`'s `neondatabase/create-branch-action`), set `POSTGRES_URL`/`DATABASE_URL_UNPOOLED` to it, `bun run db:push`, `bun run scripts/seed-e2e.ts`, then run with `E2E_LIVE_BACKEND=1` and **omit** `RESEND_API_KEY`; delete the branch after. I left this unwired so a misconfigured branch-creation can't break the green e2e lane; happy to wire + iterate it against CI on request.

## Verification
`typecheck` clean, `lint` clean, `.fallowrc.json`/seed Biome-clean, all YAML valid, no injection surface in the new workflow (dispatch input passed via quoted env).

## Handled outside this branch
- **safe-chain `~/.bashrc` guard** — applied + verified locally (the original `test:all` crash no longer reproduces in a non-interactive shell; backup at `~/.bashrc.bak-*`).
- **bun-Linux drizzle ESM bug** — filed: oven-sh/bun#32351.

[hudsor01]