### PR TITLE
ci: move live-backend e2e to a nightly workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,40 +171,10 @@ jobs:
       - name: Install Playwright (chromium)
         run: bunx playwright install --with-deps chromium
 
-      # Provision an ephemeral Neon branch (inherits the parent's schema +
-      # data) so the E2E_LIVE_BACKEND data-dependent specs (blog,
-      # testimonials) run instead of skipping. No RESEND_API_KEY is set, so
-      # the contact route returns success in "test mode" and newsletter's
-      # email is isResendConfigured()-guarded: zero emails sent.
-      #
-      # SCOPED TO main ONLY: provisioning a Neon branch per run is the costly
-      # part, so the live-backend lane runs solely on push to main. On PRs
-      # (and develop) these steps skip, db_url is empty, and the suite below
-      # runs the portable functional specs against the no-DB mock while the
-      # data-dependent specs self-skip on the empty E2E_LIVE_BACKEND.
-      - name: Branch expiry (2h)
-        if: github.ref == 'refs/heads/main'
-        run: echo "NEON_EXPIRES_AT=$(date -u --date '+2 hours' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
-
-      - name: Create Neon branch
-        id: neon
-        if: github.ref == 'refs/heads/main'
-        uses: neondatabase/create-branch-action@v6
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch_name: e2e-ci-${{ github.run_id }}-${{ github.run_attempt }}
-          api_key: ${{ secrets.NEON_API_KEY }}
-          expires_at: ${{ env.NEON_EXPIRES_AT }}
-
-      - name: Seed the Neon branch
-        if: github.ref == 'refs/heads/main'
-        env:
-          SKIP_ENV_VALIDATION: true
-          POSTGRES_URL: ${{ steps.neon.outputs.db_url }}
-        run: bun run scripts/seed-e2e.ts
-
       # Generate throwaway secrets at runtime so no secret-shaped values are
-      # committed to the workflow.
+      # committed to the workflow. The functional suite does not exercise
+      # CSRF/auth/DB-write paths (those are the E2E_LIVE_BACKEND specs, which
+      # run nightly in e2e-live.yml); these only satisfy module-load access.
       - name: Generate throwaway test secrets
         run: |
           {
@@ -212,23 +182,15 @@ jobs:
             echo "NEON_AUTH_COOKIE_SECRET=$(openssl rand -hex 24)"
           } >> "$GITHUB_ENV"
 
-      # Runs the portable functional suite. On main, POSTGRES_URL points at the
-      # seeded Neon branch and E2E_LIVE_BACKEND=1 so the data-dependent specs
-      # run; on PRs both are empty so those specs self-skip and the rest run
-      # against the no-DB mock. No RESEND_API_KEY either way (no emails).
-      # @visual stays excluded (separate Linux-baseline track).
+      # Functional suite on every push/PR with no backend: the
+      # E2E_LIVE_BACKEND data-dependent specs self-skip and @visual is
+      # excluded (separate Visual job / Linux baselines). The live-backend
+      # lane that provisions Neon + seeds runs nightly in e2e-live.yml.
       - name: Run E2E tests
         run: bun run test:e2e:ci
         env:
           SKIP_ENV_VALIDATION: true
           NEON_AUTH_BASE_URL: https://ci-e2e-placeholder.neon.tech
-          POSTGRES_URL: ${{ steps.neon.outputs.db_url }}
-          E2E_LIVE_BACKEND: ${{ github.ref == 'refs/heads/main' && '1' || '' }}
-          # The dev server runs on :3001; BASE_URL must match it so the
-          # same-origin mutation guard (isSameOriginRequest) accepts the
-          # contact/newsletter POSTs. Default is :3000 -> "Forbidden".
-          BASE_URL: http://localhost:3001
-          NEXT_PUBLIC_BASE_URL: http://localhost:3001
 
       - name: Upload Playwright report on failure
         if: failure()
@@ -237,17 +199,6 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
-
-      # Always clean up the ephemeral branch so failed runs don't orphan it
-      # (the 2h expiry is a backstop). Best-effort: never fail the job here.
-      - name: Delete Neon branch
-        if: always() && steps.neon.outcome == 'success'
-        continue-on-error: true
-        uses: neondatabase/delete-branch-action@v3
-        with:
-          project_id: ${{ vars.NEON_PROJECT_ID }}
-          branch: e2e-ci-${{ github.run_id }}-${{ github.run_attempt }}
-          api_key: ${{ secrets.NEON_API_KEY }}
 
   visual:
     name: Visual

