### PR TITLE
chore(v9): spread blog dates + fix author headshot

### DIFF
--- a/content/blog/agency-vs-freelancer-vs-diy-website-cost.md
+++ b/content/blog/agency-vs-freelancer-vs-diy-website-cost.md
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2024-12-03'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/anatomy-of-a-high-converting-homepage.md
+++ b/content/blog/anatomy-of-a-high-converting-homepage.md
@@ -1,13 +1,15 @@
 ---
 title: The Anatomy of a High-Converting Homepage
 slug: anatomy-of-a-high-converting-homepage
-excerpt: 'A high-converting homepage is a revenue system, not a brochure. The tracking, automation and content structure that turns Dallas visitors into clients.'
+excerpt: >-
+  A high-converting homepage is a revenue system, not a brochure. The tracking,
+  automation and content structure that turns Dallas visitors into clients.
 targetKeyword: high-converting homepage
 pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2024-12-10'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/automate-customer-follow-up-email-sms.md
+++ b/content/blog/automate-customer-follow-up-email-sms.md
@@ -1,13 +1,15 @@
 ---
 title: Automate Customer Follow-Up With Email and SMS
 slug: automate-customer-follow-up-email-sms
-excerpt: 'How to automate customer follow-up with email and SMS. The systems, tools and metrics DFW businesses use to recover lost revenue.'
+excerpt: >-
+  How to automate customer follow-up with email and SMS. The systems, tools and
+  metrics DFW businesses use to recover lost revenue.
 targetKeyword: automate customer follow-up
 pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2024-12-19'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/automated-lead-follow-up-for-service-businesses.md
+++ b/content/blog/automated-lead-follow-up-for-service-businesses.md
@@ -9,7 +9,7 @@ pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2024-12-23'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/call-to-action-best-practices.md
+++ b/content/blog/call-to-action-best-practices.md
@@ -9,7 +9,7 @@ pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-01-01'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/case-study-ink37-local-service-website.md
+++ b/content/blog/case-study-ink37-local-service-website.md
@@ -1,13 +1,15 @@
 ---
 title: 'Case Study: A Local Business Website (Ink37 Tattoos)'
 slug: case-study-ink37-local-service-website
-excerpt: 'Case study: how we turned Ink37 Tattoos into a revenue-driving local business website. The numbers, automation and ROI for a Dallas studio.'
+excerpt: >-
+  Case study: how we turned Ink37 Tattoos into a revenue-driving local business
+  website. The numbers, automation and ROI for a Dallas studio.
 targetKeyword: local business website
 pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-01-06'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/case-study-jirahshop-ecommerce-build.md
+++ b/content/blog/case-study-jirahshop-ecommerce-build.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-01-15'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/case-study-tenantflow-saas-web-application.md
+++ b/content/blog/case-study-tenantflow-saas-web-application.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-01-24'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/core-web-vitals-explained-for-small-business.md
+++ b/content/blog/core-web-vitals-explained-for-small-business.md
@@ -1,13 +1,15 @@
 ---
 title: Core Web Vitals Explained for Small Business Owners
 slug: core-web-vitals-explained-for-small-business
-excerpt: 'Core web vitals measure real user experience: load speed, interactivity and visual stability. How Dallas business owners fix them without wasting budget.'
+excerpt: >-
+  Core web vitals measure real user experience: load speed, interactivity and
+  visual stability. How Dallas business owners fix them without wasting budget.
 targetKeyword: core web vitals
 pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-01-28'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/crm-automation-stop-losing-leads.md
+++ b/content/blog/crm-automation-stop-losing-leads.md
@@ -10,7 +10,7 @@ pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-02-06'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/custom-website-vs-website-builder.md
+++ b/content/blog/custom-website-vs-website-builder.md
@@ -1,13 +1,15 @@
 ---
 title: 'Custom Website vs Website Builder: A Developer''s View'
 slug: custom-website-vs-website-builder
