### PR TITLE
fix(blog): emit og:image/twitter:image (branded card) on posts

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -93,29 +93,34 @@ export async function generateMetadata({
 		openGraph: {
 			title: post.title,
 			description,
-			// When a post has no custom feature_image, omit images here so the
-			// dynamic opengraph-image.tsx branded card is used instead (every
-			// post gets a Facebook/social preview without hand-made images).
-			images: post.feature_image
-				? [
-						{
-							url: post.feature_image,
-							width: 1200,
-							height: 630,
-							alt: post.title
-						}
-					]
-				: undefined,
 			type: 'article',
 			publishedTime: post.published_at,
 			authors: [post.author?.name ?? 'Unknown'],
-			tags: post.tags?.map(tag => tag.name)
+			tags: post.tags?.map(tag => tag.name),
+			// Only set `images` when a custom feature_image exists. The key must
+			// be OMITTED entirely (not set to undefined) when absent: Next treats
+			// a present `images` key as "explicitly provided" and then does NOT
+			// auto-inject the file-based opengraph-image.tsx branded card, which
+			// left every post with no og:image (socials fell back to the page's
+			// author headshot).
+			...(post.feature_image
+				? {
+						images: [
+							{
+								url: post.feature_image,
+								width: 1200,
+								height: 630,
+								alt: post.title
+							}
+						]
+					}
+				: {})
 		},
 		twitter: {
 			card: 'summary_large_image',
 			title: post.title,
 			description,
-			images: post.feature_image ? [post.feature_image] : undefined
+			...(post.feature_image ? { images: [post.feature_image] } : {})
 		},
 		alternates: {
 			canonical: `https://hudsondigitalsolutions.com/blog/${post.slug}`

--- a/src/app/(public)/blog/[slug]/twitter-image.tsx
+++ b/src/app/(public)/blog/[slug]/twitter-image.tsx
@@ -1,9 +1,12 @@
-// Twitter card image reuses the Open Graph card generator.
-export {
-	alt,
-	contentType,
-	default,
-	dynamic,
-	runtime,
-	size
-} from './opengraph-image'
+// Twitter card image reuses the Open Graph card generator. Route config
+// (runtime/dynamic/size/etc.) must be declared DIRECTLY here, not re-exported:
+// Next.js cannot statically analyze a re-exported `runtime` and silently falls
+// back to the default runtime, which breaks the Node-only readFileSync logo
+// load in opengraph-image. Only the rendering component is re-exported.
+export { default } from './opengraph-image'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const alt = 'Hudson Digital Solutions'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'


### PR DESCRIPTION
Blog posts shipped with no og:image, so Facebook shares fell back to the author headshot instead of the branded card (logo + title). Fixes: (1) omit openGraph/twitter `images` key entirely when no feature_image (setting it to `undefined` suppressed Next's file-based opengraph-image.tsx auto-injection); (2) declare twitter-image route config directly instead of re-exporting `runtime` (Next couldn't analyze the re-export, fell back to a runtime that breaks the Node readFileSync logo load). Verified locally: posts now emit og:image + twitter:image (1200x630 branded card).

[hudsor01]