### PR TITLE
chore(social): FB scheduling tooling + campaign artifacts

### DIFF
--- a/.planning/social/facebook-agent-prompt.md
+++ b/.planning/social/facebook-agent-prompt.md
@@ -1,0 +1,657 @@
+# Task: schedule 87 Facebook posts in Meta Business Suite
+
+You are a browser-automation agent. Chrome is already open and logged in to Meta
+Business Suite (business.facebook.com) for the Facebook Page "Hudson Digital
+Solutions". Schedule the 87 posts listed at the end, IN THE GIVEN ORDER.
+
+## Scheduling cadence
+Post 3 per day at these US Central times: 7:00 AM, 1:00 PM, and 7:00 PM.
+Assign posts to slots in order: POST 1 to the earliest open slot, POST 2 to the
+next, and so on. Start from the next available slot from right now (if a time
+today has already passed, skip it and use the next one). Continue day by day
+until all 87 are scheduled (about 30 days out).
+
+## Steps for EACH post (Meta Business Suite)
+1. Click "Create post".
+2. Confirm "Post to" is the "Hudson Digital Solutions" Facebook page; select it if not.
+3. Click the post text box and enter the caption EXACTLY as given (it already
+   includes the blog link and hashtags). Wait a few seconds for the link
+   preview card to load under the text. It should show a branded card with the
+   HUDSON logo and the article title (not a headshot).
+4. If a hashtag suggestion dropdown appears, press Escape to dismiss it.
+5. Scroll down to the "Schedule" section and turn ON "Set date and time".
+6. Set the Date to this slot's date.
+7. Set the Time to this slot's time. IMPORTANT: the time control has separate
+   Hours, Minutes, and AM/PM fields and is finicky. After setting it, VERIFY it
+   reads the exact target (e.g. "07:00 AM"). If it shows anything else, correct
+   it (clear and re-enter, or use the up/down arrows on each segment). Do NOT
+   continue until the displayed time is exactly right.
+8. Make sure "Share to ... Facebook story" is OFF (do not cross-post to Story).
+9. Leave Privacy as "Public".
+10. Click "Schedule" (NEVER "Publish" - do not post immediately).
+11. If a "Boost post" / advertising upsell appears, click "Maybe later" or close
+    it. NEVER click "Boost" and never spend any money.
+12. Go back and create the next post.
+
+## Hard rules
+- Always SCHEDULE for the future; never publish immediately.
+- Never boost, never run ads, never spend money - decline every paid upsell.
+- Only ever post to the "Hudson Digital Solutions" Facebook page.
+- Verify each scheduled time is exactly correct before moving on.
+- Use the captions verbatim. Do not edit them, add emojis, or change hashtags.
+- If a post titled "5 Signs Your Website is Costing You Customers" (POST 1) is
+  already published on the page, skip POST 1.
+- After every ~10 posts, glance at the calendar/Planner to confirm they are
+  appearing as scheduled posts at the right times.
+
+## The 87 posts (schedule in this order)
+
+----- POST 1 -----
+Your website might be quietly losing you jobs every week and you would never know it. Slow loads, dead phone numbers on mobile, no clear next step. Here are 5 signs your site is bleeding customers and what I fix first.
+
+https://hudsondigitalsolutions.com/blog/5-signs-your-website-is-costing-you-customers
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 2 -----
+Stop guessing how many pages your site needs. A 40-page site does not book more calls than a tight 5-page one that is built to convert. I treat every page as a revenue job and track each click. Here is the page count that actually books work.
+
+https://hudsondigitalsolutions.com/blog/how-many-pages-does-a-small-business-website-need
+
+#SmallBusinessWebsite #WebDesign #DFW
+
+----- POST 3 -----
+Google grades your site on load speed, how fast it responds to taps and whether it jumps around while loading. Fail those and you slide down the results. Here is what Core Web Vitals actually mean for a DFW owner and how to fix them without torching your budget.
+
+https://hudsondigitalsolutions.com/blog/core-web-vitals-explained-for-small-business
+
+#CoreWebVitals #WebPerformance #DallasFortWorth
+
+----- POST 4 -----
+Your Google Business Profile is the first thing a DFW customer sees and most are half filled out. A complete, optimized listing pulls calls straight off the map pack. Here is the exact checklist I run to turn that free listing into a booking machine.
+
+https://hudsondigitalsolutions.com/blog/google-business-profile-optimization-checklist
+
+#GoogleBusinessProfile #LocalSEO #DFW
+
+----- POST 5 -----
+Most homepages are pretty brochures that convert nobody. A homepage that earns its keep is a system: one clear promise, proof and a path to book. I break down the exact anatomy that turns Dallas visitors into paying clients, section by section.
+
+https://hudsondigitalsolutions.com/blog/anatomy-of-a-high-converting-homepage
+
+#ConversionOptimization #WebDesign #DFW
+
+----- POST 6 -----
+Half the leads you lose are not lost, they are just waiting on a reply you never sent. Automated email and SMS follow-up catches them while they are still warm. Here are the systems and tools DFW businesses use to recover that revenue on autopilot.
+
+https://hudsondigitalsolutions.com/blog/automate-customer-follow-up-email-sms
+
+#Automation #CustomerFollowUp #DFW
+
+----- POST 7 -----
+Wix, Squarespace and GoDaddy quietly bill you every month forever and you never actually own the site. I show Dallas owners how to build a site you own outright that pays for itself in about 90 days. Run the math, then cancel the subscription.
+
+https://hudsondigitalsolutions.com/blog/escaping-monthly-platform-fees
+
+#WebsiteMigration #SmallBusiness #DFW
+
+----- POST 8 -----
+When a Dallas homeowner has no AC in July, they call whoever shows up fast and loads fast. If your HVAC site is slow or buries the phone number, that call goes to the next guy. Here is how I build HVAC sites that turn clicks into booked jobs.
+
+https://hudsondigitalsolutions.com/blog/hvac-company-websites-that-drive-calls
+
+#HVAC #LocalSEO #DFW
+
+----- POST 9 -----
+Agency, freelancer or do it yourself? The price tags are not the real story, the hidden costs and the ROI are. I lay out agency vs freelancer vs DIY with real DFW numbers and a free estimator so you can budget before you sign anything.
+
+https://hudsondigitalsolutions.com/blog/agency-vs-freelancer-vs-diy-website-cost
+
+#WebsiteCost #SmallBusiness #DFW
+
+----- POST 10 -----
+Paper timesheets and Friday spreadsheet math cost you payroll errors and a wasted weekend. Tracking employee hours should run itself. Here is how I set up automated time tracking for DFW small businesses so the numbers are right before payroll runs.
+
+https://hudsondigitalsolutions.com/blog/how-to-track-employee-hours
+
+#TimeTracking #SmallBusiness #DFW
+
+----- POST 11 -----
+Here is what happened when a Dallas tattoo studio stopped treating its site like a Facebook page and started treating it like a booking machine. Ink37 Tattoos: the real numbers, the automation we wired in and the ROI. No theory, just what moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-ink37-local-service-website
+
+#CaseStudy #LocalBusiness #DFW
+
+----- POST 12 -----
+A site that "works" still loses you money every day. It loads, it shows your hours and it does nothing else. Your website should be your hardest-working salesperson, booking calls while you sleep. Here is the difference between a site that exists and one that sells.
+
+https://hudsondigitalsolutions.com/blog/beyond-just-works-why-businesses-need-websites-that-dominate
+
+#WebDesign #SmallBusiness #DallasFortWorth
+
+----- POST 13 -----
+More than half your DFW customers find you on a phone, then bounce because your site was built for a desktop they will never use. Mobile-first is not a style choice, it is where the booked jobs come from. Here is how I build service sites that convert on a thumb.
+
+https://hudsondigitalsolutions.com/blog/mobile-first-web-design-for-service-businesses
+
+#MobileFirst #ServiceBusiness #DFW
+
+----- POST 14 -----
+"My website is doing great" usually means "I have no idea what my website is doing." Traffic is not the metric that pays you. Here are the numbers I actually track to tie a site back to booked revenue and the ones I ignore.
+
+https://hudsondigitalsolutions.com/blog/how-to-measure-website-performance
+
+#WebAnalytics #SmallBusiness #DFW
+
+----- POST 15 -----
+The DFW business with 200 reviews is not better than you. They just have a system for asking and you do not. Reviews are the cheapest local SEO you can buy and you can automate the entire ask. Here is the exact follow-up flow I set up.
+
+https://hudsondigitalsolutions.com/blog/how-to-get-more-google-reviews
+
+#GoogleReviews #LocalSEO #DFW
+
+----- POST 16 -----
+"Contact us" is where leads go to die. A vague button asks the visitor to do the work and they will not. Your call to action should tell them exactly what happens next and make it one tap. Here is what actually gets clicked on a service site.
+
+https://hudsondigitalsolutions.com/blog/call-to-action-best-practices
+
+#ConversionOptimization #ServiceBusiness #DFW
+
+----- POST 17 -----
+A lead that waits five minutes for a reply is mostly gone. While you are on a job, your competitor already called them back. I build follow-up systems that route, score and respond to every DFW lead the second it lands, with zero manual work from you.
+
+https://hudsondigitalsolutions.com/blog/automated-lead-follow-up-for-service-businesses
+
+#LeadGeneration #BusinessAutomation #DFW
+
+----- POST 18 -----
+Thryv has your website, your data and your Google rankings hostage and you are paying monthly for the privilege. You can leave without tanking your local search. Here is how I map the data out, rebuild the site and protect every ranking on the way.
+
+https://hudsondigitalsolutions.com/blog/how-to-leave-thryv-without-losing-rankings
+
+#LocalSEO #WebsiteMigration #DFW
+
+----- POST 19 -----
+One signed client can cover a year of your website. So why does your small-practice site read like a brochure and track nothing? I build law firm sites that capture every lead, follow up automatically and tell you which case came from where.
+
+https://hudsondigitalsolutions.com/blog/law-firm-websites-for-small-practices
+
+#LawFirmMarketing #LocalSEO #DallasFortWorth
+
+----- POST 20 -----
+That $16-a-month website builder is the most expensive thing in your business. The fee is the cheap part. The real bill is the leads it loses, the tracking it cannot do and the rebuild you will pay for later. Here is the math before it drains your margins.
+
+https://hudsondigitalsolutions.com/blog/hidden-costs-of-diy-website-builders
+
+#WebsiteBuilder #SmallBusiness #DFW
+
+----- POST 21 -----
+An invoice that sits in someone's inbox for 45 days is just a loan you never agreed to make. Here is how I structure invoices and automate the follow-ups so DFW owners cut days off their pay cycle and stop chasing checks.
+
+https://hudsondigitalsolutions.com/blog/how-to-write-an-invoice-that-gets-paid
+
+#CashFlow #SmallBusiness #DallasFortWorth
+
+----- POST 22 -----
+Most ecommerce builds are a pretty storefront bolted onto guesswork. Here is the full breakdown of the JirahShop build: the systems, the attribution and the automation we wired in so every sale traces back to what actually drove it.
+
+https://hudsondigitalsolutions.com/blog/case-study-jirahshop-ecommerce-build
+
+#Ecommerce #CaseStudy #DFW
+
+----- POST 23 -----
+Busy is not the same as profitable. If you and your team burn 20 hours a week on manual data entry and scheduling, that is half a salaried person doing work software handles for free. Here are the AI automations I set up first to win those hours back.
+
+https://hudsondigitalsolutions.com/blog/how-ai-automation-can-save-your-business-20-hours-per-week
+
+#AIautomation #SmallBusiness #DFW
+
+----- POST 24 -----
+A redesign is not about looks. It is about the leads your current site quietly loses every month. Here are the hard signs that tell you a rebuild will cost less than keeping the site you have, with real numbers from Dallas Fort Worth.
+
+https://hudsondigitalsolutions.com/blog/signs-you-need-a-website-redesign
+
+#WebsiteRedesign #SmallBusiness #DallasFortWorth
+
+----- POST 25 -----
+Every extra second your page takes to load shaves points off your conversion rate. That is not a vanity metric, it is revenue walking out the door. Here is how I tie load times straight to booked jobs and pipeline for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/how-website-speed-affects-your-revenue
+
+#WebPerformance #Revenue #DFW
+
+----- POST 26 -----
+Want to rank in Plano, Frisco and Arlington without spinning up 30 thin doorway pages Google will penalize? There is a right way to do it. Here is the local SEO structure I use to pull booked calls from every zip code you serve.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-multiple-cities
+
+#LocalSEO #SmallBusiness #DFW
+
+----- POST 27 -----
+People hit your site, glance once and leave. A high bounce rate is a money problem dressed up as an analytics number. Here are the measurable fixes I run to keep DFW visitors on the page long enough to actually book.
+
+https://hudsondigitalsolutions.com/blog/how-to-reduce-bounce-rate
+
+#ConversionOptimization #SmallBusiness #DFW
+
+----- POST 28 -----
+A lead buried in your inbox is a lead your competitor is already calling. I spent years building these systems in HubSpot and Salesforce. Here is the CRM automation that routes, scores and follows up on every Dallas lead so none of them go cold.
+
+https://hudsondigitalsolutions.com/blog/crm-automation-stop-losing-leads
+
+#CRMautomation #LeadGen #DallasFortWorth
+
+----- POST 29 -----
+Leaving Wix scares people because one bad redirect can tank rankings you spent years earning. It does not have to. Here is the step-by-step migration plan I follow to move you off Wix with zero lost traffic or revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-migrate-off-wix
+
+#WebsiteMigration #SEO #DFW
+
+----- POST 30 -----
+A med spa site full of glossy photos and an empty booking calendar is just an expensive billboard. I build med spa sites that turn visitors into booked procedures with real tracking and automation behind every appointment. Here is how DFW clinics fill the schedule.
+
+https://hudsondigitalsolutions.com/blog/med-spa-websites-that-fill-the-calendar
+
+#MedSpaMarketing #LocalSEO #DFW
+
+----- POST 31 -----
+Most DFW owners pick a website budget by guessing, then get surprised by the bill. Here is how I price design, SEO and automation as line items you can actually defend, so the spend ties back to booked revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-budget-for-a-website-project
+
+#WebsiteBudget #SmallBusiness #DFW
+
+----- POST 32 -----
+A late fee buried in your terms does nothing if nobody reads it. I show DFW operators how to structure invoice late fees that actually get paid and still keep the client. Cash flow first, awkward phone calls last.
+
+https://hudsondigitalsolutions.com/blog/invoice-late-fees-what-works
+
+#CashFlow #SmallBusiness #DallasFortWorth
+
+----- POST 33 -----
+TenantFlow had vendor workflows scattered across spreadsheets and inboxes. We rebuilt it as one SaaS app that turns those handoffs into automated revenue pipelines. Full breakdown of what we built and what it moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-tenantflow-saas-web-application
+
+#SaaS #WebDevelopment #DFW
+
+----- POST 34 -----
+Traffic is easy. Turning visitors into customers is the part most sites get wrong. Here is the 2025 playbook I use to lift conversion rates on DFW service sites, from the offer down to the form field.
+
+https://hudsondigitalsolutions.com/blog/how-to-increase-website-conversion-rates-2025-guide
+
+#ConversionRate #SmallBusiness #DFW
+
+----- POST 35 -----
+A pretty website that books nothing is just an expensive brochure. I treat small business design as a revenue system, built around DFW local SEO and follow-up automation. Here is what actually converts and what is just decoration.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-design-what-converts
+
+#WebDesign #SmallBusiness #DallasFortWorth
+
+----- POST 36 -----
+Largest Contentful Paint is the moment your page feels loaded to a real visitor. Drag it past 2.5 seconds and people leave before your form ever appears. Here is how I find it and the fixes I run first for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/largest-contentful-paint-how-to-find-and-fix-it
+
+#WebPerformance #CoreWebVitals #DFW
+
+----- POST 37 -----
+The three businesses in the Google map pack get the calls. Everyone below scrolls into the void. Here are the metrics and local SEO moves that put a Dallas business in those top three spots and keep it there.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-the-google-local-pack
+
+#LocalSEO #GoogleLocalPack #DFW
+
+----- POST 38 -----
+You are paying for clicks that land on a page built to inform, not to book. That gap is where your ad budget dies. Here is how landing page optimization turns DFW local traffic into actual appointments on the calendar.
+
+https://hudsondigitalsolutions.com/blog/landing-page-optimization-small-business
+
+#LandingPages #ConversionRate #DallasFortWorth
+
+----- POST 39 -----
+Every lead that hits your contact form and then sits in an inbox is money decaying in real time. Connect the website to your CRM and each one gets tracked, routed and worked automatically. Here is exactly how I wire it up.
+
+https://hudsondigitalsolutions.com/blog/how-to-connect-your-website-to-your-crm
+
+#CRM #Automation #DFW
+
+----- POST 40 -----
+One botched domain transfer can knock your site offline and tank your rankings for weeks. It does not have to. Here are the exact steps to move your domain with zero downtime and your attribution tracking fully intact.
+
+https://hudsondigitalsolutions.com/blog/how-to-transfer-your-domain-safely
+
+#DomainTransfer #WebsiteMigration #DallasFortWorth
+
+----- POST 41 -----
+When a pipe bursts, the homeowner calls the plumber who shows up first in search, not the one with the prettiest site. I build plumber sites in DFW wired for fast load, click-to-call and tracking so you know which jobs your website actually booked.
+
+https://hudsondigitalsolutions.com/blog/plumber-website-design-that-books-jobs
+
+#PlumberMarketing #LocalSEO #DFW
+
+----- POST 42 -----
+A custom website is only worth it if it pays for itself in booked work. So stop guessing and run the math. I built a free ROI calculator that shows you whether a custom build beats your current site in real dollars, not vibes.
+
+https://hudsondigitalsolutions.com/blog/is-a-custom-website-worth-the-investment
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 43 -----
+Most owners can quote their revenue but not their actual debt service. That gap is where cash flow surprises come from. Here is how I map mortgage math for DFW business owners so you can forecast the month before it punches you.
+
+https://hudsondigitalsolutions.com/blog/mortgage-math-for-small-business-owners
+
+#SmallBusinessFinance #CashFlow #DFW
+
+----- POST 44 -----
+Website builders feel cheap until you hit the wall: no real tracking, locked-in templates and a monthly bill that never ends. I spent years in revenue ops before building sites, so here is the honest custom versus builder breakdown in hard numbers for Dallas businesses.
+
+https://hudsondigitalsolutions.com/blog/custom-website-vs-website-builder
+
+#WebDevelopment #SmallBusiness #DFW
+
+----- POST 45 -----
+Someone told you your small business needs Kubernetes. For most DFW shops, that is paying for a fleet of trucks to deliver one pizza. Here is when container orchestration actually earns its keep and when it just burns your budget.
+
+https://hudsondigitalsolutions.com/blog/kubernetes-for-small-business-is-it-worth-it
+
+#WebDevelopment #SmallBusinessTech #DFW
+
+----- POST 46 -----
+Three web design mistakes quietly cost DFW businesses customers every day: slow load, buried phone numbers and a homepage that makes people guess what you do. I see them on nearly every site I audit. Here are the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/web-design-mistakes-that-cost-customers
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 47 -----
+Your customer is standing in a parking lot on 5G with two bars and your mobile site takes six seconds to load. They are already calling someone else. Mobile speed is a revenue lever for local DFW businesses and here is how I measure and fix it.
+
+https://hudsondigitalsolutions.com/blog/mobile-site-speed-and-your-local-customers
+
+#MobileSpeed #LocalSEO #DFW
+
+----- POST 48 -----
+Ranking for "plumber" is a vanity metric. Ranking for "emergency water heater repair Fort Worth" books jobs. Here is the local keyword research workflow I use to map what DFW customers actually type, then tie those searches to booked calls.
+
+https://hudsondigitalsolutions.com/blog/local-keyword-research-for-service-businesses
+
+#KeywordResearch #LocalSEO #DFW
+
+----- POST 49 -----
+Every extra field on your contact form quietly kills conversions. Most DFW sites ask for ten things when they need three. Here is how I build lead capture forms that fill out fast, route straight to your CRM and turn traffic into booked work.
+
+https://hudsondigitalsolutions.com/blog/lead-capture-forms-that-convert
+
+#LeadGeneration #ConversionOptimization #DFW
+
+----- POST 50 -----
+A no-show is a paid-for slot that earns you nothing. For most DFW service businesses, automated reminders alone recover a chunk of that lost revenue every week. Here is the online booking setup that confirms, reminds and fills the gaps without you lifting a finger.
+
+https://hudsondigitalsolutions.com/blog/online-booking-that-cuts-no-shows
+
+#OnlineBooking #BusinessAutomation #DFW
+
+----- POST 51 -----
+Squarespace looks fine until your booking flow stalls and you cannot tell which leads came from where. When the template starts costing you jobs, it is time to move. Here is when to switch to a custom site and how I migrate it without losing a single contact.
+
+https://hudsondigitalsolutions.com/blog/squarespace-to-a-custom-site
+
+#WebsiteMigration #Squarespace #DFW
+
+----- POST 52 -----
+A photo of your menu does not feed anyone. Your restaurant site should take orders and lock in reservations while you are slammed on the line. Here is how I turn a DFW restaurant page into a system that actually drives covers and online orders.
+
+https://hudsondigitalsolutions.com/blog/restaurant-websites-that-drive-orders
+
+#RestaurantMarketing #LocalSEO #DallasFortWorth
+
+----- POST 53 -----
+Nobody tells you what a website actually costs after launch, then the surprise invoices land. I pulled real maintenance numbers from DFW operators so you know what to budget, what to automate and what is just a vendor padding the bill.
+
+https://hudsondigitalsolutions.com/blog/website-maintenance-costs-explained
+
+#SmallBusiness #WebsiteCosts #DFW
+
+----- POST 54 -----
+One wrong line on a paystub can turn into a compliance headache and a payroll mess. If you have employees in Texas, you need to get this right the first time. Here are the basics every small employer should know, plus a free calculator to skip the manual math.
+
+https://hudsondigitalsolutions.com/blog/paystub-basics-for-small-employers
+
+#Payroll #SmallBusiness #DFW
+
+----- POST 55 -----
+Fast sites are not luck, they are a build decision you make on day one. I am pulling back the curtain on the exact stack I use to ship DFW sites that load instantly and turn visitors into booked appointments. Speed is a revenue lever, so here is how I pull it.
+
+https://hudsondigitalsolutions.com/blog/how-we-build-fast-websites-the-stack
+
+#WebDevelopment #WebPerformance #DFW
+
+----- POST 56 -----
+Quotes for a small business website swing from 500 dollars to 50,000 and most owners have no idea why. I broke down what actually drives the price in 2025 so you can read any proposal and know exactly what you are paying for before you sign.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-cost-2025
+
+#SmallBusiness #WebsiteCosts #DallasFortWorth
+
+----- POST 57 -----
+A confusing menu is a quiet revenue leak. Every extra click between a visitor and your booking page costs you jobs. Here are the navigation rules I use to turn clicks into booked calls instead of dead ends.
+
+https://hudsondigitalsolutions.com/blog/website-navigation-best-practices-small-business
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 58 -----
+A local customer needs a plumber now, not in four seconds while your site loads. Slow pages send them straight to the next result. Here is how I measure, fix and automate page speed for DFW service sites so you stop losing those calls.
+
+https://hudsondigitalsolutions.com/blog/page-speed-optimization-for-local-service-sites
+
+#WebPerformance #LocalSEO #DFW
+
+----- POST 59 -----
+Local SEO is not a billboard you set and forget. It is a pipeline that runs from search demand straight to a closed deal. I map exactly how DFW searches turn into booked revenue using automation and strict attribution, no guesswork on what is working.
+
+https://hudsondigitalsolutions.com/blog/local-seo-for-small-business-guide
+
+#LocalSEO #SmallBusiness #DallasFortWorth
+
+----- POST 60 -----
+A stranger landed on your site and has about three seconds to decide if you are legit. The right proof points close that gap and turn a browser into a booked call. Here are the trust signals that actually convert DFW visitors, backed by automated follow up.
+
+https://hudsondigitalsolutions.com/blog/trust-signals-that-convert-visitors
+
+#ConversionOptimization #SmallBusiness #DFW
+
+----- POST 61 -----
+Most DFW shops bolt Stripe on, take the payment and never see where the revenue came from. Set it up right and your checkout doubles as a forecasting tool. Here is the exact Stripe setup I run so every dollar is tracked back to the source.
+
+https://hudsondigitalsolutions.com/blog/stripe-payment-setup-small-business
+
+#Stripe #SmallBusiness #DFW
+
+----- POST 62 -----
+Moving platforms is where most businesses quietly lose their rankings and half their traffic. I have migrated sites with zero downtime and no drop in search. Here is the checklist I follow line by line so your SEO and revenue tracking survive the move.
+
+https://hudsondigitalsolutions.com/blog/website-migration-checklist
+
+#WebsiteMigration #LocalSEO #DallasFortWorth
+
+----- POST 63 -----
+Roofers in DFW are paying real money for clicks that never turn into quote requests. Traffic is not the problem, your site is. Here is how I build roofing sites with HubSpot automation and local SEO that cut cost per lead and book more jobs.
+
+https://hudsondigitalsolutions.com/blog/roofing-company-websites-that-convert
+
+#RoofingMarketing #LocalSEO #DFW
+
+----- POST 64 -----
+Two website quotes can be 5,000 dollars apart and both look reasonable until you read the line items. Most owners sign before they know what they are paying for. I break down every part of a website quote so you can spot the hidden costs before you commit.
+
+https://hudsondigitalsolutions.com/blog/what-goes-into-a-website-quote
+
+#WebDesign #SmallBusiness #DallasFortWorth
+
+----- POST 65 -----
+If you mark up a job 30 percent, your margin is not 30 percent and that gap is eating your profit on every invoice. Margin and markup are not the same number. Here is the difference in plain terms plus a pricing setup that protects your bottom line.
+
+https://hudsondigitalsolutions.com/blog/profit-margin-vs-markup
+
+#PricingStrategy #SmallBusiness #DFW
+
+----- POST 66 -----
+Still copying a spreadsheet column one cell at a time to build a list? Stop. Paste the column, get a clean comma separated list in seconds. Free tool, no signup and a quick read on where this saves you real time in your workflows.
+
+https://hudsondigitalsolutions.com/blog/spreadsheet-column-to-comma-list
+
+#Productivity #SmallBusiness #DFW
+
+----- POST 67 -----
+A responsive layout that shrinks to fit a phone is the bare minimum now, not the finish line. Thumb-friendly nav, touch-ready forms, instant load. Here is the full guide to building a business website in 2025 that actually books work, start to finish.
+
+https://hudsondigitalsolutions.com/blog/the-complete-guide-to-building-a-modern-business-website-in-2025
+
+#WebDesign #SmallBusiness #DallasFortWorth
+
+----- POST 68 -----
+A slow site does not just annoy people, it has a dollar figure attached and for most local businesses it is bigger than they think. Every extra second costs you booked jobs. Here is how to put a real number on it and the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/real-cost-of-a-slow-website-for-local-business
+
+#WebPerformance #LocalBusiness #DFW
+
+----- POST 69 -----
+Google cannot rank what it cannot read. LocalBusiness schema feeds it your hours, location and services in the format it actually wants and that is often the difference between showing in the map pack or not. Here is how to set it up.
+
+https://hudsondigitalsolutions.com/blog/localbusiness-schema-help-google-find-you
+
+#LocalSEO #SchemaMarkup #DallasFortWorth
+
+----- POST 70 -----
+Plenty of visitors, almost no leads. That is not a traffic problem, it is a leak between the click and the contact form. I break down the exact attribution gaps and automation fixes that turn the traffic you already have into booked revenue.
+
+https://hudsondigitalsolutions.com/blog/website-traffic-but-no-leads
+
+#ConversionOptimization #SmallBusiness #DFW
+
+----- POST 71 -----
+You are paying a person to copy a lead from your inbox into a CRM. That is a $40 task a script does for free, every time, in two seconds. Here are the workflow automation tools I set up for DFW shops to capture leads, route them and close faster.
+
+https://hudsondigitalsolutions.com/blog/workflow-automation-tools-small-business
+
+#WorkflowAutomation #SmallBusiness #DFW
+
+----- POST 72 -----
+Quick question most owners get wrong: if your developer walked away tomorrow, could you still log into your own domain? A lot of DFW businesses do not actually own the thing their whole revenue runs on. Here is how to check in five minutes and take it back.
+
+https://hudsondigitalsolutions.com/blog/who-owns-your-website-and-domain
+
+#DomainOwnership #SmallBusiness #DFW
+
+----- POST 73 -----
+Your portfolio is your strongest sales pitch and it is buried on Instagram where nobody can book you. A tattoo studio site should show the work, take the deposit and rank when someone in DFW searches for an artist. Here is how I build all three into one system.
+
+https://hudsondigitalsolutions.com/blog/tattoo-studio-websites-booking-gallery-seo
+
+#TattooStudio #LocalSEO #DallasFortWorth
+
+----- POST 74 -----
+The $500 website is the most expensive one you can buy. Broken tracking, slow load times and a year of lost leads add up to far more than a real build ever would. Here is the actual math on what cheap costs a DFW business.
+
+https://hudsondigitalsolutions.com/blog/why-cheap-websites-cost-more
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 75 -----
+The handshake deal works right up until a client ghosts you on a $6,000 invoice. A few plain contracts protect your revenue and put onboarding on autopilot. Here are the ones every DFW small business actually needs, plus free tools to draft them fast.
+
+https://hudsondigitalsolutions.com/blog/service-contracts-every-small-business-needs
+
+#ServiceContracts #SmallBusiness #DFW
+
+----- POST 76 -----
+Two competitors offer the same service. One shows up in Google with star ratings, prices and hours right in the result. The other is a plain blue link. The difference is schema markup. Here is the practical guide to adding it and what it does for DFW bookings.
+
+https://hudsondigitalsolutions.com/blog/structured-data-and-schema-guide
+
+#StructuredData #LocalSEO #DFW
+
+----- POST 77 -----
+Your CRM only works if every tool actually talks to it. When it sits in a silo, someone is retyping data by hand and quietly losing leads. After a decade wiring up Salesforce and HubSpot, here is why a custom integration beats the off-the-shelf connector for DFW operators.
+
+https://hudsondigitalsolutions.com/blog/why-your-business-needs-a-custom-crm-integration
+
+#CRMIntegration #BusinessAutomation #DFW
+
+----- POST 78 -----
+Most DFW owners have no idea their site is leaking bookings because nobody ever audited it. Run this checklist and you will see exactly where speed, tracking and load times are costing you jobs. No fluff, just the line items I check first.
+
+https://hudsondigitalsolutions.com/blog/website-performance-audit-checklist-small-business
+
+#WebPerformance #SmallBusiness #DFW
+
+----- POST 79 -----
+Your address says Suite 200 on Google, Ste. 200 on Yelp and nothing on Facebook. To Google that looks like three different businesses and your map ranking pays for it. Here is how NAP consistency makes or breaks local SEO for DFW shops.
+
+https://hudsondigitalsolutions.com/blog/nap-consistency-local-seo
+
+#LocalSEO #NAPConsistency #DallasFortWorth
+
+----- POST 80 -----
+That $30,000 truck is not a $30,000 truck once Texas tax, title and license hit. If you run a fleet in DFW, those fees wreck your cash flow forecast when you guess at them. Here is the real breakdown, plus a free calculator to plan the next purchase.
+
+https://hudsondigitalsolutions.com/blog/texas-tax-title-license-vehicle-costs
+
+#SmallBusiness #FleetCosts #DFW
+
+----- POST 81 -----
+An API response breaks at 2am and you are staring at one giant unbroken line of text trying to find the bug. Clean JSON is the difference between a five minute fix and a wasted afternoon. Here is when formatting it actually matters for your integrations and a free tool that does it.
+
+https://hudsondigitalsolutions.com/blog/when-and-why-to-format-json
+
+#WebDevelopment #Automation #DFW
+
+----- POST 82 -----
+Most website projects do not fail because of bad code. They fail because nobody decided what the site was supposed to do before the build started. Here is the five-step blueprint I run before writing a line, so the site actually pays for itself.
+
+https://hudsondigitalsolutions.com/blog/your-website-needs-a-blueprint-how-to-plan-a-project-that-pays-off
+
+#WebDesign #SmallBusiness #DFW
+
+----- POST 83 -----
+Your site feels slow and you have no idea why. It is usually a handful of the same culprits: huge images, bloated plugins, cheap hosting. I break down what is actually dragging your DFW site down, the leads it is quietly costing you and exactly what to measure to fix it.
+
+https://hudsondigitalsolutions.com/blog/why-your-small-business-has-a-slow-website
+
+#WebsiteSpeed #SmallBusiness #DFW
+
+----- POST 84 -----
+You search your own business and it is nowhere on the map. Customers cannot find what Google will not show. I walk through the real reasons your Google Business Profile disappears, from suspensions to NAP mismatches and how to get it ranking again.
+
+https://hudsondigitalsolutions.com/blog/why-google-business-profile-not-showing-up
+
+#LocalSEO #GoogleBusinessProfile #DallasFortWorth
+
+----- POST 85 -----
+Splitting a check four ways at the table while the line backs up is dead time you are not getting paid for. Faster math means faster turnover. Here is how to handle tips and split bills in seconds, plus a free calculator you can use right now.
+
+https://hudsondigitalsolutions.com/blog/tip-calculation-and-bill-splitting
+
+#SmallBusiness #Productivity #DFW
+
+----- POST 86 -----
+WordPress runs a third of the web and a good chunk of it loads like dial-up. I stopped building on it for a reason. Here is the honest comparison of Next.js vs WordPress: speed, tracking and what each one actually costs a DFW business over three years.
+
+https://hudsondigitalsolutions.com/blog/why-we-build-on-nextjs-not-wordpress
+
+#WebDevelopment #NextJS #DallasFortWorth
+
+----- POST 87 -----
+A meta description that runs too long gets cut off in Google. An ad headline over the limit gets rejected. Word and character counts are not busywork, they decide whether your copy even shows up. Here are the counts that matter and a free tool to hit them.
+
+https://hudsondigitalsolutions.com/blog/word-and-character-counts-that-matter
+
+#ContentMarketing #SEO #DFW
+