-excerpt: 'Custom website vs website builder: the real cost, automation limits and revenue impact for Dallas businesses, in hard numbers.'
+excerpt: >-
+  Custom website vs website builder: the real cost, automation limits and
+  revenue impact for Dallas businesses, in hard numbers.
 targetKeyword: custom website vs website builder
 pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-02-11'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/escaping-monthly-platform-fees.md
+++ b/content/blog/escaping-monthly-platform-fees.md
@@ -9,7 +9,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-02-20'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/google-business-profile-optimization-checklist.md
+++ b/content/blog/google-business-profile-optimization-checklist.md
@@ -11,7 +11,7 @@ tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-03-01'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/hidden-costs-of-diy-website-builders.md
+++ b/content/blog/hidden-costs-of-diy-website-builders.md
@@ -11,7 +11,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-03-05'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-many-pages-does-a-small-business-website-need.md
+++ b/content/blog/how-many-pages-does-a-small-business-website-need.md
@@ -10,7 +10,7 @@ tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2025-03-15'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-budget-for-a-website-project.md
+++ b/content/blog/how-to-budget-for-a-website-project.md
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-03-19'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-connect-your-website-to-your-crm.md
+++ b/content/blog/how-to-connect-your-website-to-your-crm.md
@@ -9,7 +9,7 @@ pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-03-28'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-get-more-google-reviews.md
+++ b/content/blog/how-to-get-more-google-reviews.md
@@ -10,7 +10,7 @@ tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-04-06'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-leave-thryv-without-losing-rankings.md
+++ b/content/blog/how-to-leave-thryv-without-losing-rankings.md
@@ -9,7 +9,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-04-10'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-measure-website-performance.md
+++ b/content/blog/how-to-measure-website-performance.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-04-20'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-migrate-off-wix.md
+++ b/content/blog/how-to-migrate-off-wix.md
@@ -9,7 +9,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-04-24'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-rank-in-multiple-cities.md
+++ b/content/blog/how-to-rank-in-multiple-cities.md
@@ -1,14 +1,16 @@
 ---
 title: How to Rank in Multiple Cities Without Thin Pages
 slug: how-to-rank-in-multiple-cities
-excerpt: 'Rank in multiple cities without thin pages. How DFW businesses build local SEO systems that drive booked calls from every zip code.'
+excerpt: >-
+  Rank in multiple cities without thin pages. How DFW businesses build local SEO
+  systems that drive booked calls from every zip code.
 targetKeyword: rank in multiple cities
 pillar: 3
 tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-05-03'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-rank-in-the-google-local-pack.md
+++ b/content/blog/how-to-rank-in-the-google-local-pack.md
@@ -1,14 +1,16 @@
 ---
 title: How to Rank in the Google Local Pack
 slug: how-to-rank-in-the-google-local-pack
-excerpt: 'Stop guessing why your Dallas business vanishes from map results. The metrics, automations and local SEO tactics that fill your google local pack.'
+excerpt: >-
+  Stop guessing why your Dallas business vanishes from map results. The metrics,
+  automations and local SEO tactics that fill your google local pack.
 targetKeyword: google local pack
 pillar: 3
 tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-05-12'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-reduce-bounce-rate.md
+++ b/content/blog/how-to-reduce-bounce-rate.md
@@ -1,13 +1,15 @@
 ---
 title: How to Reduce Bounce Rate on Your Website
 slug: how-to-reduce-bounce-rate
-excerpt: 'How to reduce bounce rate by treating your site as a revenue system. DFW tactics, automation and measurable fixes that move bookings.'
+excerpt: >-
+  How to reduce bounce rate by treating your site as a revenue system. DFW
+  tactics, automation and measurable fixes that move bookings.
 targetKeyword: reduce bounce rate
 pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-05-17'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-track-employee-hours.md
