### PR TITLE
feat(blog): sticky table of contents + reading progress bar

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -5,11 +5,14 @@ import Link from 'next/link'
 import { notFound, permanentRedirect } from 'next/navigation'
 import { AuthorCard } from '@/components/blog/AuthorCard'
 import { BlogPostContent } from '@/components/blog/BlogPostContent'
+import { BlogTableOfContents } from '@/components/blog/BlogTableOfContents'
+import { ReadingProgress } from '@/components/blog/ReadingProgress'
 import { RelatedPosts } from '@/components/blog/RelatedPosts'
 import { Button } from '@/components/ui/button'
 import { BackLink } from '@/components/utilities/BackLink'
 import { JsonLd } from '@/components/utilities/JsonLd'
 import { getPostBySlug, getPosts, getPostsByTag } from '@/lib/blog'
+import { withHeadingIds } from '@/lib/blog-toc'
 import { BUSINESS_INFO } from '@/lib/constants/business'
 import { formatDate } from '@/lib/utils'
 
@@ -228,8 +231,13 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 		]
 	}
 
+	// Headings drive the table of contents; ids here match those injected by
+	// BlogPostContent (same deterministic slugify over the same headings).
+	const { toc } = withHeadingIds(post.content ?? '')
+
 	return (
 		<div className="min-h-screen bg-background">
+			<ReadingProgress />
 			<JsonLd data={blogPostingSchema} />
 			<JsonLd data={breadcrumbSchema} />
 
@@ -314,9 +322,20 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 					</div>
 				)}
 
-				{/* Article Content */}
-				<div className="container-narrow py-8">
-					<BlogPostContent post={post} />
+				{/* Article Content + sticky table of contents */}
+				<div className="container-wide py-8">
+					<div className="mx-auto max-w-5xl lg:grid lg:grid-cols-[minmax(0,1fr)_15rem] lg:gap-12">
+						<div className="min-w-0 max-w-3xl">
+							<BlogPostContent post={post} />
+						</div>
+						{toc.length >= 2 && (
+							<aside className="hidden lg:block">
+								<div className="sticky top-24 max-h-[calc(100vh-7rem)] overflow-y-auto">
+									<BlogTableOfContents items={toc} />
+								</div>
+							</aside>
+						)}
+					</div>
 				</div>
 
 				{/* Author Bio */}

--- a/src/components/blog/BlogPostContent.tsx
+++ b/src/components/blog/BlogPostContent.tsx
@@ -1,6 +1,7 @@
 import { cacheLife, cacheTag } from 'next/cache'
 import sanitizeHtml from 'sanitize-html'
 import type { BlogPost } from '@/lib/blog'
+import { withHeadingIds } from '@/lib/blog-toc'
 
 interface BlogPostContentProps {
 	post: BlogPost
@@ -74,13 +75,15 @@ export async function BlogPostContent({ post }: BlogPostContentProps) {
 	}
 
 	// Blog content comes from our trusted n8n pipeline; sanitization is
-	// defense in depth.
+	// defense in depth. Heading ids are injected after sanitizing (clean
+	// slugs, safe) so the table of contents can anchor-link to each section.
 	const sanitizedContent = sanitizeHtml(post.content, SANITIZE_OPTIONS)
+	const { html } = withHeadingIds(sanitizedContent)
 
 	return (
 		<div
 			className="typography max-w-none"
-			dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+			dangerouslySetInnerHTML={{ __html: html }}
 		/>
 	)
 }

--- a/src/components/blog/BlogTableOfContents.tsx
+++ b/src/components/blog/BlogTableOfContents.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { TocItem } from '@/lib/blog-toc'
+
+interface BlogTableOfContentsProps {
+	items: TocItem[]
+}
+
+/**
+ * "On this page" navigation built from the post's h2/h3 headings. Highlights
+ * the section currently in view (IntersectionObserver scrollspy) and smooth
+ * scrolls on click. Rendered as a sticky sidebar on large screens.
+ */
+export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
+	const [activeId, setActiveId] = useState<string>(items[0]?.id ?? '')
+
+	useEffect(() => {
+		const headings = items
+			.map(item => document.getElementById(item.id))
+			.filter((el): el is HTMLElement => el !== null)
+		if (headings.length === 0) {
+			return
+		}
+
+		const observer = new IntersectionObserver(
+			entries => {
+				const visible = entries
+					.filter(e => e.isIntersecting)
+					.sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+				if (visible[0]?.target.id) {
+					setActiveId(visible[0].target.id)
+				}
+			},
+			// Trigger when a heading sits in the top third of the viewport.
+			{ rootMargin: '-80px 0px -66% 0px', threshold: 0 }
+		)
+		for (const h of headings) {
+			observer.observe(h)
+		}
+		return () => observer.disconnect()
+	}, [items])
+
+	function handleClick(e: React.MouseEvent<HTMLAnchorElement>, id: string) {
+		e.preventDefault()
+		const el = document.getElementById(id)
+		if (!el) {
+			return
+		}
+		el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+		setActiveId(id)
+		history.replaceState(null, '', `#${id}`)
+	}
+
+	if (items.length < 2) {
+		return null
+	}
+
+	return (
+		<nav aria-label="Table of contents" className="text-sm">
+			<p className="font-semibold text-foreground mb-3">On this page</p>
+			<ul className="space-y-2 border-l border-border-subtle">
+				{items.map(item => {
+					const active = item.id === activeId
+					return (
+						<li key={item.id} className={item.level === 3 ? 'ml-3' : undefined}>
+							<a
+								href={`#${item.id}`}
+								onClick={e => handleClick(e, item.id)}
+								aria-current={active ? 'location' : undefined}
+								className={`-ml-px block border-l-2 pl-3 transition-colors ${
+									active
+										? 'border-accent text-accent font-medium'
+										: 'border-transparent text-muted-foreground hover:text-foreground hover:border-border-strong'
+								}`}
+							>
+								{item.text}
+							</a>
+						</li>
+					)
+				})}
+			</ul>
+		</nav>
+	)
+}