--- a/.planning/social/facebook-schedule.csv
+++ b/.planning/social/facebook-schedule.csv
@@ -1,0 +1,436 @@
+order,date,weekday,time_ct,slug,url,caption
+"1","2026-06-20","Sat","7:00 PM","5-signs-your-website-is-costing-you-customers","https://hudsondigitalsolutions.com/blog/5-signs-your-website-is-costing-you-customers","Your website might be quietly losing you jobs every week and you would never know it. Slow loads, dead phone numbers on mobile, no clear next step. Here are 5 signs your site is bleeding customers and what I fix first.
+
+https://hudsondigitalsolutions.com/blog/5-signs-your-website-is-costing-you-customers
+
+#WebDesign #SmallBusiness #DFW"
+"2","2026-06-21","Sun","7:00 AM","how-many-pages-does-a-small-business-website-need","https://hudsondigitalsolutions.com/blog/how-many-pages-does-a-small-business-website-need","Stop guessing how many pages your site needs. A 40-page site does not book more calls than a tight 5-page one that is built to convert. I treat every page as a revenue job and track each click. Here is the page count that actually books work.
+
+https://hudsondigitalsolutions.com/blog/how-many-pages-does-a-small-business-website-need
+
+#SmallBusinessWebsite #WebDesign #DFW"
+"3","2026-06-21","Sun","1:00 PM","core-web-vitals-explained-for-small-business","https://hudsondigitalsolutions.com/blog/core-web-vitals-explained-for-small-business","Google grades your site on load speed, how fast it responds to taps and whether it jumps around while loading. Fail those and you slide down the results. Here is what Core Web Vitals actually mean for a DFW owner and how to fix them without torching your budget.
+
+https://hudsondigitalsolutions.com/blog/core-web-vitals-explained-for-small-business
+
+#CoreWebVitals #WebPerformance #DallasFortWorth"
+"4","2026-06-21","Sun","7:00 PM","google-business-profile-optimization-checklist","https://hudsondigitalsolutions.com/blog/google-business-profile-optimization-checklist","Your Google Business Profile is the first thing a DFW customer sees and most are half filled out. A complete, optimized listing pulls calls straight off the map pack. Here is the exact checklist I run to turn that free listing into a booking machine.
+
+https://hudsondigitalsolutions.com/blog/google-business-profile-optimization-checklist
+
+#GoogleBusinessProfile #LocalSEO #DFW"
+"5","2026-06-22","Mon","7:00 AM","anatomy-of-a-high-converting-homepage","https://hudsondigitalsolutions.com/blog/anatomy-of-a-high-converting-homepage","Most homepages are pretty brochures that convert nobody. A homepage that earns its keep is a system: one clear promise, proof and a path to book. I break down the exact anatomy that turns Dallas visitors into paying clients, section by section.
+
+https://hudsondigitalsolutions.com/blog/anatomy-of-a-high-converting-homepage
+
+#ConversionOptimization #WebDesign #DFW"
+"6","2026-06-22","Mon","1:00 PM","automate-customer-follow-up-email-sms","https://hudsondigitalsolutions.com/blog/automate-customer-follow-up-email-sms","Half the leads you lose are not lost, they are just waiting on a reply you never sent. Automated email and SMS follow-up catches them while they are still warm. Here are the systems and tools DFW businesses use to recover that revenue on autopilot.
+
+https://hudsondigitalsolutions.com/blog/automate-customer-follow-up-email-sms
+
+#Automation #CustomerFollowUp #DFW"
+"7","2026-06-22","Mon","7:00 PM","escaping-monthly-platform-fees","https://hudsondigitalsolutions.com/blog/escaping-monthly-platform-fees","Wix, Squarespace and GoDaddy quietly bill you every month forever and you never actually own the site. I show Dallas owners how to build a site you own outright that pays for itself in about 90 days. Run the math, then cancel the subscription.
+
+https://hudsondigitalsolutions.com/blog/escaping-monthly-platform-fees
+
+#WebsiteMigration #SmallBusiness #DFW"
+"8","2026-06-23","Tue","7:00 AM","hvac-company-websites-that-drive-calls","https://hudsondigitalsolutions.com/blog/hvac-company-websites-that-drive-calls","When a Dallas homeowner has no AC in July, they call whoever shows up fast and loads fast. If your HVAC site is slow or buries the phone number, that call goes to the next guy. Here is how I build HVAC sites that turn clicks into booked jobs.
+
+https://hudsondigitalsolutions.com/blog/hvac-company-websites-that-drive-calls
+
+#HVAC #LocalSEO #DFW"
+"9","2026-06-23","Tue","1:00 PM","agency-vs-freelancer-vs-diy-website-cost","https://hudsondigitalsolutions.com/blog/agency-vs-freelancer-vs-diy-website-cost","Agency, freelancer or do it yourself? The price tags are not the real story, the hidden costs and the ROI are. I lay out agency vs freelancer vs DIY with real DFW numbers and a free estimator so you can budget before you sign anything.
+
+https://hudsondigitalsolutions.com/blog/agency-vs-freelancer-vs-diy-website-cost
+
+#WebsiteCost #SmallBusiness #DFW"
+"10","2026-06-23","Tue","7:00 PM","how-to-track-employee-hours","https://hudsondigitalsolutions.com/blog/how-to-track-employee-hours","Paper timesheets and Friday spreadsheet math cost you payroll errors and a wasted weekend. Tracking employee hours should run itself. Here is how I set up automated time tracking for DFW small businesses so the numbers are right before payroll runs.
+
+https://hudsondigitalsolutions.com/blog/how-to-track-employee-hours
+
+#TimeTracking #SmallBusiness #DFW"
+"11","2026-06-24","Wed","7:00 AM","case-study-ink37-local-service-website","https://hudsondigitalsolutions.com/blog/case-study-ink37-local-service-website","Here is what happened when a Dallas tattoo studio stopped treating its site like a Facebook page and started treating it like a booking machine. Ink37 Tattoos: the real numbers, the automation we wired in and the ROI. No theory, just what moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-ink37-local-service-website
+
+#CaseStudy #LocalBusiness #DFW"
+"12","2026-06-24","Wed","1:00 PM","beyond-just-works-why-businesses-need-websites-that-dominate","https://hudsondigitalsolutions.com/blog/beyond-just-works-why-businesses-need-websites-that-dominate","A site that ""works"" still loses you money every day. It loads, it shows your hours and it does nothing else. Your website should be your hardest-working salesperson, booking calls while you sleep. Here is the difference between a site that exists and one that sells.
+
+https://hudsondigitalsolutions.com/blog/beyond-just-works-why-businesses-need-websites-that-dominate
+
+#WebDesign #SmallBusiness #DallasFortWorth"
+"13","2026-06-24","Wed","7:00 PM","mobile-first-web-design-for-service-businesses","https://hudsondigitalsolutions.com/blog/mobile-first-web-design-for-service-businesses","More than half your DFW customers find you on a phone, then bounce because your site was built for a desktop they will never use. Mobile-first is not a style choice, it is where the booked jobs come from. Here is how I build service sites that convert on a thumb.
+
+https://hudsondigitalsolutions.com/blog/mobile-first-web-design-for-service-businesses
+
+#MobileFirst #ServiceBusiness #DFW"
+"14","2026-06-25","Thu","7:00 AM","how-to-measure-website-performance","https://hudsondigitalsolutions.com/blog/how-to-measure-website-performance","""My website is doing great"" usually means ""I have no idea what my website is doing."" Traffic is not the metric that pays you. Here are the numbers I actually track to tie a site back to booked revenue and the ones I ignore.
+
+https://hudsondigitalsolutions.com/blog/how-to-measure-website-performance
+
+#WebAnalytics #SmallBusiness #DFW"
+"15","2026-06-25","Thu","1:00 PM","how-to-get-more-google-reviews","https://hudsondigitalsolutions.com/blog/how-to-get-more-google-reviews","The DFW business with 200 reviews is not better than you. They just have a system for asking and you do not. Reviews are the cheapest local SEO you can buy and you can automate the entire ask. Here is the exact follow-up flow I set up.
+
+https://hudsondigitalsolutions.com/blog/how-to-get-more-google-reviews
+
+#GoogleReviews #LocalSEO #DFW"
+"16","2026-06-25","Thu","7:00 PM","call-to-action-best-practices","https://hudsondigitalsolutions.com/blog/call-to-action-best-practices","""Contact us"" is where leads go to die. A vague button asks the visitor to do the work and they will not. Your call to action should tell them exactly what happens next and make it one tap. Here is what actually gets clicked on a service site.
+
+https://hudsondigitalsolutions.com/blog/call-to-action-best-practices
+
+#ConversionOptimization #ServiceBusiness #DFW"
+"17","2026-06-26","Fri","7:00 AM","automated-lead-follow-up-for-service-businesses","https://hudsondigitalsolutions.com/blog/automated-lead-follow-up-for-service-businesses","A lead that waits five minutes for a reply is mostly gone. While you are on a job, your competitor already called them back. I build follow-up systems that route, score and respond to every DFW lead the second it lands, with zero manual work from you.
+
+https://hudsondigitalsolutions.com/blog/automated-lead-follow-up-for-service-businesses
+
+#LeadGeneration #BusinessAutomation #DFW"
+"18","2026-06-26","Fri","1:00 PM","how-to-leave-thryv-without-losing-rankings","https://hudsondigitalsolutions.com/blog/how-to-leave-thryv-without-losing-rankings","Thryv has your website, your data and your Google rankings hostage and you are paying monthly for the privilege. You can leave without tanking your local search. Here is how I map the data out, rebuild the site and protect every ranking on the way.
+
+https://hudsondigitalsolutions.com/blog/how-to-leave-thryv-without-losing-rankings
+
+#LocalSEO #WebsiteMigration #DFW"
+"19","2026-06-26","Fri","7:00 PM","law-firm-websites-for-small-practices","https://hudsondigitalsolutions.com/blog/law-firm-websites-for-small-practices","One signed client can cover a year of your website. So why does your small-practice site read like a brochure and track nothing? I build law firm sites that capture every lead, follow up automatically and tell you which case came from where.
+
+https://hudsondigitalsolutions.com/blog/law-firm-websites-for-small-practices
+
+#LawFirmMarketing #LocalSEO #DallasFortWorth"
+"20","2026-06-27","Sat","7:00 AM","hidden-costs-of-diy-website-builders","https://hudsondigitalsolutions.com/blog/hidden-costs-of-diy-website-builders","That $16-a-month website builder is the most expensive thing in your business. The fee is the cheap part. The real bill is the leads it loses, the tracking it cannot do and the rebuild you will pay for later. Here is the math before it drains your margins.
+
+https://hudsondigitalsolutions.com/blog/hidden-costs-of-diy-website-builders
+
+#WebsiteBuilder #SmallBusiness #DFW"
+"21","2026-06-27","Sat","1:00 PM","how-to-write-an-invoice-that-gets-paid","https://hudsondigitalsolutions.com/blog/how-to-write-an-invoice-that-gets-paid","An invoice that sits in someone's inbox for 45 days is just a loan you never agreed to make. Here is how I structure invoices and automate the follow-ups so DFW owners cut days off their pay cycle and stop chasing checks.
+
+https://hudsondigitalsolutions.com/blog/how-to-write-an-invoice-that-gets-paid
+
+#CashFlow #SmallBusiness #DallasFortWorth"
+"22","2026-06-27","Sat","7:00 PM","case-study-jirahshop-ecommerce-build","https://hudsondigitalsolutions.com/blog/case-study-jirahshop-ecommerce-build","Most ecommerce builds are a pretty storefront bolted onto guesswork. Here is the full breakdown of the JirahShop build: the systems, the attribution and the automation we wired in so every sale traces back to what actually drove it.
+
+https://hudsondigitalsolutions.com/blog/case-study-jirahshop-ecommerce-build
+
+#Ecommerce #CaseStudy #DFW"
+"23","2026-06-28","Sun","7:00 AM","how-ai-automation-can-save-your-business-20-hours-per-week","https://hudsondigitalsolutions.com/blog/how-ai-automation-can-save-your-business-20-hours-per-week","Busy is not the same as profitable. If you and your team burn 20 hours a week on manual data entry and scheduling, that is half a salaried person doing work software handles for free. Here are the AI automations I set up first to win those hours back.
+
+https://hudsondigitalsolutions.com/blog/how-ai-automation-can-save-your-business-20-hours-per-week
+
+#AIautomation #SmallBusiness #DFW"
+"24","2026-06-28","Sun","1:00 PM","signs-you-need-a-website-redesign","https://hudsondigitalsolutions.com/blog/signs-you-need-a-website-redesign","A redesign is not about looks. It is about the leads your current site quietly loses every month. Here are the hard signs that tell you a rebuild will cost less than keeping the site you have, with real numbers from Dallas Fort Worth.
+
+https://hudsondigitalsolutions.com/blog/signs-you-need-a-website-redesign
+
+#WebsiteRedesign #SmallBusiness #DallasFortWorth"
+"25","2026-06-28","Sun","7:00 PM","how-website-speed-affects-your-revenue","https://hudsondigitalsolutions.com/blog/how-website-speed-affects-your-revenue","Every extra second your page takes to load shaves points off your conversion rate. That is not a vanity metric, it is revenue walking out the door. Here is how I tie load times straight to booked jobs and pipeline for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/how-website-speed-affects-your-revenue
+
+#WebPerformance #Revenue #DFW"
+"26","2026-06-29","Mon","7:00 AM","how-to-rank-in-multiple-cities","https://hudsondigitalsolutions.com/blog/how-to-rank-in-multiple-cities","Want to rank in Plano, Frisco and Arlington without spinning up 30 thin doorway pages Google will penalize? There is a right way to do it. Here is the local SEO structure I use to pull booked calls from every zip code you serve.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-multiple-cities
+
+#LocalSEO #SmallBusiness #DFW"
+"27","2026-06-29","Mon","1:00 PM","how-to-reduce-bounce-rate","https://hudsondigitalsolutions.com/blog/how-to-reduce-bounce-rate","People hit your site, glance once and leave. A high bounce rate is a money problem dressed up as an analytics number. Here are the measurable fixes I run to keep DFW visitors on the page long enough to actually book.
+
+https://hudsondigitalsolutions.com/blog/how-to-reduce-bounce-rate
+
+#ConversionOptimization #SmallBusiness #DFW"
+"28","2026-06-29","Mon","7:00 PM","crm-automation-stop-losing-leads","https://hudsondigitalsolutions.com/blog/crm-automation-stop-losing-leads","A lead buried in your inbox is a lead your competitor is already calling. I spent years building these systems in HubSpot and Salesforce. Here is the CRM automation that routes, scores and follows up on every Dallas lead so none of them go cold.
+
+https://hudsondigitalsolutions.com/blog/crm-automation-stop-losing-leads
+
+#CRMautomation #LeadGen #DallasFortWorth"
+"29","2026-06-30","Tue","7:00 AM","how-to-migrate-off-wix","https://hudsondigitalsolutions.com/blog/how-to-migrate-off-wix","Leaving Wix scares people because one bad redirect can tank rankings you spent years earning. It does not have to. Here is the step-by-step migration plan I follow to move you off Wix with zero lost traffic or revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-migrate-off-wix
+
+#WebsiteMigration #SEO #DFW"
+"30","2026-06-30","Tue","1:00 PM","med-spa-websites-that-fill-the-calendar","https://hudsondigitalsolutions.com/blog/med-spa-websites-that-fill-the-calendar","A med spa site full of glossy photos and an empty booking calendar is just an expensive billboard. I build med spa sites that turn visitors into booked procedures with real tracking and automation behind every appointment. Here is how DFW clinics fill the schedule.
+
+https://hudsondigitalsolutions.com/blog/med-spa-websites-that-fill-the-calendar
+
+#MedSpaMarketing #LocalSEO #DFW"
+"31","2026-06-30","Tue","7:00 PM","how-to-budget-for-a-website-project","https://hudsondigitalsolutions.com/blog/how-to-budget-for-a-website-project","Most DFW owners pick a website budget by guessing, then get surprised by the bill. Here is how I price design, SEO and automation as line items you can actually defend, so the spend ties back to booked revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-budget-for-a-website-project
+
+#WebsiteBudget #SmallBusiness #DFW"
+"32","2026-07-01","Wed","7:00 AM","invoice-late-fees-what-works","https://hudsondigitalsolutions.com/blog/invoice-late-fees-what-works","A late fee buried in your terms does nothing if nobody reads it. I show DFW operators how to structure invoice late fees that actually get paid and still keep the client. Cash flow first, awkward phone calls last.
+
+https://hudsondigitalsolutions.com/blog/invoice-late-fees-what-works
+
+#CashFlow #SmallBusiness #DallasFortWorth"
+"33","2026-07-01","Wed","1:00 PM","case-study-tenantflow-saas-web-application","https://hudsondigitalsolutions.com/blog/case-study-tenantflow-saas-web-application","TenantFlow had vendor workflows scattered across spreadsheets and inboxes. We rebuilt it as one SaaS app that turns those handoffs into automated revenue pipelines. Full breakdown of what we built and what it moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-tenantflow-saas-web-application
+
+#SaaS #WebDevelopment #DFW"
+"34","2026-07-01","Wed","7:00 PM","how-to-increase-website-conversion-rates-2025-guide","https://hudsondigitalsolutions.com/blog/how-to-increase-website-conversion-rates-2025-guide","Traffic is easy. Turning visitors into customers is the part most sites get wrong. Here is the 2025 playbook I use to lift conversion rates on DFW service sites, from the offer down to the form field.
+
+https://hudsondigitalsolutions.com/blog/how-to-increase-website-conversion-rates-2025-guide
+
+#ConversionRate #SmallBusiness #DFW"
+"35","2026-07-02","Thu","7:00 AM","small-business-website-design-what-converts","https://hudsondigitalsolutions.com/blog/small-business-website-design-what-converts","A pretty website that books nothing is just an expensive brochure. I treat small business design as a revenue system, built around DFW local SEO and follow-up automation. Here is what actually converts and what is just decoration.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-design-what-converts
+
+#WebDesign #SmallBusiness #DallasFortWorth"
+"36","2026-07-02","Thu","1:00 PM","largest-contentful-paint-how-to-find-and-fix-it","https://hudsondigitalsolutions.com/blog/largest-contentful-paint-how-to-find-and-fix-it","Largest Contentful Paint is the moment your page feels loaded to a real visitor. Drag it past 2.5 seconds and people leave before your form ever appears. Here is how I find it and the fixes I run first for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/largest-contentful-paint-how-to-find-and-fix-it
+
+#WebPerformance #CoreWebVitals #DFW"
+"37","2026-07-02","Thu","7:00 PM","how-to-rank-in-the-google-local-pack","https://hudsondigitalsolutions.com/blog/how-to-rank-in-the-google-local-pack","The three businesses in the Google map pack get the calls. Everyone below scrolls into the void. Here are the metrics and local SEO moves that put a Dallas business in those top three spots and keep it there.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-the-google-local-pack
+
+#LocalSEO #GoogleLocalPack #DFW"
+"38","2026-07-03","Fri","7:00 AM","landing-page-optimization-small-business","https://hudsondigitalsolutions.com/blog/landing-page-optimization-small-business","You are paying for clicks that land on a page built to inform, not to book. That gap is where your ad budget dies. Here is how landing page optimization turns DFW local traffic into actual appointments on the calendar.
+
+https://hudsondigitalsolutions.com/blog/landing-page-optimization-small-business
+
+#LandingPages #ConversionRate #DallasFortWorth"
+"39","2026-07-03","Fri","1:00 PM","how-to-connect-your-website-to-your-crm","https://hudsondigitalsolutions.com/blog/how-to-connect-your-website-to-your-crm","Every lead that hits your contact form and then sits in an inbox is money decaying in real time. Connect the website to your CRM and each one gets tracked, routed and worked automatically. Here is exactly how I wire it up.
+
+https://hudsondigitalsolutions.com/blog/how-to-connect-your-website-to-your-crm
+
+#CRM #Automation #DFW"
+"40","2026-07-03","Fri","7:00 PM","how-to-transfer-your-domain-safely","https://hudsondigitalsolutions.com/blog/how-to-transfer-your-domain-safely","One botched domain transfer can knock your site offline and tank your rankings for weeks. It does not have to. Here are the exact steps to move your domain with zero downtime and your attribution tracking fully intact.
+
+https://hudsondigitalsolutions.com/blog/how-to-transfer-your-domain-safely
+
+#DomainTransfer #WebsiteMigration #DallasFortWorth"
+"41","2026-07-04","Sat","7:00 AM","plumber-website-design-that-books-jobs","https://hudsondigitalsolutions.com/blog/plumber-website-design-that-books-jobs","When a pipe bursts, the homeowner calls the plumber who shows up first in search, not the one with the prettiest site. I build plumber sites in DFW wired for fast load, click-to-call and tracking so you know which jobs your website actually booked.
+
+https://hudsondigitalsolutions.com/blog/plumber-website-design-that-books-jobs
+
+#PlumberMarketing #LocalSEO #DFW"
+"42","2026-07-04","Sat","1:00 PM","is-a-custom-website-worth-the-investment","https://hudsondigitalsolutions.com/blog/is-a-custom-website-worth-the-investment","A custom website is only worth it if it pays for itself in booked work. So stop guessing and run the math. I built a free ROI calculator that shows you whether a custom build beats your current site in real dollars, not vibes.
+
+https://hudsondigitalsolutions.com/blog/is-a-custom-website-worth-the-investment
+
+#WebDesign #SmallBusiness #DFW"
+"43","2026-07-04","Sat","7:00 PM","mortgage-math-for-small-business-owners","https://hudsondigitalsolutions.com/blog/mortgage-math-for-small-business-owners","Most owners can quote their revenue but not their actual debt service. That gap is where cash flow surprises come from. Here is how I map mortgage math for DFW business owners so you can forecast the month before it punches you.
+
+https://hudsondigitalsolutions.com/blog/mortgage-math-for-small-business-owners
+
+#SmallBusinessFinance #CashFlow #DFW"
+"44","2026-07-05","Sun","7:00 AM","custom-website-vs-website-builder","https://hudsondigitalsolutions.com/blog/custom-website-vs-website-builder","Website builders feel cheap until you hit the wall: no real tracking, locked-in templates and a monthly bill that never ends. I spent years in revenue ops before building sites, so here is the honest custom versus builder breakdown in hard numbers for Dallas businesses.
+
+https://hudsondigitalsolutions.com/blog/custom-website-vs-website-builder
+
+#WebDevelopment #SmallBusiness #DFW"
+"45","2026-07-05","Sun","1:00 PM","kubernetes-for-small-business-is-it-worth-it","https://hudsondigitalsolutions.com/blog/kubernetes-for-small-business-is-it-worth-it","Someone told you your small business needs Kubernetes. For most DFW shops, that is paying for a fleet of trucks to deliver one pizza. Here is when container orchestration actually earns its keep and when it just burns your budget.
+
+https://hudsondigitalsolutions.com/blog/kubernetes-for-small-business-is-it-worth-it
+
+#WebDevelopment #SmallBusinessTech #DFW"
+"46","2026-07-05","Sun","7:00 PM","web-design-mistakes-that-cost-customers","https://hudsondigitalsolutions.com/blog/web-design-mistakes-that-cost-customers","Three web design mistakes quietly cost DFW businesses customers every day: slow load, buried phone numbers and a homepage that makes people guess what you do. I see them on nearly every site I audit. Here are the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/web-design-mistakes-that-cost-customers
+
+#WebDesign #SmallBusiness #DFW"
+"47","2026-07-06","Mon","7:00 AM","mobile-site-speed-and-your-local-customers","https://hudsondigitalsolutions.com/blog/mobile-site-speed-and-your-local-customers","Your customer is standing in a parking lot on 5G with two bars and your mobile site takes six seconds to load. They are already calling someone else. Mobile speed is a revenue lever for local DFW businesses and here is how I measure and fix it.
+
+https://hudsondigitalsolutions.com/blog/mobile-site-speed-and-your-local-customers
+
+#MobileSpeed #LocalSEO #DFW"
+"48","2026-07-06","Mon","1:00 PM","local-keyword-research-for-service-businesses","https://hudsondigitalsolutions.com/blog/local-keyword-research-for-service-businesses","Ranking for ""plumber"" is a vanity metric. Ranking for ""emergency water heater repair Fort Worth"" books jobs. Here is the local keyword research workflow I use to map what DFW customers actually type, then tie those searches to booked calls.
+
+https://hudsondigitalsolutions.com/blog/local-keyword-research-for-service-businesses
+
+#KeywordResearch #LocalSEO #DFW"
+"49","2026-07-06","Mon","7:00 PM","lead-capture-forms-that-convert","https://hudsondigitalsolutions.com/blog/lead-capture-forms-that-convert","Every extra field on your contact form quietly kills conversions. Most DFW sites ask for ten things when they need three. Here is how I build lead capture forms that fill out fast, route straight to your CRM and turn traffic into booked work.
+
+https://hudsondigitalsolutions.com/blog/lead-capture-forms-that-convert
+
+#LeadGeneration #ConversionOptimization #DFW"
+"50","2026-07-07","Tue","7:00 AM","online-booking-that-cuts-no-shows","https://hudsondigitalsolutions.com/blog/online-booking-that-cuts-no-shows","A no-show is a paid-for slot that earns you nothing. For most DFW service businesses, automated reminders alone recover a chunk of that lost revenue every week. Here is the online booking setup that confirms, reminds and fills the gaps without you lifting a finger.
+
+https://hudsondigitalsolutions.com/blog/online-booking-that-cuts-no-shows
+
+#OnlineBooking #BusinessAutomation #DFW"
+"51","2026-07-07","Tue","1:00 PM","squarespace-to-a-custom-site","https://hudsondigitalsolutions.com/blog/squarespace-to-a-custom-site","Squarespace looks fine until your booking flow stalls and you cannot tell which leads came from where. When the template starts costing you jobs, it is time to move. Here is when to switch to a custom site and how I migrate it without losing a single contact.
+
+https://hudsondigitalsolutions.com/blog/squarespace-to-a-custom-site
+
+#WebsiteMigration #Squarespace #DFW"
+"52","2026-07-07","Tue","7:00 PM","restaurant-websites-that-drive-orders","https://hudsondigitalsolutions.com/blog/restaurant-websites-that-drive-orders","A photo of your menu does not feed anyone. Your restaurant site should take orders and lock in reservations while you are slammed on the line. Here is how I turn a DFW restaurant page into a system that actually drives covers and online orders.
+
+https://hudsondigitalsolutions.com/blog/restaurant-websites-that-drive-orders
+
+#RestaurantMarketing #LocalSEO #DallasFortWorth"
+"53","2026-07-08","Wed","7:00 AM","website-maintenance-costs-explained","https://hudsondigitalsolutions.com/blog/website-maintenance-costs-explained","Nobody tells you what a website actually costs after launch, then the surprise invoices land. I pulled real maintenance numbers from DFW operators so you know what to budget, what to automate and what is just a vendor padding the bill.
+
+https://hudsondigitalsolutions.com/blog/website-maintenance-costs-explained
+
+#SmallBusiness #WebsiteCosts #DFW"
+"54","2026-07-08","Wed","1:00 PM","paystub-basics-for-small-employers","https://hudsondigitalsolutions.com/blog/paystub-basics-for-small-employers","One wrong line on a paystub can turn into a compliance headache and a payroll mess. If you have employees in Texas, you need to get this right the first time. Here are the basics every small employer should know, plus a free calculator to skip the manual math.
+
+https://hudsondigitalsolutions.com/blog/paystub-basics-for-small-employers
+
+#Payroll #SmallBusiness #DFW"
+"55","2026-07-08","Wed","7:00 PM","how-we-build-fast-websites-the-stack","https://hudsondigitalsolutions.com/blog/how-we-build-fast-websites-the-stack","Fast sites are not luck, they are a build decision you make on day one. I am pulling back the curtain on the exact stack I use to ship DFW sites that load instantly and turn visitors into booked appointments. Speed is a revenue lever, so here is how I pull it.
+
+https://hudsondigitalsolutions.com/blog/how-we-build-fast-websites-the-stack
+
+#WebDevelopment #WebPerformance #DFW"
+"56","2026-07-09","Thu","7:00 AM","small-business-website-cost-2025","https://hudsondigitalsolutions.com/blog/small-business-website-cost-2025","Quotes for a small business website swing from 500 dollars to 50,000 and most owners have no idea why. I broke down what actually drives the price in 2025 so you can read any proposal and know exactly what you are paying for before you sign.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-cost-2025
+
+#SmallBusiness #WebsiteCosts #DallasFortWorth"
+"57","2026-07-09","Thu","1:00 PM","website-navigation-best-practices-small-business","https://hudsondigitalsolutions.com/blog/website-navigation-best-practices-small-business","A confusing menu is a quiet revenue leak. Every extra click between a visitor and your booking page costs you jobs. Here are the navigation rules I use to turn clicks into booked calls instead of dead ends.
+
+https://hudsondigitalsolutions.com/blog/website-navigation-best-practices-small-business
+
+#WebDesign #SmallBusiness #DFW"
+"58","2026-07-09","Thu","7:00 PM","page-speed-optimization-for-local-service-sites","https://hudsondigitalsolutions.com/blog/page-speed-optimization-for-local-service-sites","A local customer needs a plumber now, not in four seconds while your site loads. Slow pages send them straight to the next result. Here is how I measure, fix and automate page speed for DFW service sites so you stop losing those calls.
+
+https://hudsondigitalsolutions.com/blog/page-speed-optimization-for-local-service-sites
+
+#WebPerformance #LocalSEO #DFW"
+"59","2026-07-10","Fri","7:00 AM","local-seo-for-small-business-guide","https://hudsondigitalsolutions.com/blog/local-seo-for-small-business-guide","Local SEO is not a billboard you set and forget. It is a pipeline that runs from search demand straight to a closed deal. I map exactly how DFW searches turn into booked revenue using automation and strict attribution, no guesswork on what is working.
+
+https://hudsondigitalsolutions.com/blog/local-seo-for-small-business-guide
+
+#LocalSEO #SmallBusiness #DallasFortWorth"
+"60","2026-07-10","Fri","1:00 PM","trust-signals-that-convert-visitors","https://hudsondigitalsolutions.com/blog/trust-signals-that-convert-visitors","A stranger landed on your site and has about three seconds to decide if you are legit. The right proof points close that gap and turn a browser into a booked call. Here are the trust signals that actually convert DFW visitors, backed by automated follow up.
+
+https://hudsondigitalsolutions.com/blog/trust-signals-that-convert-visitors
+
+#ConversionOptimization #SmallBusiness #DFW"
+"61","2026-07-10","Fri","7:00 PM","stripe-payment-setup-small-business","https://hudsondigitalsolutions.com/blog/stripe-payment-setup-small-business","Most DFW shops bolt Stripe on, take the payment and never see where the revenue came from. Set it up right and your checkout doubles as a forecasting tool. Here is the exact Stripe setup I run so every dollar is tracked back to the source.
+
+https://hudsondigitalsolutions.com/blog/stripe-payment-setup-small-business
+
+#Stripe #SmallBusiness #DFW"
+"62","2026-07-11","Sat","7:00 AM","website-migration-checklist","https://hudsondigitalsolutions.com/blog/website-migration-checklist","Moving platforms is where most businesses quietly lose their rankings and half their traffic. I have migrated sites with zero downtime and no drop in search. Here is the checklist I follow line by line so your SEO and revenue tracking survive the move.
+
+https://hudsondigitalsolutions.com/blog/website-migration-checklist
+
+#WebsiteMigration #LocalSEO #DallasFortWorth"
+"63","2026-07-11","Sat","1:00 PM","roofing-company-websites-that-convert","https://hudsondigitalsolutions.com/blog/roofing-company-websites-that-convert","Roofers in DFW are paying real money for clicks that never turn into quote requests. Traffic is not the problem, your site is. Here is how I build roofing sites with HubSpot automation and local SEO that cut cost per lead and book more jobs.
+
+https://hudsondigitalsolutions.com/blog/roofing-company-websites-that-convert
+
+#RoofingMarketing #LocalSEO #DFW"
+"64","2026-07-11","Sat","7:00 PM","what-goes-into-a-website-quote","https://hudsondigitalsolutions.com/blog/what-goes-into-a-website-quote","Two website quotes can be 5,000 dollars apart and both look reasonable until you read the line items. Most owners sign before they know what they are paying for. I break down every part of a website quote so you can spot the hidden costs before you commit.
+
+https://hudsondigitalsolutions.com/blog/what-goes-into-a-website-quote
+
+#WebDesign #SmallBusiness #DallasFortWorth"
+"65","2026-07-12","Sun","7:00 AM","profit-margin-vs-markup","https://hudsondigitalsolutions.com/blog/profit-margin-vs-markup","If you mark up a job 30 percent, your margin is not 30 percent and that gap is eating your profit on every invoice. Margin and markup are not the same number. Here is the difference in plain terms plus a pricing setup that protects your bottom line.
+
+https://hudsondigitalsolutions.com/blog/profit-margin-vs-markup
+
+#PricingStrategy #SmallBusiness #DFW"
+"66","2026-07-12","Sun","1:00 PM","spreadsheet-column-to-comma-list","https://hudsondigitalsolutions.com/blog/spreadsheet-column-to-comma-list","Still copying a spreadsheet column one cell at a time to build a list? Stop. Paste the column, get a clean comma separated list in seconds. Free tool, no signup and a quick read on where this saves you real time in your workflows.
+
+https://hudsondigitalsolutions.com/blog/spreadsheet-column-to-comma-list
+
+#Productivity #SmallBusiness #DFW"
+"67","2026-07-12","Sun","7:00 PM","the-complete-guide-to-building-a-modern-business-website-in-2025","https://hudsondigitalsolutions.com/blog/the-complete-guide-to-building-a-modern-business-website-in-2025","A responsive layout that shrinks to fit a phone is the bare minimum now, not the finish line. Thumb-friendly nav, touch-ready forms, instant load. Here is the full guide to building a business website in 2025 that actually books work, start to finish.
+
+https://hudsondigitalsolutions.com/blog/the-complete-guide-to-building-a-modern-business-website-in-2025
+
+#WebDesign #SmallBusiness #DallasFortWorth"
+"68","2026-07-13","Mon","7:00 AM","real-cost-of-a-slow-website-for-local-business","https://hudsondigitalsolutions.com/blog/real-cost-of-a-slow-website-for-local-business","A slow site does not just annoy people, it has a dollar figure attached and for most local businesses it is bigger than they think. Every extra second costs you booked jobs. Here is how to put a real number on it and the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/real-cost-of-a-slow-website-for-local-business
+
+#WebPerformance #LocalBusiness #DFW"
+"69","2026-07-13","Mon","1:00 PM","localbusiness-schema-help-google-find-you","https://hudsondigitalsolutions.com/blog/localbusiness-schema-help-google-find-you","Google cannot rank what it cannot read. LocalBusiness schema feeds it your hours, location and services in the format it actually wants and that is often the difference between showing in the map pack or not. Here is how to set it up.
+
+https://hudsondigitalsolutions.com/blog/localbusiness-schema-help-google-find-you
+
+#LocalSEO #SchemaMarkup #DallasFortWorth"
+"70","2026-07-13","Mon","7:00 PM","website-traffic-but-no-leads","https://hudsondigitalsolutions.com/blog/website-traffic-but-no-leads","Plenty of visitors, almost no leads. That is not a traffic problem, it is a leak between the click and the contact form. I break down the exact attribution gaps and automation fixes that turn the traffic you already have into booked revenue.
+
+https://hudsondigitalsolutions.com/blog/website-traffic-but-no-leads
+
+#ConversionOptimization #SmallBusiness #DFW"
+"71","2026-07-14","Tue","7:00 AM","workflow-automation-tools-small-business","https://hudsondigitalsolutions.com/blog/workflow-automation-tools-small-business","You are paying a person to copy a lead from your inbox into a CRM. That is a $40 task a script does for free, every time, in two seconds. Here are the workflow automation tools I set up for DFW shops to capture leads, route them and close faster.
+
+https://hudsondigitalsolutions.com/blog/workflow-automation-tools-small-business
+
+#WorkflowAutomation #SmallBusiness #DFW"
+"72","2026-07-14","Tue","1:00 PM","who-owns-your-website-and-domain","https://hudsondigitalsolutions.com/blog/who-owns-your-website-and-domain","Quick question most owners get wrong: if your developer walked away tomorrow, could you still log into your own domain? A lot of DFW businesses do not actually own the thing their whole revenue runs on. Here is how to check in five minutes and take it back.
+
+https://hudsondigitalsolutions.com/blog/who-owns-your-website-and-domain
+
+#DomainOwnership #SmallBusiness #DFW"
+"73","2026-07-14","Tue","7:00 PM","tattoo-studio-websites-booking-gallery-seo","https://hudsondigitalsolutions.com/blog/tattoo-studio-websites-booking-gallery-seo","Your portfolio is your strongest sales pitch and it is buried on Instagram where nobody can book you. A tattoo studio site should show the work, take the deposit and rank when someone in DFW searches for an artist. Here is how I build all three into one system.
+
+https://hudsondigitalsolutions.com/blog/tattoo-studio-websites-booking-gallery-seo
+
+#TattooStudio #LocalSEO #DallasFortWorth"
+"74","2026-07-15","Wed","7:00 AM","why-cheap-websites-cost-more","https://hudsondigitalsolutions.com/blog/why-cheap-websites-cost-more","The $500 website is the most expensive one you can buy. Broken tracking, slow load times and a year of lost leads add up to far more than a real build ever would. Here is the actual math on what cheap costs a DFW business.
+
+https://hudsondigitalsolutions.com/blog/why-cheap-websites-cost-more
+
+#WebDesign #SmallBusiness #DFW"
+"75","2026-07-15","Wed","1:00 PM","service-contracts-every-small-business-needs","https://hudsondigitalsolutions.com/blog/service-contracts-every-small-business-needs","The handshake deal works right up until a client ghosts you on a $6,000 invoice. A few plain contracts protect your revenue and put onboarding on autopilot. Here are the ones every DFW small business actually needs, plus free tools to draft them fast.
+
+https://hudsondigitalsolutions.com/blog/service-contracts-every-small-business-needs
+
+#ServiceContracts #SmallBusiness #DFW"
+"76","2026-07-15","Wed","7:00 PM","structured-data-and-schema-guide","https://hudsondigitalsolutions.com/blog/structured-data-and-schema-guide","Two competitors offer the same service. One shows up in Google with star ratings, prices and hours right in the result. The other is a plain blue link. The difference is schema markup. Here is the practical guide to adding it and what it does for DFW bookings.
+
+https://hudsondigitalsolutions.com/blog/structured-data-and-schema-guide
+
+#StructuredData #LocalSEO #DFW"
+"77","2026-07-16","Thu","7:00 AM","why-your-business-needs-a-custom-crm-integration","https://hudsondigitalsolutions.com/blog/why-your-business-needs-a-custom-crm-integration","Your CRM only works if every tool actually talks to it. When it sits in a silo, someone is retyping data by hand and quietly losing leads. After a decade wiring up Salesforce and HubSpot, here is why a custom integration beats the off-the-shelf connector for DFW operators.
+
+https://hudsondigitalsolutions.com/blog/why-your-business-needs-a-custom-crm-integration
+
+#CRMIntegration #BusinessAutomation #DFW"
+"78","2026-07-16","Thu","1:00 PM","website-performance-audit-checklist-small-business","https://hudsondigitalsolutions.com/blog/website-performance-audit-checklist-small-business","Most DFW owners have no idea their site is leaking bookings because nobody ever audited it. Run this checklist and you will see exactly where speed, tracking and load times are costing you jobs. No fluff, just the line items I check first.
+
+https://hudsondigitalsolutions.com/blog/website-performance-audit-checklist-small-business
+
+#WebPerformance #SmallBusiness #DFW"
+"79","2026-07-16","Thu","7:00 PM","nap-consistency-local-seo","https://hudsondigitalsolutions.com/blog/nap-consistency-local-seo","Your address says Suite 200 on Google, Ste. 200 on Yelp and nothing on Facebook. To Google that looks like three different businesses and your map ranking pays for it. Here is how NAP consistency makes or breaks local SEO for DFW shops.
+
+https://hudsondigitalsolutions.com/blog/nap-consistency-local-seo
+
+#LocalSEO #NAPConsistency #DallasFortWorth"
+"80","2026-07-17","Fri","7:00 AM","texas-tax-title-license-vehicle-costs","https://hudsondigitalsolutions.com/blog/texas-tax-title-license-vehicle-costs","That $30,000 truck is not a $30,000 truck once Texas tax, title and license hit. If you run a fleet in DFW, those fees wreck your cash flow forecast when you guess at them. Here is the real breakdown, plus a free calculator to plan the next purchase.
+
+https://hudsondigitalsolutions.com/blog/texas-tax-title-license-vehicle-costs
+
+#SmallBusiness #FleetCosts #DFW"
+"81","2026-07-17","Fri","1:00 PM","when-and-why-to-format-json","https://hudsondigitalsolutions.com/blog/when-and-why-to-format-json","An API response breaks at 2am and you are staring at one giant unbroken line of text trying to find the bug. Clean JSON is the difference between a five minute fix and a wasted afternoon. Here is when formatting it actually matters for your integrations and a free tool that does it.
+
+https://hudsondigitalsolutions.com/blog/when-and-why-to-format-json
+
+#WebDevelopment #Automation #DFW"
+"82","2026-07-17","Fri","7:00 PM","your-website-needs-a-blueprint-how-to-plan-a-project-that-pays-off","https://hudsondigitalsolutions.com/blog/your-website-needs-a-blueprint-how-to-plan-a-project-that-pays-off","Most website projects do not fail because of bad code. They fail because nobody decided what the site was supposed to do before the build started. Here is the five-step blueprint I run before writing a line, so the site actually pays for itself.
+
+https://hudsondigitalsolutions.com/blog/your-website-needs-a-blueprint-how-to-plan-a-project-that-pays-off
+
+#WebDesign #SmallBusiness #DFW"
+"83","2026-07-18","Sat","7:00 AM","why-your-small-business-has-a-slow-website","https://hudsondigitalsolutions.com/blog/why-your-small-business-has-a-slow-website","Your site feels slow and you have no idea why. It is usually a handful of the same culprits: huge images, bloated plugins, cheap hosting. I break down what is actually dragging your DFW site down, the leads it is quietly costing you and exactly what to measure to fix it.
+
+https://hudsondigitalsolutions.com/blog/why-your-small-business-has-a-slow-website
+
+#WebsiteSpeed #SmallBusiness #DFW"
+"84","2026-07-18","Sat","1:00 PM","why-google-business-profile-not-showing-up","https://hudsondigitalsolutions.com/blog/why-google-business-profile-not-showing-up","You search your own business and it is nowhere on the map. Customers cannot find what Google will not show. I walk through the real reasons your Google Business Profile disappears, from suspensions to NAP mismatches and how to get it ranking again.
+
+https://hudsondigitalsolutions.com/blog/why-google-business-profile-not-showing-up
+
+#LocalSEO #GoogleBusinessProfile #DallasFortWorth"
+"85","2026-07-18","Sat","7:00 PM","tip-calculation-and-bill-splitting","https://hudsondigitalsolutions.com/blog/tip-calculation-and-bill-splitting","Splitting a check four ways at the table while the line backs up is dead time you are not getting paid for. Faster math means faster turnover. Here is how to handle tips and split bills in seconds, plus a free calculator you can use right now.
+
+https://hudsondigitalsolutions.com/blog/tip-calculation-and-bill-splitting
+
+#SmallBusiness #Productivity #DFW"
+"86","2026-07-19","Sun","7:00 AM","why-we-build-on-nextjs-not-wordpress","https://hudsondigitalsolutions.com/blog/why-we-build-on-nextjs-not-wordpress","WordPress runs a third of the web and a good chunk of it loads like dial-up. I stopped building on it for a reason. Here is the honest comparison of Next.js vs WordPress: speed, tracking and what each one actually costs a DFW business over three years.
+
+https://hudsondigitalsolutions.com/blog/why-we-build-on-nextjs-not-wordpress
+
+#WebDevelopment #NextJS #DallasFortWorth"
+"87","2026-07-19","Sun","1:00 PM","word-and-character-counts-that-matter","https://hudsondigitalsolutions.com/blog/word-and-character-counts-that-matter","A meta description that runs too long gets cut off in Google. An ad headline over the limit gets rejected. Word and character counts are not busywork, they decide whether your copy even shows up. Here are the counts that matter and a free tool to hit them.
+
+https://hudsondigitalsolutions.com/blog/word-and-character-counts-that-matter
+
+#ContentMarketing #SEO #DFW"