+++ b/content/blog/how-to-track-employee-hours.md
@@ -9,7 +9,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-05-26'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-transfer-your-domain-safely.md
+++ b/content/blog/how-to-transfer-your-domain-safely.md
@@ -10,7 +10,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-05-30'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-to-write-an-invoice-that-gets-paid.md
+++ b/content/blog/how-to-write-an-invoice-that-gets-paid.md
@@ -10,7 +10,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-06-08'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-we-build-fast-websites-the-stack.md
+++ b/content/blog/how-we-build-fast-websites-the-stack.md
@@ -10,7 +10,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-06-17'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/how-website-speed-affects-your-revenue.md
+++ b/content/blog/how-website-speed-affects-your-revenue.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-06-22'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/hvac-company-websites-that-drive-calls.md
+++ b/content/blog/hvac-company-websites-that-drive-calls.md
@@ -10,7 +10,7 @@ tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-07-01'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/invoice-late-fees-what-works.md
+++ b/content/blog/invoice-late-fees-what-works.md
@@ -9,7 +9,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-07-05'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/is-a-custom-website-worth-the-investment.md
+++ b/content/blog/is-a-custom-website-worth-the-investment.md
@@ -1,5 +1,5 @@
 ---
-title: 'Is a Custom Website Worth It?'
+title: Is a Custom Website Worth It?
 slug: is-a-custom-website-worth-the-investment
 excerpt: >-
   Stop guessing if your site pays for itself. I track revenue systems, not
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-07-14'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/landing-page-optimization-small-business.md
+++ b/content/blog/landing-page-optimization-small-business.md
@@ -1,13 +1,15 @@
 ---
 title: Landing Page Optimization for Small Business
 slug: landing-page-optimization-small-business
-excerpt: 'Stop treating your site like a brochure. How landing page optimization turns local traffic into booked appointments for DFW businesses.'
+excerpt: >-
+  Stop treating your site like a brochure. How landing page optimization turns
+  local traffic into booked appointments for DFW businesses.
 targetKeyword: landing page optimization
 pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-07-24'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/largest-contentful-paint-how-to-find-and-fix-it.md
+++ b/content/blog/largest-contentful-paint-how-to-find-and-fix-it.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-07-28'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/law-firm-websites-for-small-practices.md
+++ b/content/blog/law-firm-websites-for-small-practices.md
@@ -1,14 +1,16 @@
 ---
 title: Law Firm Websites for Small Practices
 slug: law-firm-websites-for-small-practices
-excerpt: 'Stop treating your site as a brochure. We build law firm websites that run on revenue automation, track every lead and convert more clients.'
+excerpt: >-
+  Stop treating your site as a brochure. We build law firm websites that run on
+  revenue automation, track every lead and convert more clients.
 targetKeyword: law firm website
 pillar: 7
 tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-08-06'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/lead-capture-forms-that-convert.md
+++ b/content/blog/lead-capture-forms-that-convert.md
@@ -10,7 +10,7 @@ pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-08-10'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/local-keyword-research-for-service-businesses.md
+++ b/content/blog/local-keyword-research-for-service-businesses.md
@@ -1,14 +1,16 @@
 ---
 title: Local Keyword Research for Service Businesses
 slug: local-keyword-research-for-service-businesses
-excerpt: 'Local keyword research for DFW service businesses: the workflow to map search intent, track conversions and book more qualified calls.'
+excerpt: >-
+  Local keyword research for DFW service businesses: the workflow to map search
+  intent, track conversions and book more qualified calls.
 targetKeyword: local keyword research
 pillar: 3
 tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-08-19'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/local-seo-for-small-business-guide.md
+++ b/content/blog/local-seo-for-small-business-guide.md
@@ -10,7 +10,7 @@ tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-08-29'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/localbusiness-schema-help-google-find-you.md
+++ b/content/blog/localbusiness-schema-help-google-find-you.md
@@ -1,14 +1,16 @@
 ---
 title: 'LocalBusiness Schema: Help Google Find You'
 slug: localbusiness-schema-help-google-find-you
