### PR TITLE
content: CRM post 301 redirect + content strategy doc

### DIFF
--- a/.planning/CONTENT-STRATEGY.md
+++ b/.planning/CONTENT-STRATEGY.md
@@ -1,0 +1,113 @@
+# Content Strategy: Blog Pillars and Backlog
+
+Source of truth for blog topic selection. Every post must map to one pillar
+below and reinforce a service, a tool, or a market we serve. Goal: position
+Hudson Digital Solutions as the subject-matter expert for small-business web,
+local SEO, and booking/payments automation.
+
+Last updated: 2026-06-16
+
+## Who we are (the topical lens)
+
+Hudson Digital Solutions, Lewisville TX (Dallas-Fort Worth). We build
+small-business websites, run local SEO, and set up booking/payments/follow-up
+automation. We serve 75 cities across 11 states (AZ, AR, CO, FL, GA, LA, NM,
+NC, OK, TN, TX). We sell against all-in-one SaaS platforms (Thryv, Wix,
+Squarespace, GoDaddy) on ownership, no lock-in, and no monthly fees.
+
+Three productized services:
+- Website Design and Development (custom, mobile-ready, fast, owner-controlled admin)
+- Get Found on Google (local SEO, Google Business Profile, schema, indexing)
+- Booking, Payments and Follow-Up (Stripe, scheduling, automatic lead follow-up)
+
+## Pillars
+
+| # | Pillar | Maps to | SME angle | Primary tag |
+|---|--------|---------|-----------|-------------|
+| 1 | Small-business web design | Core service; 9 existing posts | Design that drives revenue, not aesthetics | web-design, web-development |
+| 2 | Website performance / Core Web Vitals | Performance Savings Calculator, PageSpeed API, "Fast Core Web Vitals" service | Real PageSpeed data, speed-to-revenue | website-performance |
+| 3 | Local SEO / get found on Google | "Get Found on Google" service, Schema + Meta Tag generators, 75 city pages | Local pack ranking, schema, GBP | seo, local-marketing, dallas-fort-worth |
+| 4 | Conversion optimization | ROI Calculator, conversion service | Turning traffic into customers | conversion-optimization |
+| 5 | Booking, payments and automation | Booking/Payments/Follow-Up service (Stripe, scheduling) | Automating ops without enterprise tools | business-automation |
+| 6 | Own your site / migrate off platforms | /switch-from-thryv, /website-migration | Lock-in, domain/data ownership, migrate without losing SEO | website-migration |
+| 7 | Industry verticals (home/local services) | home-services tag; Ink37 case study | Vertical playbooks (HVAC, trades, salons, studios) | home-services |
+| 8 | What a website costs / buying guide | Website Cost Estimator, Proposal Generator | Demystify pricing; agency vs DIY vs platform fees | business, small-business |
+| 9 | Running the business (ops/finance) | Invoice, Late-Fee, Paystub, Margin, Time-Card, Contract, Proposal tools | Practical money/ops guides that back each tool | business |
+| 10 | Technical / developer authority | Stack (Next.js 16, Drizzle/Neon, Stripe), case studies | Custom over template; structured data; stack choices | web-development |
+
+## Tag taxonomy (cleaned 2026-06-16)
+
+All tags now carry descriptions; `website-performance` added for pillar 2.
+Spread new posts across pillars 2-9; `web-development` already holds 9 of 11
+posts, so avoid piling onto pillars 1 and 10.
+
+## Prioritized backlog
+
+P0 = empty pillar with a service AND a tool behind it (best SEO + conversion
+leverage). Titles are starting points, not final.
+
+### P0 (write first)
+- Local SEO: "How to Rank in Google's Local Pack: A Small Business Checklist" (-> Schema Generator, GBP)
+- Local SEO: "LocalBusiness Schema: The Markup That Helps Google Find You" (-> Schema Generator tool)
+- Performance: "How Fast Should Your Small Business Website Be? Core Web Vitals Explained" (-> Performance Calculator)
+- Performance: "Why Your Wix or Squarespace Site Is Slow, and What It Costs You" (-> Performance Calculator)
+- Migration: "How to Leave Thryv Without Losing Your Google Rankings" (-> /switch-from-thryv)
+- Migration: "Who Actually Owns Your Website and Domain? How to Check" (-> /website-migration)
+- Automation: "Online Booking for Service Businesses: Setup, Tools, and Pitfalls" (-> Booking service)
+
+### P1
+- Local SEO: "Google Business Profile Optimization: 12 Fixes to Make Today"
+- Migration: "Escaping Monthly Platform Fees: The Real Cost of Wix, Squarespace, and GoDaddy"
+- Migration: "Website Migration Checklist: Move Without Losing SEO"
+- Conversion: "The Anatomy of a Service-Business Homepage That Converts" (-> ROI Calculator)
+- Conversion: "7 Trust Signals That Turn Visitors Into Calls"
+- Pricing: "What Should a Small Business Website Cost in 2026?" (refresh of the 2025 post; -> Cost Estimator)
+- Pricing: "Agency vs Freelancer vs DIY Builder: An Honest Cost Breakdown"
+- Verticals: "Tattoo Studio Websites: Booking, Gallery, and Local SEO" (Ink37 case study)
+- Verticals: "Websites for HVAC Companies: What Actually Drives Calls"
+
+### P2
+- Automation: "Stop Chasing Leads: Automating Follow-Up With Stripe and Email"
+- Ops: "Invoice Late Fees: What Is Legal and What Actually Works" (-> Late Fee Calculator)
+- Ops: "Profit Margin vs Markup: Pricing Your Services Right" (-> Margin Calculator)
+- Ops: "How to Write a Proposal That Wins the Job" (-> Proposal Generator)
+- Web design: "Signs It Is Time to Redesign Your Website"
+- Web design: "Mobile-First Web Design for Service Businesses"
+- Technical: case-study deep-dives (TenantFlow SaaS, JirahShop e-commerce)
+
+## Force multipliers (built into the codebase)
+
+- Tool-aligned posts: each of the 18 free tools deserves a backing article that
+  links to it (the help center already has a "Tools and Calculators" category).
+- Programmatic local SEO: 75 city pages x pillars 2/3/7 is a large geo-content
+  engine ("web design in Dallas", "local SEO for Houston plumbers"). Guard
+  against thin or duplicate pages; each needs unique local substance.
+- Case study to article: turn each showcase into a "how we did it" post (Ink37
+  local service, TenantFlow SaaS, JirahShop e-commerce).
+- Competitor-switch content (pillar 6) is differentiated and barely tapped.
+
+## Editorial guidelines
+
+- Voice: concrete, benefit-led, plain English for business owners. No jargon for
+  jargon's sake.
+- NO em-dashes or en-dashes in published content (project-wide rule). Use commas,
+  periods, hyphens, or "to" for ranges.
+- No emojis in content.
+- Length: 1,200-2,000 words for pillar posts; cornerstone guides can run longer.
+- Each post: one primary pillar tag plus optional secondary tags; link to the
+  matching tool/service; one clear CTA (free website plan or the relevant tool).
+- Meta description 120-160 chars.
+- Where relevant, target a keyword plus a city for local SEO.
+
+## Content hygiene (open items, need a decision)
+
+1. Keyword cannibalization: two published posts compete for "custom CRM
+   integration":
+   - why-your-business-needs-a-custom-crm-integration (2026-02-19, 4597 chars)
+   - why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency (2026-03-28, 4446 chars)
+   Recommendation: keep the stronger one, fold the best of the other into it,
+   unpublish the loser and 301 its slug to the keeper.
+2. Off-brand drafts (unpublished): "From Undefined to Defined" and "Turning the
+   Undefined into Defined Success" lean on a coding pun rather than the concrete
+   benefit-led voice. Recommendation: rewrite into a single pillar-1 or pillar-8
+   post, or drop.

--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,11 @@
 			"source": "/portfolio",
 			"destination": "/services",
 			"permanent": true
+		},
+		{
+			"source": "/blog/why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency",
+			"destination": "/blog/why-your-business-needs-a-custom-crm-integration",
+			"permanent": true
 		}
 	],
 


### PR DESCRIPTION
## What

- **301 redirect** in `vercel.json`: the cannibalizing CRM long-slug (`/blog/why-your-business-needs-a-custom-crm-integration-to-unlock-true-efficiency`) now permanently redirects to the canonical short slug.
- **`.planning/CONTENT-STRATEGY.md`**: 10-pillar blog map, cleaned tag taxonomy, prioritized P0/P1/P2 backlog, force-multiplier plays, editorial guidelines.

## Companion DB changes (already applied to Neon production)

These were applied directly to `blog_posts`/`blog_tags` (content lives in the DB, not the repo):
- Upgraded the keeper CRM post; **unpublished** the duplicate (this redirect points the old URL at the keeper).
- Rewrote an off-brand draft into a published pillar post: *Your Website Needs a Blueprint*.
- Filled descriptions on 8 empty tags + added a `Website Performance` tag.

Merging this to `main` activates the redirect (Vercel production deploy).

[hudsor01]