--- a/.planning/social/facebook-schedule.md
+++ b/.planning/social/facebook-schedule.md
@@ -1,0 +1,934 @@
+# Facebook posting schedule (v9 blog campaign)
+
+87 posts, 3/day at 7:00 AM / 1:00 PM / 7:00 PM Central, 2026-06-20 to 2026-07-19.
+Each links a live blog post; captions in Richard's voice, verified clean (no emoji/dash/comma-before-and/AI-tells).
+
+## 2026-06-20 (Sat)
+
+### 7:00 PM CT  -  #1  5 Signs Your Website is Costing You Customers
+
+```
+Your website might be quietly losing you jobs every week and you would never know it. Slow loads, dead phone numbers on mobile, no clear next step. Here are 5 signs your site is bleeding customers and what I fix first.
+
+https://hudsondigitalsolutions.com/blog/5-signs-your-website-is-costing-you-customers
+
+#WebDesign #SmallBusiness #DFW
+```
+
+## 2026-06-21 (Sun)
+
+### 7:00 AM CT  -  #2  How Many Pages Does a Small Business Website Need?
+
+```
+Stop guessing how many pages your site needs. A 40-page site does not book more calls than a tight 5-page one that is built to convert. I treat every page as a revenue job and track each click. Here is the page count that actually books work.
+
+https://hudsondigitalsolutions.com/blog/how-many-pages-does-a-small-business-website-need
+
+#SmallBusinessWebsite #WebDesign #DFW
+```
+
+### 1:00 PM CT  -  #3  Core Web Vitals Explained for Small Business Owners
+
+```
+Google grades your site on load speed, how fast it responds to taps and whether it jumps around while loading. Fail those and you slide down the results. Here is what Core Web Vitals actually mean for a DFW owner and how to fix them without torching your budget.
+
+https://hudsondigitalsolutions.com/blog/core-web-vitals-explained-for-small-business
+
+#CoreWebVitals #WebPerformance #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #4  Google Business Profile Optimization Checklist
+
+```
+Your Google Business Profile is the first thing a DFW customer sees and most are half filled out. A complete, optimized listing pulls calls straight off the map pack. Here is the exact checklist I run to turn that free listing into a booking machine.
+
+https://hudsondigitalsolutions.com/blog/google-business-profile-optimization-checklist
+
+#GoogleBusinessProfile #LocalSEO #DFW
+```
+
+## 2026-06-22 (Mon)
+
+### 7:00 AM CT  -  #5  The Anatomy of a High-Converting Homepage
+
+```
+Most homepages are pretty brochures that convert nobody. A homepage that earns its keep is a system: one clear promise, proof and a path to book. I break down the exact anatomy that turns Dallas visitors into paying clients, section by section.
+
+https://hudsondigitalsolutions.com/blog/anatomy-of-a-high-converting-homepage
+
+#ConversionOptimization #WebDesign #DFW
+```
+
+### 1:00 PM CT  -  #6  Automate Customer Follow-Up With Email and SMS
+
+```
+Half the leads you lose are not lost, they are just waiting on a reply you never sent. Automated email and SMS follow-up catches them while they are still warm. Here are the systems and tools DFW businesses use to recover that revenue on autopilot.
+
+https://hudsondigitalsolutions.com/blog/automate-customer-follow-up-email-sms
+
+#Automation #CustomerFollowUp #DFW
+```
+
+### 7:00 PM CT  -  #7  Escaping Monthly Platform Fees: Wix, Squarespace, GoDaddy
+
+```
+Wix, Squarespace and GoDaddy quietly bill you every month forever and you never actually own the site. I show Dallas owners how to build a site you own outright that pays for itself in about 90 days. Run the math, then cancel the subscription.
+
+https://hudsondigitalsolutions.com/blog/escaping-monthly-platform-fees
+
+#WebsiteMigration #SmallBusiness #DFW
+```
+
+## 2026-06-23 (Tue)
+
+### 7:00 AM CT  -  #8  HVAC Website Design That Drives Calls
+
+```
+When a Dallas homeowner has no AC in July, they call whoever shows up fast and loads fast. If your HVAC site is slow or buries the phone number, that call goes to the next guy. Here is how I build HVAC sites that turn clicks into booked jobs.
+
+https://hudsondigitalsolutions.com/blog/hvac-company-websites-that-drive-calls
+
+#HVAC #LocalSEO #DFW
+```
+
+### 1:00 PM CT  -  #9  Agency vs Freelancer vs DIY: A Website Cost Breakdown
+
+```
+Agency, freelancer or do it yourself? The price tags are not the real story, the hidden costs and the ROI are. I lay out agency vs freelancer vs DIY with real DFW numbers and a free estimator so you can budget before you sign anything.
+
+https://hudsondigitalsolutions.com/blog/agency-vs-freelancer-vs-diy-website-cost
+
+#WebsiteCost #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #10  How to Track Employee Hours Without the Headache
+
+```
+Paper timesheets and Friday spreadsheet math cost you payroll errors and a wasted weekend. Tracking employee hours should run itself. Here is how I set up automated time tracking for DFW small businesses so the numbers are right before payroll runs.
+
+https://hudsondigitalsolutions.com/blog/how-to-track-employee-hours
+
+#TimeTracking #SmallBusiness #DFW
+```
+
+## 2026-06-24 (Wed)
+
+### 7:00 AM CT  -  #11  Case Study: A Local Business Website (Ink37 Tattoos)
+
+```
+Here is what happened when a Dallas tattoo studio stopped treating its site like a Facebook page and started treating it like a booking machine. Ink37 Tattoos: the real numbers, the automation we wired in and the ROI. No theory, just what moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-ink37-local-service-website
+
+#CaseStudy #LocalBusiness #DFW
+```
+
+### 1:00 PM CT  -  #12  Beyond "Just Works": Why Businesses Need Websites That Dominate
+
+```
+A site that "works" still loses you money every day. It loads, it shows your hours and it does nothing else. Your website should be your hardest-working salesperson, booking calls while you sleep. Here is the difference between a site that exists and one that sells.
+
+https://hudsondigitalsolutions.com/blog/beyond-just-works-why-businesses-need-websites-that-dominate
+
+#WebDesign #SmallBusiness #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #13  Mobile-First Web Design for Service Businesses
+
+```
+More than half your DFW customers find you on a phone, then bounce because your site was built for a desktop they will never use. Mobile-first is not a style choice, it is where the booked jobs come from. Here is how I build service sites that convert on a thumb.
+
+https://hudsondigitalsolutions.com/blog/mobile-first-web-design-for-service-businesses
+
+#MobileFirst #ServiceBusiness #DFW
+```
+
+## 2026-06-25 (Thu)
+
+### 7:00 AM CT  -  #14  How to Measure Website Performance
+
+```
+"My website is doing great" usually means "I have no idea what my website is doing." Traffic is not the metric that pays you. Here are the numbers I actually track to tie a site back to booked revenue and the ones I ignore.
+
+https://hudsondigitalsolutions.com/blog/how-to-measure-website-performance
+
+#WebAnalytics #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #15  How to Get More Google Reviews for Your Business
+
+```
+The DFW business with 200 reviews is not better than you. They just have a system for asking and you do not. Reviews are the cheapest local SEO you can buy and you can automate the entire ask. Here is the exact follow-up flow I set up.
+
+https://hudsondigitalsolutions.com/blog/how-to-get-more-google-reviews
+
+#GoogleReviews #LocalSEO #DFW
+```
+
+### 7:00 PM CT  -  #16  Call to Action Best Practices for Service Sites
+
+```
+"Contact us" is where leads go to die. A vague button asks the visitor to do the work and they will not. Your call to action should tell them exactly what happens next and make it one tap. Here is what actually gets clicked on a service site.
+
+https://hudsondigitalsolutions.com/blog/call-to-action-best-practices
+
+#ConversionOptimization #ServiceBusiness #DFW
+```
+
+## 2026-06-26 (Fri)
+
+### 7:00 AM CT  -  #17  Automated Lead Follow-Up for Service Businesses
+
+```
+A lead that waits five minutes for a reply is mostly gone. While you are on a job, your competitor already called them back. I build follow-up systems that route, score and respond to every DFW lead the second it lands, with zero manual work from you.
+
+https://hudsondigitalsolutions.com/blog/automated-lead-follow-up-for-service-businesses
+
+#LeadGeneration #BusinessAutomation #DFW
+```
+
+### 1:00 PM CT  -  #18  How to Leave Thryv Without Losing Your Rankings
+
+```
+Thryv has your website, your data and your Google rankings hostage and you are paying monthly for the privilege. You can leave without tanking your local search. Here is how I map the data out, rebuild the site and protect every ranking on the way.
+
+https://hudsondigitalsolutions.com/blog/how-to-leave-thryv-without-losing-rankings
+
+#LocalSEO #WebsiteMigration #DFW
+```
+
+### 7:00 PM CT  -  #19  Law Firm Websites for Small Practices
+
+```
+One signed client can cover a year of your website. So why does your small-practice site read like a brochure and track nothing? I build law firm sites that capture every lead, follow up automatically and tell you which case came from where.
+
+https://hudsondigitalsolutions.com/blog/law-firm-websites-for-small-practices
+
+#LawFirmMarketing #LocalSEO #DallasFortWorth
+```
+
+## 2026-06-27 (Sat)
+
+### 7:00 AM CT  -  #20  The Hidden Costs of DIY Website Builders
+
+```
+That $16-a-month website builder is the most expensive thing in your business. The fee is the cheap part. The real bill is the leads it loses, the tracking it cannot do and the rebuild you will pay for later. Here is the math before it drains your margins.
+
+https://hudsondigitalsolutions.com/blog/hidden-costs-of-diy-website-builders
+
+#WebsiteBuilder #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #21  How to Write an Invoice That Gets Paid Fast
+
+```
+An invoice that sits in someone's inbox for 45 days is just a loan you never agreed to make. Here is how I structure invoices and automate the follow-ups so DFW owners cut days off their pay cycle and stop chasing checks.
+
+https://hudsondigitalsolutions.com/blog/how-to-write-an-invoice-that-gets-paid
+
+#CashFlow #SmallBusiness #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #22  Case Study: An Ecommerce Website Build (JirahShop)
+
+```
+Most ecommerce builds are a pretty storefront bolted onto guesswork. Here is the full breakdown of the JirahShop build: the systems, the attribution and the automation we wired in so every sale traces back to what actually drove it.
+
+https://hudsondigitalsolutions.com/blog/case-study-jirahshop-ecommerce-build
+
+#Ecommerce #CaseStudy #DFW
+```
+
+## 2026-06-28 (Sun)
+
+### 7:00 AM CT  -  #23  How AI Automation Can Save Your Business 20+ Hours Per Week
+
+```
+Busy is not the same as profitable. If you and your team burn 20 hours a week on manual data entry and scheduling, that is half a salaried person doing work software handles for free. Here are the AI automations I set up first to win those hours back.
+
+https://hudsondigitalsolutions.com/blog/how-ai-automation-can-save-your-business-20-hours-per-week
+
+#AIautomation #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #24  Signs You Need a Website Redesign (Small Business Guide)
+
+```
+A redesign is not about looks. It is about the leads your current site quietly loses every month. Here are the hard signs that tell you a rebuild will cost less than keeping the site you have, with real numbers from Dallas Fort Worth.
+
+https://hudsondigitalsolutions.com/blog/signs-you-need-a-website-redesign
+
+#WebsiteRedesign #SmallBusiness #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #25  How Website Speed Affects Your Revenue
+
+```
+Every extra second your page takes to load shaves points off your conversion rate. That is not a vanity metric, it is revenue walking out the door. Here is how I tie load times straight to booked jobs and pipeline for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/how-website-speed-affects-your-revenue
+
+#WebPerformance #Revenue #DFW
+```
+
+## 2026-06-29 (Mon)
+
+### 7:00 AM CT  -  #26  How to Rank in Multiple Cities Without Thin Pages
+
+```
+Want to rank in Plano, Frisco and Arlington without spinning up 30 thin doorway pages Google will penalize? There is a right way to do it. Here is the local SEO structure I use to pull booked calls from every zip code you serve.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-multiple-cities
+
+#LocalSEO #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #27  How to Reduce Bounce Rate on Your Website
+
+```
+People hit your site, glance once and leave. A high bounce rate is a money problem dressed up as an analytics number. Here are the measurable fixes I run to keep DFW visitors on the page long enough to actually book.
+
+https://hudsondigitalsolutions.com/blog/how-to-reduce-bounce-rate
+
+#ConversionOptimization #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #28  CRM Automation: Stop Losing Leads in Your Inbox
+
+```
+A lead buried in your inbox is a lead your competitor is already calling. I spent years building these systems in HubSpot and Salesforce. Here is the CRM automation that routes, scores and follows up on every Dallas lead so none of them go cold.
+
+https://hudsondigitalsolutions.com/blog/crm-automation-stop-losing-leads
+
+#CRMautomation #LeadGen #DallasFortWorth
+```
+
+## 2026-06-30 (Tue)
+
+### 7:00 AM CT  -  #29  How to Migrate Off Wix Without Breaking SEO
+
+```
+Leaving Wix scares people because one bad redirect can tank rankings you spent years earning. It does not have to. Here is the step-by-step migration plan I follow to move you off Wix with zero lost traffic or revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-migrate-off-wix
+
+#WebsiteMigration #SEO #DFW
+```
+
+### 1:00 PM CT  -  #30  Med Spa Websites That Fill the Calendar
+
+```
+A med spa site full of glossy photos and an empty booking calendar is just an expensive billboard. I build med spa sites that turn visitors into booked procedures with real tracking and automation behind every appointment. Here is how DFW clinics fill the schedule.
+
+https://hudsondigitalsolutions.com/blog/med-spa-websites-that-fill-the-calendar
+
+#MedSpaMarketing #LocalSEO #DFW
+```
+
+### 7:00 PM CT  -  #31  How to Set a Website Budget for Your Project
+
+```
+Most DFW owners pick a website budget by guessing, then get surprised by the bill. Here is how I price design, SEO and automation as line items you can actually defend, so the spend ties back to booked revenue.
+
+https://hudsondigitalsolutions.com/blog/how-to-budget-for-a-website-project
+
+#WebsiteBudget #SmallBusiness #DFW
+```
+
+## 2026-07-01 (Wed)
+
+### 7:00 AM CT  -  #32  Invoice Late Fees: What Actually Works
+
+```
+A late fee buried in your terms does nothing if nobody reads it. I show DFW operators how to structure invoice late fees that actually get paid and still keep the client. Cash flow first, awkward phone calls last.
+
+https://hudsondigitalsolutions.com/blog/invoice-late-fees-what-works
+
+#CashFlow #SmallBusiness #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #33  Case Study: A SaaS Web Application Build (TenantFlow)
+
+```
+TenantFlow had vendor workflows scattered across spreadsheets and inboxes. We rebuilt it as one SaaS app that turns those handoffs into automated revenue pipelines. Full breakdown of what we built and what it moved.
+
+https://hudsondigitalsolutions.com/blog/case-study-tenantflow-saas-web-application
+
+#SaaS #WebDevelopment #DFW
+```
+
+### 7:00 PM CT  -  #34  How to Increase Website Conversion Rates: 2025 Guide
+
+```
+Traffic is easy. Turning visitors into customers is the part most sites get wrong. Here is the 2025 playbook I use to lift conversion rates on DFW service sites, from the offer down to the form field.
+
+https://hudsondigitalsolutions.com/blog/how-to-increase-website-conversion-rates-2025-guide
+
+#ConversionRate #SmallBusiness #DFW
+```
+
+## 2026-07-02 (Thu)
+
+### 7:00 AM CT  -  #35  Small Business Website Design: What Actually Converts
+
+```
+A pretty website that books nothing is just an expensive brochure. I treat small business design as a revenue system, built around DFW local SEO and follow-up automation. Here is what actually converts and what is just decoration.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-design-what-converts
+
+#WebDesign #SmallBusiness #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #36  Largest Contentful Paint: How to Find and Fix It
+
+```
+Largest Contentful Paint is the moment your page feels loaded to a real visitor. Drag it past 2.5 seconds and people leave before your form ever appears. Here is how I find it and the fixes I run first for DFW businesses.
+
+https://hudsondigitalsolutions.com/blog/largest-contentful-paint-how-to-find-and-fix-it
+
+#WebPerformance #CoreWebVitals #DFW
+```
+
+### 7:00 PM CT  -  #37  How to Rank in the Google Local Pack
+
+```
+The three businesses in the Google map pack get the calls. Everyone below scrolls into the void. Here are the metrics and local SEO moves that put a Dallas business in those top three spots and keep it there.
+
+https://hudsondigitalsolutions.com/blog/how-to-rank-in-the-google-local-pack
+
+#LocalSEO #GoogleLocalPack #DFW
+```
+
+## 2026-07-03 (Fri)
+
+### 7:00 AM CT  -  #38  Landing Page Optimization for Small Business
+
+```
+You are paying for clicks that land on a page built to inform, not to book. That gap is where your ad budget dies. Here is how landing page optimization turns DFW local traffic into actual appointments on the calendar.
+
+https://hudsondigitalsolutions.com/blog/landing-page-optimization-small-business
+
+#LandingPages #ConversionRate #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #39  How to Connect Your Website to Your CRM
+
+```
+Every lead that hits your contact form and then sits in an inbox is money decaying in real time. Connect the website to your CRM and each one gets tracked, routed and worked automatically. Here is exactly how I wire it up.
+
+https://hudsondigitalsolutions.com/blog/how-to-connect-your-website-to-your-crm
+
+#CRM #Automation #DFW
+```
+
+### 7:00 PM CT  -  #40  How to Transfer Your Domain Safely
+
+```
+One botched domain transfer can knock your site offline and tank your rankings for weeks. It does not have to. Here are the exact steps to move your domain with zero downtime and your attribution tracking fully intact.
+
+https://hudsondigitalsolutions.com/blog/how-to-transfer-your-domain-safely
+
+#DomainTransfer #WebsiteMigration #DallasFortWorth
+```
+
+## 2026-07-04 (Sat)
+
+### 7:00 AM CT  -  #41  Plumber Website Design That Books Jobs
+
+```
+When a pipe bursts, the homeowner calls the plumber who shows up first in search, not the one with the prettiest site. I build plumber sites in DFW wired for fast load, click-to-call and tracking so you know which jobs your website actually booked.
+
+https://hudsondigitalsolutions.com/blog/plumber-website-design-that-books-jobs
+
+#PlumberMarketing #LocalSEO #DFW
+```
+
+### 1:00 PM CT  -  #42  Is a Custom Website Worth It?
+
+```
+A custom website is only worth it if it pays for itself in booked work. So stop guessing and run the math. I built a free ROI calculator that shows you whether a custom build beats your current site in real dollars, not vibes.
+
+https://hudsondigitalsolutions.com/blog/is-a-custom-website-worth-the-investment
+
+#WebDesign #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #43  Mortgage Math for Small Business Owners
+
+```
+Most owners can quote their revenue but not their actual debt service. That gap is where cash flow surprises come from. Here is how I map mortgage math for DFW business owners so you can forecast the month before it punches you.
+
+https://hudsondigitalsolutions.com/blog/mortgage-math-for-small-business-owners
+
+#SmallBusinessFinance #CashFlow #DFW
+```
+
+## 2026-07-05 (Sun)
+
+### 7:00 AM CT  -  #44  Custom Website vs Website Builder: A Developer's View
+
+```
+Website builders feel cheap until you hit the wall: no real tracking, locked-in templates and a monthly bill that never ends. I spent years in revenue ops before building sites, so here is the honest custom versus builder breakdown in hard numbers for Dallas businesses.
+
+https://hudsondigitalsolutions.com/blog/custom-website-vs-website-builder
+
+#WebDevelopment #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #45  Kubernetes for Small Business: Is It Worth It?
+
+```
+Someone told you your small business needs Kubernetes. For most DFW shops, that is paying for a fleet of trucks to deliver one pizza. Here is when container orchestration actually earns its keep and when it just burns your budget.
+
+https://hudsondigitalsolutions.com/blog/kubernetes-for-small-business-is-it-worth-it
+
+#WebDevelopment #SmallBusinessTech #DFW
+```
+
+### 7:00 PM CT  -  #46  Web Design Mistakes That Cost Small Businesses Customers
+
+```
+Three web design mistakes quietly cost DFW businesses customers every day: slow load, buried phone numbers and a homepage that makes people guess what you do. I see them on nearly every site I audit. Here are the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/web-design-mistakes-that-cost-customers
+
+#WebDesign #SmallBusiness #DFW
+```
+
+## 2026-07-06 (Mon)
+
+### 7:00 AM CT  -  #47  Mobile Site Speed and Your Local Customers
+
+```
+Your customer is standing in a parking lot on 5G with two bars and your mobile site takes six seconds to load. They are already calling someone else. Mobile speed is a revenue lever for local DFW businesses and here is how I measure and fix it.
+
+https://hudsondigitalsolutions.com/blog/mobile-site-speed-and-your-local-customers
+
+#MobileSpeed #LocalSEO #DFW
+```
+
+### 1:00 PM CT  -  #48  Local Keyword Research for Service Businesses
+
+```
+Ranking for "plumber" is a vanity metric. Ranking for "emergency water heater repair Fort Worth" books jobs. Here is the local keyword research workflow I use to map what DFW customers actually type, then tie those searches to booked calls.
+
+https://hudsondigitalsolutions.com/blog/local-keyword-research-for-service-businesses
+
+#KeywordResearch #LocalSEO #DFW
+```
+
+### 7:00 PM CT  -  #49  Lead Capture Forms That Actually Convert
+
+```
+Every extra field on your contact form quietly kills conversions. Most DFW sites ask for ten things when they need three. Here is how I build lead capture forms that fill out fast, route straight to your CRM and turn traffic into booked work.
+
+https://hudsondigitalsolutions.com/blog/lead-capture-forms-that-convert
+
+#LeadGeneration #ConversionOptimization #DFW
+```
+
+## 2026-07-07 (Tue)
+
+### 7:00 AM CT  -  #50  Online Booking That Cuts No-Shows
+
+```
+A no-show is a paid-for slot that earns you nothing. For most DFW service businesses, automated reminders alone recover a chunk of that lost revenue every week. Here is the online booking setup that confirms, reminds and fills the gaps without you lifting a finger.
+
+https://hudsondigitalsolutions.com/blog/online-booking-that-cuts-no-shows
+
+#OnlineBooking #BusinessAutomation #DFW
+```
+
+### 1:00 PM CT  -  #51  Squarespace to a Custom Site: When and How to Switch
+
+```
+Squarespace looks fine until your booking flow stalls and you cannot tell which leads came from where. When the template starts costing you jobs, it is time to move. Here is when to switch to a custom site and how I migrate it without losing a single contact.
+
+https://hudsondigitalsolutions.com/blog/squarespace-to-a-custom-site
+
+#WebsiteMigration #Squarespace #DFW
+```
+
+### 7:00 PM CT  -  #52  Restaurant Websites That Drive Orders and Reservations
+
+```
+A photo of your menu does not feed anyone. Your restaurant site should take orders and lock in reservations while you are slammed on the line. Here is how I turn a DFW restaurant page into a system that actually drives covers and online orders.
+
+https://hudsondigitalsolutions.com/blog/restaurant-websites-that-drive-orders
+
+#RestaurantMarketing #LocalSEO #DallasFortWorth
+```
+
+## 2026-07-08 (Wed)
+
+### 7:00 AM CT  -  #53  Website Maintenance Costs Explained
+
+```
+Nobody tells you what a website actually costs after launch, then the surprise invoices land. I pulled real maintenance numbers from DFW operators so you know what to budget, what to automate and what is just a vendor padding the bill.
+
+https://hudsondigitalsolutions.com/blog/website-maintenance-costs-explained
+
+#SmallBusiness #WebsiteCosts #DFW
+```
+
+### 1:00 PM CT  -  #54  Paystub Basics Every Small Employer Should Know
+
+```
+One wrong line on a paystub can turn into a compliance headache and a payroll mess. If you have employees in Texas, you need to get this right the first time. Here are the basics every small employer should know, plus a free calculator to skip the manual math.
+
+https://hudsondigitalsolutions.com/blog/paystub-basics-for-small-employers
+
+#Payroll #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #55  How We Build Fast Websites: The Stack
+
+```
+Fast sites are not luck, they are a build decision you make on day one. I am pulling back the curtain on the exact stack I use to ship DFW sites that load instantly and turn visitors into booked appointments. Speed is a revenue lever, so here is how I pull it.
+
+https://hudsondigitalsolutions.com/blog/how-we-build-fast-websites-the-stack
+
+#WebDevelopment #WebPerformance #DFW
+```
+
+## 2026-07-09 (Thu)
+
+### 7:00 AM CT  -  #56  Small Business Website Cost in 2025: What to Expect
+
+```
+Quotes for a small business website swing from 500 dollars to 50,000 and most owners have no idea why. I broke down what actually drives the price in 2025 so you can read any proposal and know exactly what you are paying for before you sign.
+
+https://hudsondigitalsolutions.com/blog/small-business-website-cost-2025
+
+#SmallBusiness #WebsiteCosts #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #57  Website Navigation Best Practices for Small Business
+
+```
+A confusing menu is a quiet revenue leak. Every extra click between a visitor and your booking page costs you jobs. Here are the navigation rules I use to turn clicks into booked calls instead of dead ends.
+
+https://hudsondigitalsolutions.com/blog/website-navigation-best-practices-small-business
+
+#WebDesign #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #58  Page Speed Optimization for Local Service Sites
+
+```
+A local customer needs a plumber now, not in four seconds while your site loads. Slow pages send them straight to the next result. Here is how I measure, fix and automate page speed for DFW service sites so you stop losing those calls.
+
+https://hudsondigitalsolutions.com/blog/page-speed-optimization-for-local-service-sites
+
+#WebPerformance #LocalSEO #DFW
+```
+
+## 2026-07-10 (Fri)
+
+### 7:00 AM CT  -  #59  Local SEO for Small Business: A Practical Guide
+
+```
+Local SEO is not a billboard you set and forget. It is a pipeline that runs from search demand straight to a closed deal. I map exactly how DFW searches turn into booked revenue using automation and strict attribution, no guesswork on what is working.
+
+https://hudsondigitalsolutions.com/blog/local-seo-for-small-business-guide
+
+#LocalSEO #SmallBusiness #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #60  Trust Signals That Turn Visitors Into Customers
+
+```
+A stranger landed on your site and has about three seconds to decide if you are legit. The right proof points close that gap and turn a browser into a booked call. Here are the trust signals that actually convert DFW visitors, backed by automated follow up.
+
+https://hudsondigitalsolutions.com/blog/trust-signals-that-convert-visitors
+
+#ConversionOptimization #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #61  Stripe Payment Setup for Small Business Websites
+
+```
+Most DFW shops bolt Stripe on, take the payment and never see where the revenue came from. Set it up right and your checkout doubles as a forecasting tool. Here is the exact Stripe setup I run so every dollar is tracked back to the source.
+
+https://hudsondigitalsolutions.com/blog/stripe-payment-setup-small-business
+
+#Stripe #SmallBusiness #DFW
+```
+
+## 2026-07-11 (Sat)
+
+### 7:00 AM CT  -  #62  Website Migration Checklist: Move Without Losing SEO
+
+```
+Moving platforms is where most businesses quietly lose their rankings and half their traffic. I have migrated sites with zero downtime and no drop in search. Here is the checklist I follow line by line so your SEO and revenue tracking survive the move.
+
+https://hudsondigitalsolutions.com/blog/website-migration-checklist
+
+#WebsiteMigration #LocalSEO #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #63  Roofing Company Websites That Convert
+
+```
+Roofers in DFW are paying real money for clicks that never turn into quote requests. Traffic is not the problem, your site is. Here is how I build roofing sites with HubSpot automation and local SEO that cut cost per lead and book more jobs.
+
+https://hudsondigitalsolutions.com/blog/roofing-company-websites-that-convert
+
+#RoofingMarketing #LocalSEO #DFW
+```
+
+### 7:00 PM CT  -  #64  What Goes Into a Website Quote
+
+```
+Two website quotes can be 5,000 dollars apart and both look reasonable until you read the line items. Most owners sign before they know what they are paying for. I break down every part of a website quote so you can spot the hidden costs before you commit.
+
+https://hudsondigitalsolutions.com/blog/what-goes-into-a-website-quote
+
+#WebDesign #SmallBusiness #DallasFortWorth
+```
+
+## 2026-07-12 (Sun)
+
+### 7:00 AM CT  -  #65  Profit Margin vs Markup: Price Your Services Right
+
+```
+If you mark up a job 30 percent, your margin is not 30 percent and that gap is eating your profit on every invoice. Margin and markup are not the same number. Here is the difference in plain terms plus a pricing setup that protects your bottom line.
+
+https://hudsondigitalsolutions.com/blog/profit-margin-vs-markup
+
+#PricingStrategy #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #66  Turn a Spreadsheet Column Into a Comma Separated List
+
+```
+Still copying a spreadsheet column one cell at a time to build a list? Stop. Paste the column, get a clean comma separated list in seconds. Free tool, no signup and a quick read on where this saves you real time in your workflows.
+
+https://hudsondigitalsolutions.com/blog/spreadsheet-column-to-comma-list
+
+#Productivity #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #67  The Complete Guide to Building a Modern Business Website in 2025
+
+```
+A responsive layout that shrinks to fit a phone is the bare minimum now, not the finish line. Thumb-friendly nav, touch-ready forms, instant load. Here is the full guide to building a business website in 2025 that actually books work, start to finish.
+
+https://hudsondigitalsolutions.com/blog/the-complete-guide-to-building-a-modern-business-website-in-2025
+
+#WebDesign #SmallBusiness #DallasFortWorth
+```
+
+## 2026-07-13 (Mon)
+
+### 7:00 AM CT  -  #68  The Real Cost of a Slow Website for Local Business
+
+```
+A slow site does not just annoy people, it has a dollar figure attached and for most local businesses it is bigger than they think. Every extra second costs you booked jobs. Here is how to put a real number on it and the fixes I run first.
+
+https://hudsondigitalsolutions.com/blog/real-cost-of-a-slow-website-for-local-business
+
+#WebPerformance #LocalBusiness #DFW
+```
+
+### 1:00 PM CT  -  #69  LocalBusiness Schema: Help Google Find You
+
+```
+Google cannot rank what it cannot read. LocalBusiness schema feeds it your hours, location and services in the format it actually wants and that is often the difference between showing in the map pack or not. Here is how to set it up.
+
+https://hudsondigitalsolutions.com/blog/localbusiness-schema-help-google-find-you
+
+#LocalSEO #SchemaMarkup #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #70  Your Website Gets Traffic but No Leads: Fix It
+
+```
+Plenty of visitors, almost no leads. That is not a traffic problem, it is a leak between the click and the contact form. I break down the exact attribution gaps and automation fixes that turn the traffic you already have into booked revenue.
+
+https://hudsondigitalsolutions.com/blog/website-traffic-but-no-leads
+
+#ConversionOptimization #SmallBusiness #DFW
+```
+
+## 2026-07-14 (Tue)
+
+### 7:00 AM CT  -  #71  Workflow Automation Tools for Small Business
+
+```
+You are paying a person to copy a lead from your inbox into a CRM. That is a $40 task a script does for free, every time, in two seconds. Here are the workflow automation tools I set up for DFW shops to capture leads, route them and close faster.
+
+https://hudsondigitalsolutions.com/blog/workflow-automation-tools-small-business
+
+#WorkflowAutomation #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #72  Who Owns Your Website and Domain? How to Check
+
+```
+Quick question most owners get wrong: if your developer walked away tomorrow, could you still log into your own domain? A lot of DFW businesses do not actually own the thing their whole revenue runs on. Here is how to check in five minutes and take it back.
+
+https://hudsondigitalsolutions.com/blog/who-owns-your-website-and-domain
+
+#DomainOwnership #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #73  Tattoo Studio Websites: Booking, Gallery and Local SEO
+
+```
+Your portfolio is your strongest sales pitch and it is buried on Instagram where nobody can book you. A tattoo studio site should show the work, take the deposit and rank when someone in DFW searches for an artist. Here is how I build all three into one system.
+
+https://hudsondigitalsolutions.com/blog/tattoo-studio-websites-booking-gallery-seo
+
+#TattooStudio #LocalSEO #DallasFortWorth
+```
+
+## 2026-07-15 (Wed)
+
+### 7:00 AM CT  -  #74  Why Cheap Websites Cost More in the Long Run
+
+```
+The $500 website is the most expensive one you can buy. Broken tracking, slow load times and a year of lost leads add up to far more than a real build ever would. Here is the actual math on what cheap costs a DFW business.
+
+https://hudsondigitalsolutions.com/blog/why-cheap-websites-cost-more
+
+#WebDesign #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #75  Service Contracts Every Small Business Needs
+
+```
+The handshake deal works right up until a client ghosts you on a $6,000 invoice. A few plain contracts protect your revenue and put onboarding on autopilot. Here are the ones every DFW small business actually needs, plus free tools to draft them fast.
+
+https://hudsondigitalsolutions.com/blog/service-contracts-every-small-business-needs
+
+#ServiceContracts #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #76  Structured Data and Schema: A Practical Guide
+
+```
+Two competitors offer the same service. One shows up in Google with star ratings, prices and hours right in the result. The other is a plain blue link. The difference is schema markup. Here is the practical guide to adding it and what it does for DFW bookings.
+
+https://hudsondigitalsolutions.com/blog/structured-data-and-schema-guide
+
+#StructuredData #LocalSEO #DFW
+```
+
+## 2026-07-16 (Thu)
+
+### 7:00 AM CT  -  #77  Why Your Business Needs a Custom CRM Integration
+
+```
+Your CRM only works if every tool actually talks to it. When it sits in a silo, someone is retyping data by hand and quietly losing leads. After a decade wiring up Salesforce and HubSpot, here is why a custom integration beats the off-the-shelf connector for DFW operators.
+
+https://hudsondigitalsolutions.com/blog/why-your-business-needs-a-custom-crm-integration
+
+#CRMIntegration #BusinessAutomation #DFW
+```
+
+### 1:00 PM CT  -  #78  A Website Performance Audit Checklist for Small Business
+
+```
+Most DFW owners have no idea their site is leaking bookings because nobody ever audited it. Run this checklist and you will see exactly where speed, tracking and load times are costing you jobs. No fluff, just the line items I check first.
+
+https://hudsondigitalsolutions.com/blog/website-performance-audit-checklist-small-business
+
+#WebPerformance #SmallBusiness #DFW
+```
+
+### 7:00 PM CT  -  #79  NAP Consistency and Why It Makes or Breaks Local SEO
+
+```
+Your address says Suite 200 on Google, Ste. 200 on Yelp and nothing on Facebook. To Google that looks like three different businesses and your map ranking pays for it. Here is how NAP consistency makes or breaks local SEO for DFW shops.
+
+https://hudsondigitalsolutions.com/blog/nap-consistency-local-seo
+
+#LocalSEO #NAPConsistency #DallasFortWorth
+```
+
+## 2026-07-17 (Fri)
+
+### 7:00 AM CT  -  #80  Texas Tax Title and License: What a Vehicle Costs
+
+```
+That $30,000 truck is not a $30,000 truck once Texas tax, title and license hit. If you run a fleet in DFW, those fees wreck your cash flow forecast when you guess at them. Here is the real breakdown, plus a free calculator to plan the next purchase.
+
+https://hudsondigitalsolutions.com/blog/texas-tax-title-license-vehicle-costs
+
+#SmallBusiness #FleetCosts #DFW
+```
+
+### 1:00 PM CT  -  #81  When and Why to Format JSON
+
+```
+An API response breaks at 2am and you are staring at one giant unbroken line of text trying to find the bug. Clean JSON is the difference between a five minute fix and a wasted afternoon. Here is when formatting it actually matters for your integrations and a free tool that does it.
+
+https://hudsondigitalsolutions.com/blog/when-and-why-to-format-json
+
+#WebDevelopment #Automation #DFW
+```
+
+### 7:00 PM CT  -  #82  Your Website Needs a Blueprint: How to Plan a Project That Pays Off
+
+```
+Most website projects do not fail because of bad code. They fail because nobody decided what the site was supposed to do before the build started. Here is the five-step blueprint I run before writing a line, so the site actually pays for itself.
+
+https://hudsondigitalsolutions.com/blog/your-website-needs-a-blueprint-how-to-plan-a-project-that-pays-off
+
+#WebDesign #SmallBusiness #DFW
+```
+
+## 2026-07-18 (Sat)
+
+### 7:00 AM CT  -  #83  Why Your Small Business Has a Slow Website
+
+```
+Your site feels slow and you have no idea why. It is usually a handful of the same culprits: huge images, bloated plugins, cheap hosting. I break down what is actually dragging your DFW site down, the leads it is quietly costing you and exactly what to measure to fix it.
+
+https://hudsondigitalsolutions.com/blog/why-your-small-business-has-a-slow-website
+
+#WebsiteSpeed #SmallBusiness #DFW
+```
+
+### 1:00 PM CT  -  #84  Google Business Profile Not Showing Up? Here Is Why
+
+```
+You search your own business and it is nowhere on the map. Customers cannot find what Google will not show. I walk through the real reasons your Google Business Profile disappears, from suspensions to NAP mismatches and how to get it ranking again.
+
+https://hudsondigitalsolutions.com/blog/why-google-business-profile-not-showing-up
+
+#LocalSEO #GoogleBusinessProfile #DallasFortWorth
+```
+
+### 7:00 PM CT  -  #85  Tip Calculator and Bill Splitting Made Simple
+
+```
+Splitting a check four ways at the table while the line backs up is dead time you are not getting paid for. Faster math means faster turnover. Here is how to handle tips and split bills in seconds, plus a free calculator you can use right now.
+
+https://hudsondigitalsolutions.com/blog/tip-calculation-and-bill-splitting
+
+#SmallBusiness #Productivity #DFW
+```
+
+## 2026-07-19 (Sun)
+
+### 7:00 AM CT  -  #86  Next.js vs WordPress: Why We Build on Next.js
+
+```
+WordPress runs a third of the web and a good chunk of it loads like dial-up. I stopped building on it for a reason. Here is the honest comparison of Next.js vs WordPress: speed, tracking and what each one actually costs a DFW business over three years.
+
+https://hudsondigitalsolutions.com/blog/why-we-build-on-nextjs-not-wordpress
+
+#WebDevelopment #NextJS #DallasFortWorth
+```
+
+### 1:00 PM CT  -  #87  Word Counter: Counts That Actually Matter
+
+```
+A meta description that runs too long gets cut off in Google. An ad headline over the limit gets rejected. Word and character counts are not busywork, they decide whether your copy even shows up. Here are the counts that matter and a free tool to hit them.
+
+https://hudsondigitalsolutions.com/blog/word-and-character-counts-that-matter
+
+#ContentMarketing #SEO #DFW
+```