-excerpt: 'Localbusiness schema for DFW businesses. Feed Google structured data to win map pack visibility and drive predictable revenue.'
+excerpt: >-
+  Localbusiness schema for DFW businesses. Feed Google structured data to win
+  map pack visibility and drive predictable revenue.
 targetKeyword: localbusiness schema
 pillar: 3
 tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-09-02'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/med-spa-websites-that-fill-the-calendar.md
+++ b/content/blog/med-spa-websites-that-fill-the-calendar.md
@@ -10,7 +10,7 @@ tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-09-11'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/mobile-first-web-design-for-service-businesses.md
+++ b/content/blog/mobile-first-web-design-for-service-businesses.md
@@ -1,14 +1,16 @@
 ---
 title: Mobile-First Web Design for Service Businesses
 slug: mobile-first-web-design-for-service-businesses
-excerpt: 'Mobile-first web design for DFW service businesses should run like a revenue engine. The metrics, automation and tracking that move booked jobs.'
+excerpt: >-
+  Mobile-first web design for DFW service businesses should run like a revenue
+  engine. The metrics, automation and tracking that move booked jobs.
 targetKeyword: mobile-first web design
 pillar: 1
 tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2025-09-15'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/mobile-site-speed-and-your-local-customers.md
+++ b/content/blog/mobile-site-speed-and-your-local-customers.md
@@ -10,7 +10,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-09-25'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/mortgage-math-for-small-business-owners.md
+++ b/content/blog/mortgage-math-for-small-business-owners.md
@@ -9,7 +9,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-10-04'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/nap-consistency-local-seo.md
+++ b/content/blog/nap-consistency-local-seo.md
@@ -10,7 +10,7 @@ tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-10-08'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/online-booking-that-cuts-no-shows.md
+++ b/content/blog/online-booking-that-cuts-no-shows.md
@@ -1,13 +1,15 @@
 ---
 title: Online Booking That Cuts No-Shows
 slug: online-booking-that-cuts-no-shows
-excerpt: 'DFW businesses lose revenue to no-shows. How online booking systems automate reminders, fill gaps and protect your revenue.'
+excerpt: >-
+  DFW businesses lose revenue to no-shows. How online booking systems automate
+  reminders, fill gaps and protect your revenue.
 targetKeyword: online booking
 pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-10-17'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/page-speed-optimization-for-local-service-sites.md
+++ b/content/blog/page-speed-optimization-for-local-service-sites.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-10-21'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/paystub-basics-for-small-employers.md
+++ b/content/blog/paystub-basics-for-small-employers.md
@@ -1,13 +1,15 @@
 ---
 title: Paystub Basics Every Small Employer Should Know
 slug: paystub-basics-for-small-employers
-excerpt: 'Small employers in DFW need accurate paystubs to stay compliant. The basics, how to automate the workflow and cut payroll errors with our free calculator.'
+excerpt: >-
+  Small employers in DFW need accurate paystubs to stay compliant. The basics,
+  how to automate the workflow and cut payroll errors with our free calculator.
 targetKeyword: paystub
 pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-10-31'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/plumber-website-design-that-books-jobs.md
+++ b/content/blog/plumber-website-design-that-books-jobs.md
@@ -1,14 +1,16 @@
 ---
 title: Plumber Website Design That Books Jobs
 slug: plumber-website-design-that-books-jobs
-excerpt: 'We build plumber websites that book jobs in DFW: traffic turned into revenue with automation, local SEO and real ROI tracking.'
+excerpt: >-
+  We build plumber websites that book jobs in DFW: traffic turned into revenue
+  with automation, local SEO and real ROI tracking.
 targetKeyword: plumber website
 pillar: 7
 tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-11-09'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/profit-margin-vs-markup.md
+++ b/content/blog/profit-margin-vs-markup.md
@@ -1,13 +1,15 @@
 ---
 title: 'Profit Margin vs Markup: Price Your Services Right'
 slug: profit-margin-vs-markup
