### PR TITLE
feat(blog): redesign OG card aligned to design tokens

### DIFF
--- a/src/app/(public)/blog/[slug]/opengraph-image.tsx
+++ b/src/app/(public)/blog/[slug]/opengraph-image.tsx
@@ -12,6 +12,22 @@ export const alt = 'Hudson Digital Solutions'
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
 
+// Brand tokens from globals.css (oklch) converted to hex, since Satori cannot
+// read CSS variables or oklch. Keep in sync with @theme in src/app/globals.css.
+const C = {
+	background: '#ffffff', // --color-surface-elevated (matches the logo's white)
+	foreground: '#070a10', // --color-foreground (title)
+	accent: '#ef852e', // --color-accent (dash)
+	accentText: '#a44100', // --color-accent-text (eyebrow, legible)
+	primaryDeep: '#002561', // --color-primary-deep (footer band)
+	inverted: '#fafaf9', // --color-text-inverted (footer text)
+	footerMuted: 'rgba(250,250,249,0.66)'
+}
+
+function eyebrowFor(tag: string | undefined): string {
+	return (tag ?? 'Insights').replace(/-/g, ' ').toUpperCase()
+}
+
 export default async function Image({
 	params
 }: {
@@ -20,44 +36,96 @@ export default async function Image({
 	const { slug } = await params
 	const post = await getPostBySlug(slug)
 	const title = (post?.title ?? 'Hudson Digital Solutions').slice(0, 110)
+	const eyebrow = eyebrowFor(post?.tags?.[0]?.name)
 
 	return new ImageResponse(
 		<div
 			style={{
 				display: 'flex',
 				flexDirection: 'column',
-				justifyContent: 'space-between',
 				width: '100%',
 				height: '100%',
-				padding: '72px',
-				backgroundColor: '#ffffff'
+				backgroundColor: C.background
 			}}
 		>
-			{/* biome-ignore lint/performance/noImgElement: ImageResponse (Satori) requires a raw img element; next/image is unavailable in OG rendering. */}
-			<img src={LOGO_DATA_URL} height={64} alt="Hudson Digital Solutions" />
+			{/* Content area: logo top, title block anchored at the bottom. */}
 			<div
 				style={{
 					display: 'flex',
-					fontSize: 62,
-					fontWeight: 700,
-					color: '#070a10',
-					lineHeight: 1.15,
-					maxWidth: 1056
+					flexDirection: 'column',
+					flexGrow: 1,
+					padding: '64px 72px 48px'
 				}}
 			>
-				{title}
-			</div>
-			<div style={{ display: 'flex', alignItems: 'center' }}>
+				{/* biome-ignore lint/performance/noImgElement: ImageResponse (Satori) requires a raw img element; next/image is unavailable in OG rendering. */}
+				<img src={LOGO_DATA_URL} height={46} alt="Hudson Digital Solutions" />
+				<div style={{ display: 'flex', flexGrow: 1 }} />
+				{/* Eyebrow: accent dash + category label */}
 				<div
 					style={{
-						width: 56,
-						height: 8,
-						backgroundColor: '#ef852e',
-						marginRight: 20
+						display: 'flex',
+						alignItems: 'center',
+						marginBottom: 22
 					}}
-				/>
-				<div style={{ display: 'flex', fontSize: 30, color: '#064180' }}>
+				>
+					<div
+						style={{
+							width: 44,
+							height: 6,
+							borderRadius: 3,
+							backgroundColor: C.accent,
+							marginRight: 18
+						}}
+					/>
+					<div
+						style={{
+							display: 'flex',
+							fontSize: 26,
+							fontWeight: 700,
+							letterSpacing: 3,
+							color: C.accentText
+						}}
+					>
+						{eyebrow}
+					</div>
+				</div>
+				{/* Title */}
+				<div
+					style={{
+						display: 'flex',
+						fontSize: 62,
+						fontWeight: 700,
+						lineHeight: 1.12,
+						letterSpacing: -1,
+						color: C.foreground,
+						maxWidth: 1010
+					}}
+				>
+					{title}
+				</div>
+			</div>
+			{/* Footer band: brand navy with domain + positioning line. */}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					backgroundColor: C.primaryDeep,
+					padding: '30px 72px'
+				}}
+			>
+				<div
+					style={{
+						display: 'flex',
+						fontSize: 30,
+						fontWeight: 700,
+						color: C.inverted
+					}}
+				>
 					hudsondigitalsolutions.com
+				</div>
+				<div style={{ display: 'flex', fontSize: 25, color: C.footerMuted }}>
+					Websites that drive revenue, Dallas to Fort Worth
 				</div>
 			</div>
 		</div>,


### PR DESCRIPTION
Rebuilds the blog Open Graph / social card with an editorial layout and the exact globals.css brand tokens (oklch converted to hex for Satori): surface-elevated white, foreground title, accent + accent-text eyebrow showing the post category, primary-deep navy footer band with domain + positioning line. Replaces the sparse all-white card (title floating) with anchored hierarchy and brand presence. Rendered + verified locally for multiple posts.

[hudsor01]