### PR TITLE
feat(blog): richer editorial typography for post content

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -769,7 +769,9 @@ button,
 /* Typography component */
 @layer components {
 	.typography {
-		line-height: 1.625;
+		font-size: 1.0625rem;
+		line-height: 1.8;
+		color: var(--foreground);
 	}
 	.typography h1 {
 		font-size: var(--font-size-3xl);
@@ -778,50 +780,172 @@ button,
 		letter-spacing: var(--tracking-heading);
 		margin-bottom: 1rem;
 	}
+	/* Headings get generous top space so each section breathes. */
 	.typography h2 {
 		font-size: var(--font-size-2xl);
 		font-weight: var(--font-weight-semibold);
 		line-height: var(--line-height-snug);
+		letter-spacing: var(--tracking-heading);
+		margin-top: 3rem;
 		margin-bottom: 1rem;
-		border-bottom: 1px solid var(--border);
 		padding-bottom: 0.5rem;
+		border-bottom: 1px solid var(--border-subtle, var(--border));
 	}
 	.typography h3 {
 		font-size: var(--font-size-xl);
 		font-weight: var(--font-weight-semibold);
 		line-height: var(--line-height-normal);
+		margin-top: 2rem;
 		margin-bottom: 0.75rem;
 	}
+	.typography h2 + h3 {
+		margin-top: 1rem;
+	}
 	.typography p {
-		margin-bottom: 1rem;
+		margin-bottom: 1.4rem;
+		text-wrap: pretty;
+	}
+	/* Lead-in: the opening paragraph reads larger, like an editorial standfirst. */
+	.typography > p:first-of-type {
+		font-size: 1.2rem;
+		line-height: 1.7;
+		color: var(--muted-foreground);
+	}
+	.typography strong {
+		font-weight: var(--font-weight-semibold);
+		color: var(--foreground);
 	}
 	.typography a {
 		color: var(--primary);
 		text-decoration: underline;
+		text-decoration-color: color-mix(in oklab, var(--primary) 35%, transparent);
+		text-underline-offset: 3px;
+		text-decoration-thickness: 2px;
+		transition:
+			color 0.15s ease,
+			text-decoration-color 0.15s ease;
 	}
 	.typography a:hover {
 		color: var(--accent);
+		text-decoration-color: var(--accent);
 	}
+	/* Generic list rules first (lower specificity before the ul>li rules
+	   below, to satisfy no-descending-specificity). */
 	.typography ul,
 	.typography ol {
 		padding-left: 1.5rem;
-		margin-block: 1rem;
+		margin-block: 1.4rem;
+	}
+	.typography li {
+		padding-left: 0.25rem;
 	}
 	.typography li + li {
 		margin-top: 0.5rem;
 	}
+	.typography ul {
+		list-style: none;
+		padding-left: 1.75rem;
+	}
+	.typography ol {
+		list-style: decimal;
+	}
+	.typography ol > li::marker {
+		color: var(--accent-text, var(--accent));
+		font-weight: var(--font-weight-semibold);
+	}
+	/* Brand-colored custom bullets. */
+	.typography ul > li {
+		position: relative;
+	}
+	.typography ul > li::before {
+		content: '';
+		position: absolute;
+		left: -1.25rem;
+		top: 0.7em;
+		width: 0.4rem;
+		height: 0.4rem;
+		border-radius: 9999px;
+		background: var(--accent);
+	}
+	/* Blockquote as a soft callout card, not just an italic indent. */
 	.typography blockquote {
-		padding-left: 1.5rem;
+		margin-block: 1.75rem;
+		padding: 1rem 1.5rem;
 		border-left: 4px solid var(--accent);
-		color: var(--muted-foreground);
-		font-style: italic;
+		border-radius: 0.5rem;
+		background: color-mix(in oklab, var(--accent) 7%, var(--card));
+		color: var(--foreground);
+		font-size: 1.125rem;
+	}
+	.typography blockquote p:last-child {
+		margin-bottom: 0;
 	}
 	.typography code {
-		padding: 0.25rem 0.5rem;
+		padding: 0.15rem 0.4rem;
 		background: var(--secondary);
 		border-radius: 0.375rem;
 		font-family: var(--font-mono);
-		font-size: 0.875rem;
+		font-size: 0.875em;
+	}
+	/* Fenced code blocks (pre) were unstyled before. */
+	.typography pre {
+		margin-block: 1.5rem;
+		padding: 1.25rem 1.5rem;
+		background: var(--surface-sunken, var(--secondary));
+		border: 1px solid var(--border-subtle, var(--border));
+		border-radius: 0.75rem;
+		overflow-x: auto;
+		line-height: 1.6;
+	}
+	.typography pre code {
+		padding: 0;
+		background: transparent;
+		font-size: 0.9rem;
+	}
+	.typography img {
+		margin-block: 1.75rem;
+		border-radius: 0.75rem;
+		border: 1px solid var(--border-subtle, var(--border));
+	}
+	.typography hr {
+		margin-block: 2.5rem;
+		border: 0;
+		border-top: 1px solid var(--border-subtle, var(--border));
+	}
+	/* Scroll-margin so in-page anchor jumps (table of contents) clear the
+	   sticky navbar, per the shadcn typography reference. */
+	.typography :is(h1, h2, h3, h4) {
+		scroll-margin-top: 6rem;
+		text-wrap: balance;
+	}
+	/* Tables (comparison posts). The sanitizer now allows table tags, so style
+	   them as a bordered, zebra-striped block instead of raw rows. */
+	.typography table {
+		width: 100%;
+		margin-block: 1.75rem;
+		border-collapse: collapse;
+		font-size: 0.95rem;
+	}
+	.typography thead {
+		background: var(--surface-sunken, var(--secondary));
+	}
+	.typography th,
+	.typography td {
+		padding: 0.625rem 0.875rem;
+		border: 1px solid var(--border-subtle, var(--border));
+		text-align: left;
+		vertical-align: top;
+	}
+	.typography th {
+		font-weight: var(--font-weight-semibold);
+		color: var(--foreground);
+	}
+	.typography tbody tr:nth-child(even) {
+		background: color-mix(in oklab, var(--secondary) 50%, transparent);
+	}
+	/* Don't let the last element add trailing space before the author card. */
+	.typography > *:last-child {
+		margin-bottom: 0;
 	}
 }
 