-excerpt: 'Stop guessing your pricing. The profit margin vs markup difference and how to build a DFW pricing system that grows your bottom line.'
+excerpt: >-
+  Stop guessing your pricing. The profit margin vs markup difference and how to
+  build a DFW pricing system that grows your bottom line.
 targetKeyword: profit margin vs markup
 pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-11-13'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/real-cost-of-a-slow-website-for-local-business.md
+++ b/content/blog/real-cost-of-a-slow-website-for-local-business.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-11-22'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/restaurant-websites-that-drive-orders.md
+++ b/content/blog/restaurant-websites-that-drive-orders.md
@@ -1,14 +1,16 @@
 ---
 title: Restaurant Websites That Drive Orders and Reservations
 slug: restaurant-websites-that-drive-orders
-excerpt: 'A restaurant website should drive orders and reservations, not just display a menu. How we turn your site into a revenue system.'
+excerpt: >-
+  A restaurant website should drive orders and reservations, not just display a
+  menu. How we turn your site into a revenue system.
 targetKeyword: restaurant website
 pillar: 7
 tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-11-27'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/roofing-company-websites-that-convert.md
+++ b/content/blog/roofing-company-websites-that-convert.md
@@ -1,14 +1,16 @@
 ---
 title: Roofing Company Websites That Convert
 slug: roofing-company-websites-that-convert
-excerpt: 'Your DFW roofing company website should drive quotes, not just traffic. Revenue systems with HubSpot automation and local SEO that cut cost per lead.'
+excerpt: >-
+  Your DFW roofing company website should drive quotes, not just traffic.
+  Revenue systems with HubSpot automation and local SEO that cut cost per lead.
 targetKeyword: roofing company website
 pillar: 7
 tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-12-06'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/service-contracts-every-small-business-needs.md
+++ b/content/blog/service-contracts-every-small-business-needs.md
@@ -9,7 +9,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2025-12-15'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/signs-you-need-a-website-redesign.md
+++ b/content/blog/signs-you-need-a-website-redesign.md
@@ -11,7 +11,7 @@ tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2025-12-19'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/small-business-website-design-what-converts.md
+++ b/content/blog/small-business-website-design-what-converts.md
@@ -11,7 +11,7 @@ tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2025-12-28'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/spreadsheet-column-to-comma-list.md
+++ b/content/blog/spreadsheet-column-to-comma-list.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-01-02'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/squarespace-to-a-custom-site.md
+++ b/content/blog/squarespace-to-a-custom-site.md
@@ -10,7 +10,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-01-11'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/stripe-payment-setup-small-business.md
+++ b/content/blog/stripe-payment-setup-small-business.md
@@ -1,13 +1,16 @@
 ---
 title: Stripe Payment Setup for Small Business Websites
 slug: stripe-payment-setup-small-business
-excerpt: 'A no-nonsense guide to stripe payment setup for DFW small businesses. Cut friction, track revenue automatically and turn checkout into a forecasting engine.'
+excerpt: >-
+  A no-nonsense guide to stripe payment setup for DFW small businesses. Cut
+  friction, track revenue automatically and turn checkout into a forecasting
+  engine.
 targetKeyword: stripe payment setup
 pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-01-20'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/structured-data-and-schema-guide.md
+++ b/content/blog/structured-data-and-schema-guide.md
@@ -10,7 +10,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-01-24'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/tattoo-studio-websites-booking-gallery-seo.md
+++ b/content/blog/tattoo-studio-websites-booking-gallery-seo.md
@@ -10,7 +10,7 @@ tags:
   - home-services
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-02-03'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/texas-tax-title-license-vehicle-costs.md
+++ b/content/blog/texas-tax-title-license-vehicle-costs.md
@@ -9,7 +9,7 @@ pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-02-07'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/tip-calculation-and-bill-splitting.md
+++ b/content/blog/tip-calculation-and-bill-splitting.md
@@ -1,13 +1,15 @@
 ---
 title: Tip Calculator and Bill Splitting Made Simple
 slug: tip-calculation-and-bill-splitting