--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -1,0 +1,123 @@
+name: E2E (live backend)
+
+# Nightly live-backend e2e. Provisions an ephemeral Neon branch (a
+# copy-on-write fork of the project's default branch where prod data lives),
+# seeds deterministic fixtures, runs the data-dependent specs (blog,
+# testimonials, contact, newsletter) against it, then deletes the branch.
+#
+# Decoupled from the per-push/PR CI lane on purpose: the normal `E2E` job in
+# ci.yml is functional-only and never spends a Neon branch, so regular
+# development costs nothing. This runs on a schedule (1 ephemeral branch/day)
+# as a smoke check, plus on demand via workflow_dispatch.
+#
+# No RESEND_API_KEY is set, so the contact route returns success in "test
+# mode" and newsletter email is isResendConfigured()-guarded: zero emails.
+#
+# NOTE: scheduled workflows only fire from the default branch (main), so this
+# starts running nightly once merged.
+
+on:
+  schedule:
+    # 07:00 UTC daily (~02:00 US Central)
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+# Cancel an in-progress nightly if a new one is triggered
+concurrency:
+  group: e2e-live
+  cancel-in-progress: true
+
+jobs:
+  e2e-live:
+    name: E2E (live backend)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/bun.lock') }}
+
+      - name: Install Playwright (chromium)
+        run: bunx playwright install --with-deps chromium
+
+      - name: Branch expiry (2h)
+        run: echo "NEON_EXPIRES_AT=$(date -u --date '+2 hours' +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+
+      - name: Create Neon branch
+        id: neon
+        uses: neondatabase/create-branch-action@v6
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: e2e-nightly-${{ github.run_id }}-${{ github.run_attempt }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          expires_at: ${{ env.NEON_EXPIRES_AT }}
+
+      - name: Seed the Neon branch
+        env:
+          SKIP_ENV_VALIDATION: true
+          POSTGRES_URL: ${{ steps.neon.outputs.db_url }}
+        run: bun run scripts/seed-e2e.ts
+
+      # Generate throwaway secrets at runtime so no secret-shaped values are
+      # committed to the workflow.
+      - name: Generate throwaway test secrets
+        run: |
+          {
+            echo "CSRF_SECRET=$(openssl rand -hex 24)"
+            echo "NEON_AUTH_COOKIE_SECRET=$(openssl rand -hex 24)"
+          } >> "$GITHUB_ENV"
+
+      # E2E_LIVE_BACKEND=1 so the data-dependent specs run against the seeded
+      # branch. BASE_URL must match the dev server's :3001 so the same-origin
+      # mutation guard accepts contact/newsletter POSTs (default :3000 ->
+      # "Forbidden"). @visual stays excluded (separate Linux-baseline track).
+      - name: Run E2E tests
+        run: bun run test:e2e:ci
+        env:
+          SKIP_ENV_VALIDATION: true
+          NEON_AUTH_BASE_URL: https://ci-e2e-placeholder.neon.tech
+          POSTGRES_URL: ${{ steps.neon.outputs.db_url }}
+          E2E_LIVE_BACKEND: '1'
+          BASE_URL: http://localhost:3001
+          NEXT_PUBLIC_BASE_URL: http://localhost:3001
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-live
+          path: playwright-report/
+          retention-days: 7
+
+      # Always clean up the ephemeral branch so failed runs don't orphan it
+      # (the 2h expiry is a backstop). Best-effort: never fail the job here.
+      - name: Delete Neon branch
+        if: always() && steps.neon.outcome == 'success'
+        continue-on-error: true
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: e2e-nightly-${{ github.run_id }}-${{ github.run_attempt }}
+          api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
## What

Splits the live-backend e2e out of the per-push/PR CI lane into a dedicated nightly workflow.

- **`ci.yml` E2E job** is now functional-only on every push/PR. No Neon provisioning. The `E2E_LIVE_BACKEND` data-dependent specs self-skip on the empty flag; `@visual` stays in its own Visual job.
- **New `e2e-live.yml`** runs on a nightly `schedule` (`0 7 * * *` UTC) plus `workflow_dispatch`. It provisions one ephemeral Neon branch (copy-on-write fork of the prod/default branch), seeds deterministic fixtures, runs the data-dependent specs with `E2E_LIVE_BACKEND=1`, and deletes the branch.

## Why

Provisioning Neon on `push` to `main` was post-merge: it could not gate anything and spent an ephemeral branch per merge. A nightly schedule gives the same data-dependent coverage as a smoke check at ~1 ephemeral branch/day (auto-deleted), and decouples it from the merge flow. Regular development now costs zero Neon branches.

## Notes

- Scheduled workflows only fire from the default branch, so the nightly starts once this merges to `main`. `workflow_dispatch` allows manual runs.
- No `RESEND_API_KEY` is set in either lane, so no emails are sent.

[hudsor01]