--- a/src/components/blog/ReadingProgress.tsx
+++ b/src/components/blog/ReadingProgress.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Thin fixed bar at the top of the viewport that fills as the reader scrolls
+ * through the article. Accessibility: exposed as a progressbar with a live
+ * aria-valuenow so assistive tech can announce reading position.
+ */
+export function ReadingProgress() {
+	const [progress, setProgress] = useState(0)
+
+	useEffect(() => {
+		function update() {
+			const doc = document.documentElement
+			const scrollable = doc.scrollHeight - doc.clientHeight
+			const pct = scrollable > 0 ? (doc.scrollTop / scrollable) * 100 : 0
+			setProgress(Math.min(100, Math.max(0, Math.round(pct))))
+		}
+		update()
+		window.addEventListener('scroll', update, { passive: true })
+		window.addEventListener('resize', update)
+		return () => {
+			window.removeEventListener('scroll', update)
+			window.removeEventListener('resize', update)
+		}
+	}, [])
+
+	return (
+		<div
+			className="fixed inset-x-0 top-0 z-50 h-1 bg-transparent"
+			role="progressbar"
+			aria-label="Reading progress"
+			aria-valuenow={progress}
+			aria-valuemin={0}
+			aria-valuemax={100}
+		>
+			<div
+				className="h-full bg-accent transition-[width] duration-150 ease-out"
+				style={{ width: `${progress}%` }}
+			/>
+		</div>
+	)
+}

--- a/src/lib/blog-toc.ts
+++ b/src/lib/blog-toc.ts
@@ -1,0 +1,65 @@
+/**
+ * Blog table-of-contents helper. The post body is stored as HTML (markdown
+ * converted by marked at publish time) with no heading ids. This injects
+ * stable kebab-case ids onto h2/h3 and returns the TOC so the page can render
+ * an "On this page" nav with working anchor links + scrollspy.
+ */
+
+export interface TocItem {
+	id: string
+	text: string
+	level: 2 | 3
+}
+
+function slugifyHeading(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/<[^>]+>/g, '')
+		.replace(/&[a-z]+;/g, ' ')
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '')
+}
+
+/**
+ * Inject `id` attributes on h2/h3 (skipping any that already have one) and
+ * collect the TOC. Returns the rewritten HTML and the heading list. Pure
+ * string work, no DOM/jsdom, so it runs in the Vercel build runtime.
+ */
+export function withHeadingIds(html: string): { html: string; toc: TocItem[] } {
+	const toc: TocItem[] = []
+	const seen = new Map<string, number>()
+
+	const out = html.replace(
+		/<h([23])(\s[^>]*)?>([\s\S]*?)<\/h\1>/g,
+		(match, levelStr: string, attrs: string | undefined, inner: string) => {
+			const level = Number(levelStr) as 2 | 3
+			const text = inner
+				.replace(/<[^>]+>/g, '')
+				.replace(/\s+/g, ' ')
+				.trim()
+			if (!text) {
+				return match
+			}
+			// Respect an existing id if the markup already has one.
+			const existing = attrs?.match(/\sid=["']([^"']+)["']/)
+			let id = existing?.[1] ?? slugifyHeading(text)
+			if (!id) {
+				return match
+			}
+			// De-duplicate ids across the document.
+			const count = seen.get(id) ?? 0
+			seen.set(id, count + 1)
+			if (count > 0) {
+				id = `${id}-${count}`
+			}
+			toc.push({ id, text, level })
+			if (existing) {
+				return match
+			}
+			const cleanAttrs = attrs ?? ''
+			return `<h${level}${cleanAttrs} id="${id}">${inner}</h${level}>`
+		}
+	)
+
+	return { html: out, toc }
+}


### PR DESCRIPTION
Premium reading experience for the long-form posts.

- **ReadingProgress**: fixed top bar that fills on scroll (accessible progressbar).
- **BlogTableOfContents**: sticky 'On this page' nav auto-built from each post's H2/H3, IntersectionObserver scrollspy (active highlight), smooth-scroll anchors, sidebar on lg / hidden on mobile.
- src/lib/blog-toc.ts injects deterministic heading ids (post-sanitize); pairs with the scroll-margin from the typography pass. Renders only when a post has >= 2 headings.

No content changes. lint/typecheck/build green.

[hudsor01]