-excerpt: 'How DFW businesses automate tip splitting and bill math for faster checkout and higher turnover. Try our free tip calculator.'
+excerpt: >-
+  How DFW businesses automate tip splitting and bill math for faster checkout
+  and higher turnover. Try our free tip calculator.
 targetKeyword: tip calculator
 pillar: 9
 tags:
   - business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-02-16'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/trust-signals-that-convert-visitors.md
+++ b/content/blog/trust-signals-that-convert-visitors.md
@@ -9,7 +9,7 @@ pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-02-25'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/web-design-mistakes-that-cost-customers.md
+++ b/content/blog/web-design-mistakes-that-cost-customers.md
@@ -1,14 +1,16 @@
 ---
 title: Web Design Mistakes That Cost Small Businesses Customers
 slug: web-design-mistakes-that-cost-customers
-excerpt: 'Stop losing customers to common web design mistakes. Get expert fixes for faster sites, higher SEO rankings and more bookings in Dallas-Fort Worth.'
+excerpt: >-
+  Stop losing customers to common web design mistakes. Get expert fixes for
+  faster sites, higher SEO rankings and more bookings in Dallas-Fort Worth.
 targetKeyword: web design mistakes
 pillar: 1
 tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2026-03-01'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/website-maintenance-costs-explained.md
+++ b/content/blog/website-maintenance-costs-explained.md
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-03-11'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/website-migration-checklist.md
+++ b/content/blog/website-migration-checklist.md
@@ -1,13 +1,15 @@
 ---
 title: 'Website Migration Checklist: Move Without Losing SEO'
 slug: website-migration-checklist
-excerpt: 'A website migration checklist that protects your SEO, preserves revenue tracking and cuts downtime. Built for DFW businesses moving platforms.'
+excerpt: >-
+  A website migration checklist that protects your SEO, preserves revenue
+  tracking and cuts downtime. Built for DFW businesses moving platforms.
 targetKeyword: website migration checklist
 pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-03-15'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/website-navigation-best-practices-small-business.md
+++ b/content/blog/website-navigation-best-practices-small-business.md
@@ -10,7 +10,7 @@ tags:
   - web-design
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-18'
+publishedAt: '2026-03-24'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/website-performance-audit-checklist-small-business.md
+++ b/content/blog/website-performance-audit-checklist-small-business.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-04-02'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/website-traffic-but-no-leads.md
+++ b/content/blog/website-traffic-but-no-leads.md
@@ -9,7 +9,7 @@ pillar: 4
 tags:
   - conversion-optimization
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-04-07'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/what-goes-into-a-website-quote.md
+++ b/content/blog/what-goes-into-a-website-quote.md
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-04-16'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/when-and-why-to-format-json.md
+++ b/content/blog/when-and-why-to-format-json.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-04-20'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/who-owns-your-website-and-domain.md
+++ b/content/blog/who-owns-your-website-and-domain.md
@@ -9,7 +9,7 @@ pillar: 6
 tags:
   - website-migration
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-04-29'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/why-cheap-websites-cost-more.md
+++ b/content/blog/why-cheap-websites-cost-more.md
@@ -10,7 +10,7 @@ tags:
   - business
   - small-business
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-05-08'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/why-google-business-profile-not-showing-up.md
+++ b/content/blog/why-google-business-profile-not-showing-up.md
@@ -1,5 +1,5 @@
 ---
-title: 'Google Business Profile Not Showing Up? Here Is Why'
+title: Google Business Profile Not Showing Up? Here Is Why
 slug: why-google-business-profile-not-showing-up
 excerpt: >-
   Fix your google business profile not showing issues with a data-driven