--- a/src/components/blog/BlogPostContent.tsx
+++ b/src/components/blog/BlogPostContent.tsx
@@ -30,11 +30,20 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
 		'code',
 		'pre',
 		'br',
-		'img'
+		'img',
+		'hr',
+		'table',
+		'thead',
+		'tbody',
+		'tr',
+		'th',
+		'td'
 	],
 	allowedAttributes: {
 		a: ['href', 'title', 'target', 'rel', 'class'],
-		img: ['src', 'alt', 'title', 'class']
+		img: ['src', 'alt', 'title', 'class'],
+		th: ['align'],
+		td: ['align']
 	},
 	allowedSchemes: ['http', 'https', 'mailto']
 	// Intentionally NOT allowing data: URIs on <img>: blog content can be


### PR DESCRIPTION
Upgrades the .typography content styles (all 87 posts render through it), aligned with the shadcn typography reference + Tailwind typography utilities on existing brand tokens.

- Larger relaxed body, section breathing, lead-paragraph standfirst, brand-colored list markers, blockquote callout cards, code-block/strong/img/hr styling, underline-offset links, balanced headings, scroll-margin for future TOC anchors.
- **Table support**: sanitizer now allows table tags (were silently stripped) + bordered zebra styling, so markdown comparison tables render.

No content changes; pure styling + sanitizer allowlist. lint/typecheck/build green.

[hudsor01]