--- a/scripts/blog/dump-posts.ts
+++ b/scripts/blog/dump-posts.ts
@@ -1,0 +1,23 @@
+/**
+ * One-off: emit JSON of every PUBLISHED post (slug, title, excerpt, keyword,
+ * tags, pillar) for the social-caption workflow. Read-only.
+ */
+import { listPostFiles, parsePost } from './lib'
+
+const SITE = 'https://hudsondigitalsolutions.com'
+
+const posts = listPostFiles()
+	.map(parsePost)
+	.filter(p => p.data.published)
+	.map(p => ({
+		slug: p.slug,
+		title: p.data.title,
+		excerpt: p.data.excerpt ?? '',
+		keyword: p.data.targetKeyword ?? '',
+		tags: p.data.tags ?? [],
+		pillar: p.data.pillar ?? 0,
+		url: `${SITE}/blog/${p.slug}`
+	}))
+	.sort((a, b) => a.slug.localeCompare(b.slug))
+
+process.stdout.write(`${JSON.stringify(posts)}\n`)

--- a/scripts/blog/social-doc.ts
+++ b/scripts/blog/social-doc.ts
@@ -1,0 +1,65 @@
+/**
+ * Render the final Facebook schedule (/tmp/hds-fb-final.json) into durable
+ * artifacts: a CSV (record / potential import) and a readable MD checklist.
+ *   bun run scripts/blog/social-doc.ts
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+
+interface Row {
+	order: number
+	date: string
+	weekday: string
+	time: string
+	slug: string
+	title: string
+	url: string
+	pillar: number
+	caption: string
+}
+
+const rows: Row[] = JSON.parse(readFileSync('/tmp/hds-fb-final.json', 'utf8'))
+mkdirSync('.planning/social', { recursive: true })
+
+// CSV (quote every field; double internal quotes; newlines stay inside quotes).
+const q = (s: string) => `"${String(s).replace(/"/g, '""')}"`
+const csv = [
+	'order,date,weekday,time_ct,slug,url,caption',
+	...rows.map(r =>
+		[r.order, r.date, r.weekday, r.time, r.slug, r.url, r.caption]
+			.map(v => q(String(v)))
+			.join(',')
+	)
+].join('\n')
+writeFileSync('.planning/social/facebook-schedule.csv', `${csv}\n`)
+
+// MD checklist grouped by date.
+const byDate = new Map<string, Row[]>()
+for (const r of rows) {
+	const arr = byDate.get(r.date) ?? []
+	arr.push(r)
+	byDate.set(r.date, arr)
+}
+const md: string[] = [
+	'# Facebook posting schedule (v9 blog campaign)',
+	'',
+	`${rows.length} posts, 3/day at 7:00 AM / 1:00 PM / 7:00 PM Central, ${rows[0]?.date} to ${rows[rows.length - 1]?.date}.`,
+	"Each links a live blog post; captions in Richard's voice, verified clean (no emoji/dash/comma-before-and/AI-tells).",
+	''
+]
+for (const [date, items] of byDate) {
+	md.push(`## ${date} (${items[0]?.weekday})`)
+	for (const r of items) {
+		md.push('')
+		md.push(`### ${r.time} CT  -  #${r.order}  ${r.title}`)
+		md.push('')
+		md.push('```')
+		md.push(r.caption)
+		md.push('```')
+	}
+	md.push('')
+}
+writeFileSync('.planning/social/facebook-schedule.md', md.join('\n'))
+
+console.warn(
+	`wrote .planning/social/facebook-schedule.csv + .md (${rows.length} posts)`
+)

--- a/scripts/blog/social-prompt.ts
+++ b/scripts/blog/social-prompt.ts
@@ -1,0 +1,73 @@
+/**
+ * Build a fully self-contained prompt for a browser-automation agent that does
+ * NOT have local file access: embeds all 87 captions + the Meta Business Suite
+ * scheduling instructions inline. Writes .planning/social/facebook-agent-prompt.md
+ *   bun run scripts/blog/social-prompt.ts
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+
+interface Row {
+	order: number
+	caption: string
+}
+
+const rows: Row[] = JSON.parse(readFileSync('/tmp/hds-fb-final.json', 'utf8'))
+
+const header = `# Task: schedule 87 Facebook posts in Meta Business Suite
+
+You are a browser-automation agent. Chrome is already open and logged in to Meta
+Business Suite (business.facebook.com) for the Facebook Page "Hudson Digital
+Solutions". Schedule the 87 posts listed at the end, IN THE GIVEN ORDER.
+
+## Scheduling cadence
+Post 3 per day at these US Central times: 7:00 AM, 1:00 PM, and 7:00 PM.
+Assign posts to slots in order: POST 1 to the earliest open slot, POST 2 to the
+next, and so on. Start from the next available slot from right now (if a time
+today has already passed, skip it and use the next one). Continue day by day
+until all 87 are scheduled (about 30 days out).
+
+## Steps for EACH post (Meta Business Suite)
+1. Click "Create post".
+2. Confirm "Post to" is the "Hudson Digital Solutions" Facebook page; select it if not.
+3. Click the post text box and enter the caption EXACTLY as given (it already
+   includes the blog link and hashtags). Wait a few seconds for the link
+   preview card to load under the text. It should show a branded card with the
+   HUDSON logo and the article title (not a headshot).
+4. If a hashtag suggestion dropdown appears, press Escape to dismiss it.
+5. Scroll down to the "Schedule" section and turn ON "Set date and time".
+6. Set the Date to this slot's date.
+7. Set the Time to this slot's time. IMPORTANT: the time control has separate
+   Hours, Minutes, and AM/PM fields and is finicky. After setting it, VERIFY it
+   reads the exact target (e.g. "07:00 AM"). If it shows anything else, correct
+   it (clear and re-enter, or use the up/down arrows on each segment). Do NOT
+   continue until the displayed time is exactly right.
+8. Make sure "Share to ... Facebook story" is OFF (do not cross-post to Story).
+9. Leave Privacy as "Public".
+10. Click "Schedule" (NEVER "Publish" - do not post immediately).
+11. If a "Boost post" / advertising upsell appears, click "Maybe later" or close
+    it. NEVER click "Boost" and never spend any money.
+12. Go back and create the next post.
+
+## Hard rules
+- Always SCHEDULE for the future; never publish immediately.
+- Never boost, never run ads, never spend money - decline every paid upsell.
+- Only ever post to the "Hudson Digital Solutions" Facebook page.
+- Verify each scheduled time is exactly correct before moving on.
+- Use the captions verbatim. Do not edit them, add emojis, or change hashtags.
+- If a post titled "5 Signs Your Website is Costing You Customers" (POST 1) is
+  already published on the page, skip POST 1.
+- After every ~10 posts, glance at the calendar/Planner to confirm they are
+  appearing as scheduled posts at the right times.
+
+## The 87 posts (schedule in this order)
+`
+
+const body = rows
+	.sort((a, b) => a.order - b.order)
+	.map(r => `\n----- POST ${r.order} -----\n${r.caption}\n`)
+	.join('')
+
+writeFileSync('.planning/social/facebook-agent-prompt.md', `${header}${body}\n`)
+console.warn(
+	`wrote .planning/social/facebook-agent-prompt.md (${rows.length} posts)`
+)

--- a/scripts/blog/social-schedule.ts
+++ b/scripts/blog/social-schedule.ts
@@ -1,0 +1,118 @@
+/**
+ * Build the Facebook posting schedule skeleton: take the 87 published posts,
+ * interleave them across content pillars (so consecutive posts vary by topic),
+ * and assign 3 slots/day at 7:00 AM / 1:00 PM / 7:00 PM Central starting from
+ * the next valid future slot. Emits JSON consumed by the caption workflow.
+ *
+ *   bun run scripts/blog/social-schedule.ts <startISO> <nowISO> > out.json
+ *   startISO: first calendar day, e.g. 2026-06-20
+ *   nowISO:   current Central time 'YYYY-MM-DDTHH:MM' to skip past slots today
+ */
+import { readFileSync } from 'node:fs'
+
+interface Post {
+	slug: string
+	title: string
+	excerpt: string
+	keyword: string
+	tags: string[]
+	pillar: number
+	url: string
+}
+
+const POSTS: Post[] = JSON.parse(readFileSync('/tmp/hds-posts.json', 'utf8'))
+const startDay = process.argv[2] ?? '2026-06-20'
+const nowStr = process.argv[3] ?? `${startDay}T00:00`
+
+// Slot times in Central, as [hour24, label].
+const SLOTS: Array<[number, string]> = [
+	[7, '7:00 AM'],
+	[13, '1:00 PM'],
+	[19, '7:00 PM']
+]
+
+// Round-robin interleave across pillars so the feed mixes topics.
+function interleave(posts: Post[]): Post[] {
+	const byPillar = new Map<number, Post[]>()
+	for (const p of [...posts].sort((a, b) => a.slug.localeCompare(b.slug))) {
+		const arr = byPillar.get(p.pillar) ?? []
+		arr.push(p)
+		byPillar.set(p.pillar, arr)
+	}
+	const pillars = [...byPillar.keys()].sort((a, b) => a - b)
+	const out: Post[] = []
+	let remaining = posts.length
+	while (remaining > 0) {
+		for (const pl of pillars) {
+			const arr = byPillar.get(pl)
+			if (arr && arr.length > 0) {
+				const next = arr.shift()
+				if (next) {
+					out.push(next)
+					remaining--
+				}
+			}
+		}
+	}
+	return out
+}
+
+function pad(n: number): string {
+	return String(n).padStart(2, '0')
+}
+function parseYMD(iso: string): [number, number, number] {
+	const parts = iso.split('-')
+	return [Number(parts[0]), Number(parts[1]), Number(parts[2])]
+}
+function addDays(iso: string, days: number): string {
+	const [y, m, d] = parseYMD(iso)
+	const dt = new Date(Date.UTC(y, m - 1, d + days))
+	return `${dt.getUTCFullYear()}-${pad(dt.getUTCMonth() + 1)}-${pad(dt.getUTCDate())}`
+}
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+function weekday(iso: string): string {
+	const [y, m, d] = parseYMD(iso)
+	return WEEKDAYS[new Date(Date.UTC(y, m - 1, d)).getUTCDay()] ?? ''
+}
+
+const ordered = interleave(POSTS)
+
+// Walk day/slot, skipping any slot on the first day already in the past.
+const nowDay = nowStr.slice(0, 10)
+const nowHour = Number(nowStr.slice(11, 13))
+const rows: Array<Record<string, unknown>> = []
+let day = startDay
+let i = 0
+while (i < ordered.length) {
+	for (const [hour, label] of SLOTS) {
+		if (i >= ordered.length) {
+			break
+		}
+		// Skip past slots on the current day (need a future slot).
+		if (day === nowDay && hour <= nowHour) {
+			continue
+		}
+		const p = ordered[i]
+		if (!p) {
+			break
+		}
+		rows.push({
+			order: i + 1,
+			date: day,
+			weekday: weekday(day),
+			time: label,
+			hour24: hour,
+			slug: p.slug,
+			title: p.title,
+			excerpt: p.excerpt,
+			keyword: p.keyword,
+			tags: p.tags,
+			pillar: p.pillar,
+			url: p.url
+		})
+		i++
+	}
+	day = addDays(day, 1)
+}
+
+process.stdout.write(`${JSON.stringify(rows)}\n`)