@@ -10,7 +10,7 @@ tags:
   - seo
   - local-marketing
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-05-13'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/why-we-build-on-nextjs-not-wordpress.md
+++ b/content/blog/why-we-build-on-nextjs-not-wordpress.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-05-22'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/why-your-small-business-has-a-slow-website.md
+++ b/content/blog/why-your-small-business-has-a-slow-website.md
@@ -9,7 +9,7 @@ pillar: 2
 tags:
   - website-performance
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-05-26'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/word-and-character-counts-that-matter.md
+++ b/content/blog/word-and-character-counts-that-matter.md
@@ -9,7 +9,7 @@ pillar: 10
 tags:
   - web-development
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-06-04'
 published: true
 featured: false
 featureImage: ''

--- a/content/blog/workflow-automation-tools-small-business.md
+++ b/content/blog/workflow-automation-tools-small-business.md
@@ -10,7 +10,7 @@ pillar: 5
 tags:
   - business-automation
 author: richard-hudson
-publishedAt: '2026-06-19'
+publishedAt: '2026-06-12'
 published: true
 featured: false
 featureImage: ''

--- a/scripts/blog/spread-dates.ts
+++ b/scripts/blog/spread-dates.ts
@@ -1,0 +1,59 @@
+/**
+ * One-time: spread publishedAt across the NEW v9 posts so the blog reads like
+ * an organic ~18-month publishing history instead of a same-day bulk drop.
+ * Only touches non-legacy posts (the 11 migrated posts are legacy:true and keep
+ * their real historical dates). Deterministic: even spread + small jitter.
+ *   bun run scripts/blog/spread-dates.ts            # write new dates
+ *   bun run scripts/blog/spread-dates.ts --dry-run  # preview only
+ * After running, commit the files and run blog:publish to sync Neon.
+ */
+import { writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import matter from 'gray-matter'
+import { CONTENT_DIR, listPostFiles, parsePost } from './lib'
+
+const dryRun = process.argv.includes('--dry-run')
+
+// Publishing window: oldest -> newest. Ends a week before "today" so the most
+// recent posts look freshly published, not future-dated.
+const START = Date.parse('2024-12-03T00:00:00Z')
+const END = Date.parse('2026-06-12T00:00:00Z')
+const DAY = 86_400_000
+
+function fmt(ms: number): string {
+	return new Date(ms).toISOString().slice(0, 10)
+}
+
+function main(): void {
+	const targets = listPostFiles()
+		.map(parsePost)
+		.filter(p => p.data.legacy !== true)
+		.sort((a, b) => a.slug.localeCompare(b.slug))
+
+	const n = targets.length
+	const span = END - START
+	let i = 0
+	for (const p of targets) {
+		// Even spacing with a deterministic +/- 2 day wobble so the cadence
+		// looks human, not metronomic.
+		const base = START + Math.round((i / (n - 1)) * span)
+		const jitter = (((i * 37) % 5) - 2) * DAY
+		const date = fmt(Math.min(END, Math.max(START, base + jitter)))
+		i++
+		if (dryRun) {
+			console.warn(`${date}  ${p.slug}`)
+			continue
+		}
+		const raw = matter.read(join(CONTENT_DIR, p.file))
+		raw.data.publishedAt = date
+		writeFileSync(
+			join(CONTENT_DIR, p.file),
+			matter.stringify(`\n${raw.content.trim()}\n`, raw.data)
+		)
+	}
+	console.warn(
+		`blog:spread-dates - ${n} new posts re-dated ${fmt(START)} to ${fmt(END)}${dryRun ? ' (dry-run)' : ''}`
+	)
+}
+
+main()


### PR DESCRIPTION
Polish on the v9 campaign:
- **Dates:** spread publishedAt across the 78 new posts over Dec 2024 to Jun 2026 (organic 2-5/month cadence) so the blog does not read as a same-day bulk drop. 11 migrated posts keep real dates. Synced to Neon. Adds scripts/blog/spread-dates.ts.
- **Headshot:** author profile_image was a missing /images/team/richard.webp; repointed to the real /images/founder.jpg (739x739) via Neon UPDATE. Fixes the broken byline avatar across all posts.

[hudsor01]