--- a/scripts/blog/verify-captions.ts
+++ b/scripts/blog/verify-captions.ts
@@ -1,0 +1,95 @@
+/**
+ * Verify the generated Facebook captions against the brand rules. Reads
+ * /tmp/hds-schedule-base.json + /tmp/hds-cap/<order>.json and reports any
+ * caption that breaks a rule, plus assembles /tmp/hds-fb-final.json on success.
+ *   bun run scripts/blog/verify-captions.ts
+ */
+import { readFileSync, writeFileSync } from 'node:fs'
+import { countCommaBeforeAnd, findAiTells } from './voice'
+
+interface BaseRow {
+	order: number
+	date: string
+	weekday: string
+	time: string
+	hour24: number
+	slug: string
+	title: string
+	url: string
+	pillar: number
+}
+interface Cap {
+	order: number
+	slug: string
+	caption: string
+}
+
+const base: BaseRow[] = JSON.parse(
+	readFileSync('/tmp/hds-schedule-base.json', 'utf8')
+)
+const EMOJI =
+	/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2300}-\u{23FF}\u{2B00}-\u{2BFF}\u{2190}-\u{21FF}]|\u{FE0F}/u
+const DASH = /[‒-―−]|—|–/
+
+let failures = 0
+const final: Array<BaseRow & { caption: string }> = []
+
+for (const row of base) {
+	const path = `/tmp/hds-cap/${row.order}.json`
+	const issues: string[] = []
+	let cap: Cap | null = null
+	try {
+		cap = JSON.parse(readFileSync(path, 'utf8')) as Cap
+	} catch {
+		issues.push('MISSING or invalid JSON')
+	}
+	if (cap) {
+		const c = cap.caption ?? ''
+		if (cap.slug !== row.slug) {
+			issues.push(`slug mismatch (${cap.slug})`)
+		}
+		if (!c.includes(row.url)) {
+			issues.push('missing correct url')
+		}
+		if (EMOJI.test(c)) {
+			issues.push('emoji')
+		}
+		if (DASH.test(c)) {
+			issues.push('em/en dash')
+		}
+		const commas = countCommaBeforeAnd(c)
+		if (commas > 0) {
+			issues.push(`${commas}x comma-before-and`)
+		}
+		const tells = findAiTells(c)
+		if (tells.length) {
+			issues.push(`AI tells: ${tells.join(', ')}`)
+		}
+		const hashtags = (c.match(/#[A-Za-z0-9]+/g) ?? []).length
+		if (hashtags < 2 || hashtags > 3) {
+			issues.push(`${hashtags} hashtags`)
+		}
+		if (c.length > 600) {
+			issues.push(`len ${c.length}`)
+		}
+		if (c.length < 60) {
+			issues.push(`too short (${c.length})`)
+		}
+		if (issues.length === 0) {
+			final.push({ ...row, caption: c })
+		}
+	}
+	if (issues.length) {
+		failures++
+		console.warn(`FAIL order ${row.order} (${row.slug}): ${issues.join('; ')}`)
+	}
+}
+
+console.warn(
+	`\nverify-captions: ${base.length - failures}/${base.length} clean, ${failures} failed`
+)
+if (failures === 0) {
+	final.sort((a, b) => a.order - b.order)
+	writeFileSync('/tmp/hds-fb-final.json', JSON.stringify(final, null, 2))
+	console.warn(`wrote /tmp/hds-fb-final.json (${final.length} rows)`)
+}


### PR DESCRIPTION
Lint-clean generator scripts + their outputs in .planning/social/: 87 captions, the 3/day schedule (md/csv), and the self-contained browser-agent prompt used to schedule all 87 posts on the HDS Facebook page.

[hudsor01]