### PR TITLE
content(voice): migrate core marketing pages into Richard's voice

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -88,9 +88,9 @@ export default function AboutPage() {
 						Built Around Your Business
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						Where real business experience meets the skill to build it. I make
-						small businesses a website that does justice to the reputation
-						they&apos;ve already earned.
+						I spent 5+ years in revenue operations before I built websites. Now
+						I build DFW small businesses a site that earns its keep and does
+						justice to the reputation you already have.
 					</p>
 				</div>
 			</section>
@@ -106,8 +106,8 @@ export default function AboutPage() {
 							The Experience Behind Your Website
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							I build websites the way a business owner thinks. Every choice is
-							measured against whether it brings customers in.
+							I build the way a business owner thinks. Every choice gets
+							measured against one thing: does it bring customers in.
 						</p>
 					</div>
 
@@ -115,46 +115,42 @@ export default function AboutPage() {
 						{/* Story Content */}
 						<div className="rounded-xl border border-border bg-surface-raised p-8 hover:border-border-strong transition-colors">
 							<h3 className="text-h3 text-foreground mb-4">
-								Built in Revenue Operations, Refined in Practice
+								Five Years in Revenue Operations First
 							</h3>
 							<div className="space-y-4 text-sm text-muted-foreground leading-relaxed">
 								<p>
-									Most agencies learned web development in bootcamps. I learned
-									it in the trenches of revenue operations, where every decision
-									either moves the business forward or holds it back.
+									Most agencies learned web development in a bootcamp. I learned
+									revenue first. I spent 5+ years in revenue operations running
+									Salesforce, Power BI, Workato and HubSpot, where every
+									decision either moved the number or it did not.
 								</p>
 								<p>
-									With{' '}
-									<strong className="text-accent">
-										hands-on revenue experience
-									</strong>{' '}
-									across growing businesses, I discovered something agencies
-									miss:{' '}
+									Working that close to the{' '}
+									<strong className="text-accent">numbers</strong> taught me
+									something most agencies miss:{' '}
 									<strong className="text-info">
-										websites fail not because of bad code, but because they were
-										never built to bring in customers, just to look nice
+										websites do not fail on bad code. They fail because nobody
+										built them to bring in customers. They were built to look
+										nice
 									</strong>
 									.
 								</p>
 								<p>
-									That&apos;s why my clients see{' '}
-									<strong className="text-accent">
-										real, measurable results
-									</strong>{' '}
-									in months, not years. I don&apos;t just launch a{' '}
+									So my clients see{' '}
+									<strong className="text-accent">measurable results</strong> in
+									months, not years. I do not launch a{' '}
 									<Link href="/services" className="link-primary font-semibold">
 										professional website
 									</Link>{' '}
-									and walk away. Every page is built and measured against one
-									question:{' '}
+									and walk away. Every page gets measured against one question:{' '}
 									<strong className="text-success-text">
-										does this help your business get and keep customers?
+										does this help you get and keep customers?
 									</strong>
 								</p>
 								<p className="text-foreground font-semibold">
-									I&apos;m not another agency selling &quot;beautiful
-									websites&quot; that sit there doing nothing. I build websites
-									that earn their keep.{' '}
+									I am not another agency selling &quot;beautiful websites&quot;
+									that sit there doing nothing. I build a website that earns its
+									keep.{' '}
 									<Link href="/contact" className="link-primary">
 										Let&apos;s talk about your project
 									</Link>
@@ -173,11 +169,10 @@ export default function AboutPage() {
 									<h3 className="text-h3 text-foreground">My Mission</h3>
 								</div>
 								<p className="text-sm text-muted-foreground leading-relaxed">
-									Make a great website accessible to every small business. No
-									small business should have to choose between a site
-									that&apos;s cheap but embarrassing and one that&apos;s great
-									but unaffordable. You get a professional site that brings in
-									customers, at a fair price.
+									Put a real website in reach of every small business. No owner
+									should have to pick between a site that is cheap and
+									embarrassing and one that is great and unaffordable. You get a
+									professional site that brings in customers, at a fair price.
 								</p>
 							</div>
 
@@ -189,13 +184,13 @@ export default function AboutPage() {
 									<h3 className="text-h3 text-foreground">My Guarantee</h3>
 								</div>
 								<p className="text-sm text-muted-foreground leading-relaxed">
-									If the KPI I agree to with you at kickoff (typically
-									conversion rate, qualified leads per month, or revenue per
-									visitor) doesn&apos;t improve over its installed-analytics
-									baseline within 90 days, I keep working (up to 3 additional
-									revision rounds covering optimization scope) at no extra cost
-									until it does. Baseline is measured from analytics installed
-									on day one of the engagement.
+									We agree on one KPI at kickoff (usually conversion rate,
+									qualified leads per month, or revenue per visitor). If it does
+									not beat its installed-analytics baseline within 90 days, I
+									keep working at no extra cost until it does, up to 3 added
+									revision rounds covering optimization scope. The baseline is
+									measured from analytics installed on day one of the
+									engagement.
 								</p>
 							</div>
 						</div>
@@ -214,8 +209,8 @@ export default function AboutPage() {
 							What I Build With
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Proven tools. Modern technology. Everything chosen because it
-							delivers results for business owners.
+							Proven tools, modern tech. I pick each one because it gets results
+							for the owner, not because it is trendy.
 						</p>
 					</div>
 
@@ -288,9 +283,9 @@ export default function AboutPage() {
 							The Builder Behind the Work
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Why trust a former revenue operations professional to build your
-							website? Because I understand something most agencies don&apos;t:
-							a website is only worth what it brings in.
+							Why hand your website to a former revenue operations guy? Because
+							I know something most agencies do not: a website is only worth
+							what it brings in.
 						</p>
 					</div>
 
@@ -313,31 +308,29 @@ export default function AboutPage() {
 						</div>
 						<div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
 							<p className="text-base">
-								Before building for clients, I spent 5+ years in{' '}
+								Before I built for clients, I spent 5+ years in{' '}
 								<strong className="text-accent">revenue operations</strong> at
-								established companies, close enough to the numbers to see
-								exactly which websites{' '}
+								established companies. Salesforce, Power BI, Workato, HubSpot.
+								Close enough to the numbers to see exactly which sites{' '}
 								<strong className="text-accent">brought in customers</strong>{' '}
 								and which just looked nice.
 							</p>
 
 							<p className="text-base">
-								Here&apos;s what I learned:{' '}
+								Same job, same lesson every time:{' '}
 								<strong className="text-info">
-									most websites fail not because of bad technology, but because
-									they were never built to bring in customers
+									most websites fail not on the technology but because nobody
+									built them to bring in customers
 								</strong>
-								. Agencies charge $50K for a beautiful site the owner can&apos;t
-								even update. I build small businesses a professional website
-								they control, one that turns the reputation they&apos;ve already
-								earned into booked customers.
+								. Agencies charge $50K for a pretty site the owner cannot even
+								update. I build a professional website you control, one that
+								turns the reputation you already have into booked customers.
 							</p>
 
 							<p className="text-base">
-								When I saw how many great local businesses had glowing reviews
-								but no website (or one so dated it cost them customers), I knew
-								where I could help. Hudson Digital Solutions exists to fix
-								exactly that:{' '}
+								I kept seeing great DFW businesses with glowing reviews and no
+								website, or one so dated it was costing them customers. That is
+								the gap I fill. Hudson Digital Solutions exists to fix it:{' '}
 								<strong className="text-accent">
 									a professional website, built around how your business
 									actually works
@@ -346,9 +339,8 @@ export default function AboutPage() {
 							</p>
 
 							<blockquote className="text-base text-foreground font-bold border-l-4 border-accent pl-6 py-4 bg-accent/5">
-								&quot;I don&apos;t care how beautiful your website is if it
-								doesn&apos;t bring in customers. Build results or build
-								nothing.&quot;
+								&quot;I do not care how pretty your website is if it does not
+								bring in customers. Build results or build nothing.&quot;
 							</blockquote>
 
 							<div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6 mt-8 pt-8 border-t border-border">
@@ -391,7 +383,7 @@ export default function AboutPage() {
 							How I Work
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							The core beliefs behind every website I build.
+							The rules I build every website by.
 						</p>
 					</div>
 
@@ -404,9 +396,8 @@ export default function AboutPage() {
 								Performance First
 							</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								Every millisecond matters. I build for speed because fast sites
-								convert better, rank higher, and deliver a better experience for
-								your customers.
+								Every millisecond counts. I build for speed because fast sites
+								convert better, rank higher and feel better to your customers.
 							</p>
 						</div>
 
@@ -416,9 +407,9 @@ export default function AboutPage() {
 							</div>
 							<h3 className="text-h3 text-foreground mb-3">Data Driven</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								Assumptions kill businesses. Every decision is backed by data,
-								every feature is measured, and every optimization is validated
-								against real results.
+								Guessing kills businesses. Data backs every decision, every
+								feature gets measured and every change is checked against real
+								results.
 							</p>
 						</div>
 
@@ -430,8 +421,9 @@ export default function AboutPage() {
 								Built to Grow With You
 							</h3>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								I build for growth. Your website and systems grow with your
-								business, no expensive rebuilds when you scale.
+								I build for growth. Your site and your booking and payment
+								systems scale with the business, so no costly rebuild when you
+								get bigger.
 							</p>
 						</div>
 					</div>
@@ -455,8 +447,8 @@ export default function AboutPage() {
 							</h2>
 
 							<p className="text-lead text-muted-foreground max-w-2xl mx-auto mb-10">
-								Let&apos;s map out the website your business needs, and build
-								you something that turns the reputation you&apos;ve earned into
+								Let&apos;s map out the website your business actually needs and
+								build you something that turns the reputation you have into
 								booked customers.
 							</p>
 

--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -88,9 +88,9 @@ export default function AboutPage() {
 						Built Around Your Business
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						I spent 5+ years in revenue operations before I built websites. Now
-						I build DFW small businesses a site that earns its keep and does
-						justice to the reputation you already have.
+						I spent nearly a decade in revenue operations before I built
+						websites. Now I build DFW small businesses a site that earns its
+						keep and does justice to the reputation you already have.
 					</p>
 				</div>
 			</section>
@@ -115,13 +115,13 @@ export default function AboutPage() {
 						{/* Story Content */}
 						<div className="rounded-xl border border-border bg-surface-raised p-8 hover:border-border-strong transition-colors">
 							<h3 className="text-h3 text-foreground mb-4">
-								Five Years in Revenue Operations First
+								Nearly a Decade in Revenue Operations First
 							</h3>
 							<div className="space-y-4 text-sm text-muted-foreground leading-relaxed">
 								<p>
 									Most agencies learned web development in a bootcamp. I learned
-									revenue first. I spent 5+ years in revenue operations running
-									Salesforce, Power BI, Workato and HubSpot, where every
+									revenue first. I spent nearly a decade in revenue operations
+									running Salesforce, Power BI, Workato and HubSpot, where every
 									decision either moved the number or it did not.
 								</p>
 								<p>
@@ -308,7 +308,7 @@ export default function AboutPage() {
 						</div>
 						<div className="space-y-6 text-sm text-muted-foreground leading-relaxed">
 							<p className="text-base">
-								Before I built for clients, I spent 5+ years in{' '}
+								Before I built for clients, I spent nearly a decade in{' '}
 								<strong className="text-accent">revenue operations</strong> at
 								established companies. Salesforce, Power BI, Workato, HubSpot.
 								Close enough to the numbers to see exactly which sites{' '}
@@ -345,25 +345,27 @@ export default function AboutPage() {
 
 							<div className="grid sm:grid-cols-2 md:grid-cols-3 gap-6 mt-8 pt-8 border-t border-border">
 								<div className="text-center">
-									<div className="text-3xl font-black text-accent mb-1">5+</div>
+									<div className="text-3xl font-black text-accent mb-1">
+										2,200%
+									</div>
 									<div className="text-sm text-muted-foreground">
-										Years in Rev Ops
+										Partner growth scaled
 									</div>
 								</div>
 								<div className="text-center">
 									<div className="text-3xl font-black text-accent mb-1">
-										10+
+										95%
 									</div>
 									<div className="text-sm text-muted-foreground">
-										Businesses Served
+										Forecast accuracy
 									</div>
 								</div>
 								<div className="text-center">
 									<div className="text-3xl font-black text-accent mb-1">
-										Measurable
+										$3.7M
 									</div>
 									<div className="text-sm text-muted-foreground">
-										Revenue Impact
+										Pipeline driven
 									</div>
 								</div>
 							</div>

--- a/src/app/(public)/contact/page.tsx
+++ b/src/app/(public)/contact/page.tsx
@@ -7,11 +7,11 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/contact' },
 	title: 'Get a Free Website Plan | Hudson Digital Solutions',
 	description:
-		"Tell us about your business and we'll map out the website it needs (pages, timeline, and cost) on a free 30-minute call. No sales pitch.",
+		"Tell me about your business and I'll map the website it needs: pages, timeline and a real price. Free 30-minute call. No pitch. I reply in 2 hours.",
 	openGraph: {
 		title: 'Free Website Plan in 30 Minutes | Hudson Digital',
 		description:
-			'A free 30-minute call where we map out the website your business needs: pages, timeline, and cost. No sales pitch. Response in 2 hours.'
+			'A free 30-minute call where I map the website your business needs: pages, timeline and price. No pitch. I reply within 2 hours.'
 	}
 }
 
@@ -84,9 +84,9 @@ export default function ContactPage() {
 									Get Your Free Website Plan
 								</h1>
 								<p className="mt-4 text-lead text-muted-foreground">
-									Tell us about your business. We&apos;ll map out the website it
-									needs (pages, timeline, and cost) on a free 30-minute call. No
-									sales pitch. No commitment.
+									Tell me about your business. I&apos;ll map the website it
+									needs: the pages, the timeline and a real price, on a free
+									30-minute call. No pitch. No commitment.
 								</p>
 							</div>
 
@@ -105,10 +105,10 @@ export default function ContactPage() {
 									</div>
 									<div>
 										<p className="font-semibold text-foreground text-sm">
-											We respond within 2 hours
+											I reply within 2 hours
 										</p>
 										<p className="text-xs text-muted-foreground mt-0.5">
-											Get a confirmation email with next steps
+											You get a confirmation email with next steps
 										</p>
 									</div>
 								</div>
@@ -122,7 +122,8 @@ export default function ContactPage() {
 											30-minute website call
 										</p>
 										<p className="text-xs text-muted-foreground mt-0.5">
-											We learn your business and map out what your site needs
+											I learn how your business makes money and map what the
+											site needs to do
 										</p>
 									</div>
 								</div>
@@ -136,7 +137,7 @@ export default function ContactPage() {
 											Get your website plan
 										</p>
 										<p className="text-xs text-muted-foreground mt-0.5">
-											Pages, timeline, and a clear price, yours to keep, no
+											Pages, timeline and a clear price. Yours to keep, no
 											obligation
 										</p>
 									</div>
@@ -229,11 +230,11 @@ export default function ContactPage() {
 						    those signals and with the site's TX-headquartered
 						    address (1301 Cherry Hill Ln, Lewisville, TX 75067). */}
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							Dallas-Fort Worth headquarters. Remote across the South.
+							Based in Dallas-Fort Worth. Working across the South.
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Local-first in the DFW metroplex; remote-capable across TX, FL,
-							GA, OK, and the surrounding states.
+							I work local-first in the DFW metroplex and remote across TX, FL,
+							GA, OK and the states around them.
 						</p>
 					</div>
 

--- a/src/app/(public)/faq/FaqClient.tsx
+++ b/src/app/(public)/faq/FaqClient.tsx
@@ -19,22 +19,22 @@ const faqs = [
 			{
 				question: 'What website design services do you offer?',
 				answer:
-					'We design and build professional websites for small businesses: custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
+					'I build websites for small businesses in Dallas-Fort Worth that bring in work: custom design, fast, mobile-first and built to show up on Google. Once your site is live, I wire in booking, payments and customer follow-up so the leads it generates turn into paying customers.'
 			},
 			{
 				question: 'How much does it cost to build a website?',
 				answer:
-					'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call. We will walk you through options that fit your budget.'
+					'Every project is priced to what you actually need, so it comes down to page count, features and timeline. The fastest way to a real number is our free Cost Estimator tool or a free website plan call. I will walk you through options that fit your budget. No surprise line items later.'
 			},
 			{
 				question: 'Do you offer monthly retainer packages?',
 				answer:
-					'Yes. We offer ongoing maintenance and support retainers that include regular updates, security patches, performance monitoring, feature additions, and priority support. Perfect for businesses that need continuous support without hiring in-house. Contact us to discuss a package that fits your needs.'
+					'Yes. I keep sites running with monthly retainers: updates, security patches, performance checks, new features and priority support. It is for owners who want the site handled without hiring someone in-house. Reach out and I will scope a package to what your business actually needs.'
 			},
 			{
 				question: 'What is your typical project timeline?',
 				answer:
-					'Timelines depend on project scope. Simple websites take 4 to 6 weeks. E-commerce and booking-enabled sites take 8 to 12 weeks. Larger sites with custom features and booking or payment setup typically take 3 to 6 months. We can expedite urgent projects with dedicated resources.'
+					'Depends on scope. A simple site runs 4 to 6 weeks. Add online store or booking and it is 8 to 12 weeks. Bigger builds with custom features and payment setup run 3 to 6 months. If you are on a deadline, I can put dedicated time on it and move faster.'
 			}
 		]
 	},
@@ -44,22 +44,22 @@ const faqs = [
 			{
 				question: 'What is your development process?',
 				answer:
-					'Our process includes: 1) Discovery call to understand your business and goals, 2) Detailed proposal with timeline and milestones, 3) Design phase with mockups for approval, 4) Build phase with weekly progress updates, 5) Testing and quality checks, 6) Launch and go-live, 7) Training and handoff, 8) Ongoing support and maintenance.'
+					'Eight steps, no mystery: 1) a discovery call to learn your business and goals, 2) a detailed proposal with timeline and milestones, 3) design with mockups you sign off on, 4) the build with weekly progress updates, 5) testing and quality checks, 6) launch and go-live, 7) training and handoff, 8) ongoing support. You always know what is next.'
 			},
 			{
 				question: 'How often will we communicate during the project?',
 				answer:
-					"We provide weekly progress updates via email or video call. You'll have access to a shared project management board to track progress in real-time. For urgent matters, we're available via Slack or email within 2 hours during business hours."
+					'You get a progress update every week by email or video call and a shared board so you can see exactly where things stand any time. Need me fast? Slack or email gets a reply within 2 hours during business hours.'
 			},
 			{
 				question: 'Can I make changes to the project after it starts?',
 				answer:
-					'Yes, we understand requirements evolve. Minor changes are included in the project scope. Major changes that affect timeline or budget will be discussed and approved before implementation. We plan for flexibility from the start.'
+					'Yes. Plans change once you see the work taking shape. Small tweaks are part of the scope. Anything big enough to move the timeline or budget gets talked through and approved before I touch it. I build in room for that from the start.'
 			},
 			{
 				question: 'Do you sign NDAs?',
 				answer:
-					"Absolutely. We're happy to sign your NDA before discussing confidential project details. We take intellectual property and confidentiality very seriously."
+					'Yes. Send your NDA and I will sign it before we get into anything confidential. Your ideas and your business stay yours.'
 			}
 		]
 	},
@@ -69,27 +69,27 @@ const faqs = [
 			{
 				question: 'What technologies do you use?',
 				answer:
-					"We use modern, proven tools chosen for reliability and speed, not because they're trendy. The specific technology depends on what works best for your business. You don't need to know what's under the hood; you just need it to work."
+					'I use modern, proven tools picked for speed and reliability, not because they are trendy. The exact stack depends on what fits your business. You do not need to know what is under the hood. You need it to load fast, work right and never embarrass you in front of a customer.'
 			},
 			{
 				question: 'Will my website be mobile-friendly?',
 				answer:
-					'Yes, all our websites are fully responsive and mobile-first. We test on actual devices (iOS and Android) to ensure perfect functionality across all screen sizes. Mobile-friendliness is essential for SEO and user experience.'
+					'Yes. Every site I build is mobile-first and fully responsive. I test on real iOS and Android devices, not on a single browser tab. Most of your customers will find you on a phone. Google ranks on mobile first too, so this is not optional.'
 			},
 			{
 				question: 'Do you provide SEO services?',
 				answer:
-					'We build SEO-friendly websites with clean code, fast loading times, proper meta tags, schema markup, and sitemap generation. For ongoing SEO, content strategy, and link building, we can recommend trusted SEO partners.'
+					'Every site I build is set up to be found: clean code, fast load times, proper meta tags, schema markup and a sitemap. Local SEO so DFW customers find you on Google is part of the work. For deep ongoing content and link building, I can point you to partners I trust.'
 			},
 			{
 				question: 'Can you integrate with my existing systems?',
 				answer:
-					'Yes. We connect whatever tools your business already uses: HubSpot, Salesforce, Stripe, your booking system, your email platform. If it has a connection point, we can link it to your website and your workflows.'
+					'Yes. I spent about ten years in revenue operations wiring up HubSpot, Salesforce, Stripe and Workato before I built sites, so connecting tools is home turf. Booking system, email platform, payment processor: if it has a connection point, I can tie it into your site and your workflow.'
 			},
 			{
 				question: 'Do you provide hosting and maintenance?',
 				answer:
-					'We can set up hosting on your preferred platform or recommend one that fits your needs. We offer maintenance packages that include updates, security patches, backups, monitoring, and technical support.'
+					'Yes. I can set you up on the host you prefer or recommend one that fits. And I offer maintenance packages that cover updates, security patches, backups, monitoring and support, so the site keeps running while you run the business.'
 			}
 		]
 	},
@@ -99,22 +99,22 @@ const faqs = [
 			{
 				question: 'How do I get started?',
 				answer:
-					"Schedule a free 30-minute website plan call. We'll discuss your business, your customers, and what your website needs to do for you. After the call, we'll send a detailed plan with exact pricing and deliverables."
+					'Book a free 30-minute website plan call. We talk through your business, your customers and what the site has to do for you. After that I send a detailed plan with exact pricing and deliverables. No pressure, no canned pitch.'
 			},
 			{
 				question: 'Do you work with new businesses?',
 				answer:
-					"Absolutely. We understand fast timelines, tight budgets, and the need for quick wins. We help new businesses get their digital foundation right from day one, so you're not paying to redo it later."
+					'Yes, plenty of them. I get the tight budgets, the fast timelines and the need for early wins. I help new businesses get the foundation right on day one so you are not paying to rip it out and redo it in a year.'
 			},
 			{
 				question: 'What payment terms do you offer?',
 				answer:
-					'For fixed-price projects, we typically split payments: 50% upfront, 25% at midpoint, 25% at completion. For retainers, we bill monthly. We accept bank transfers, credit cards, and PayPal.'
+					'On fixed-price projects I usually split it 50% up front, 25% at the midpoint and 25% at completion. Retainers are billed monthly. I take bank transfers, credit cards and PayPal.'
 			},
 			{
 				question: 'Do you offer guarantees?',
 				answer:
-					"Yes. We guarantee our work meets the specifications outlined in the proposal. If something doesn't work as promised, we'll fix it at no additional cost. We also offer a 30-day bug-fix warranty after launch."
+					'Yes. I stand behind what is in the proposal. If something does not work the way I promised, I fix it at no extra cost and you get a 30-day bug-fix warranty after launch on top of that.'
 			}
 		]
 	}
@@ -158,8 +158,8 @@ export default function FaqClient() {
 					</h1>
 
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-8">
-						Everything you need to know about working with us: websites,
-						pricing, process, and timelines.
+						Straight answers about working with me: websites, pricing, process
+						and timelines.
 					</p>
 
 					{/* Search */}
@@ -236,8 +236,8 @@ export default function FaqClient() {
 								Still Have Questions?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Get a free website plan. We&apos;ll map out what your site needs
-								and answer every question along the way.
+								Get a free website plan. I&apos;ll map out exactly what your
+								site needs and answer every question you have along the way.
 							</p>
 							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">

--- a/src/app/(public)/faq/page.tsx
+++ b/src/app/(public)/faq/page.tsx
@@ -10,11 +10,11 @@ import FaqClient from './FaqClient'
 export const metadata: Metadata = {
 	title: 'Frequently Asked Questions | Hudson Digital Solutions',
 	description:
-		'Answers to common questions about our small business website design and development: pricing, process, timelines, and what is included.',
+		'Real answers about my small business web design in Dallas-Fort Worth: pricing, process, timelines and what every site I build includes.',
 	openGraph: {
 		title: 'Frequently Asked Questions | Hudson Digital Solutions',
 		description:
-			'Common questions about our small business website design and development: pricing, process, timelines, and what every project includes.',
+			'Questions about my small business web design in Dallas-Fort Worth: pricing, process, timelines and what every project I take on includes.',
 		url: 'https://hudsondigitalsolutions.com/faq',
 		images: [
 			{
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
 		card: 'summary_large_image',
 		title: 'Frequently Asked Questions | Hudson Digital Solutions',
 		description:
-			'Common questions about our small business website design and development: pricing, process, timelines, and what every project includes.',
+			'Questions about my small business web design in Dallas-Fort Worth: pricing, process, timelines and what every project I take on includes.',
 		images: ['/HDS-Logo.webp']
 	},
 	alternates: {
@@ -48,7 +48,7 @@ const faqSchema = {
 			name: 'What website design services do you offer?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'We design and build professional websites for small businesses: custom design, mobile-ready, fast, and built to be found on Google. Once your site is live, we can also connect booking, payments, and customer follow-up.'
+				text: 'I build websites for small businesses in Dallas-Fort Worth that bring in work: custom design, fast, mobile-first and built to show up on Google. Once your site is live, I wire in booking, payments and customer follow-up so the leads it generates turn into paying customers.'
 			}
 		},
 		{
@@ -56,7 +56,7 @@ const faqSchema = {
 			name: 'How much does it cost to build a website?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'Every project is scoped to your specific needs, so costs vary based on the number of pages, the features you need, and the timeline. The best way to get a realistic estimate is to use our free Cost Estimator tool or book a free website plan call. We will walk you through options that fit your budget.'
+				text: 'Every project is priced to what you actually need, so it comes down to page count, features and timeline. The fastest way to a real number is our free Cost Estimator tool or a free website plan call. I will walk you through options that fit your budget. No surprise line items later.'
 			}
 		},
 		{
@@ -64,7 +64,7 @@ const faqSchema = {
 			name: 'What is your typical project timeline?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'Timelines depend on project scope. Simple websites take 4 to 6 weeks. E-commerce and booking-enabled sites take 8 to 12 weeks. Larger sites with custom features and booking or payment setup typically take 3 to 6 months. We can expedite urgent projects with dedicated resources.'
+				text: 'Depends on scope. A simple site runs 4 to 6 weeks. Add online store or booking and it is 8 to 12 weeks. Bigger builds with custom features and payment setup run 3 to 6 months. If you are on a deadline, I can put dedicated time on it and move faster.'
 			}
 		},
 		{
@@ -72,7 +72,7 @@ const faqSchema = {
 			name: 'Do you offer monthly retainer packages?',
 			acceptedAnswer: {
 				'@type': 'Answer',
-				text: 'Yes. We offer ongoing maintenance and support retainers that include regular updates, security patches, performance monitoring, feature additions, and priority support. Perfect for businesses that need continuous support without hiring in-house. Contact us to discuss a package that fits your needs.'
+				text: 'Yes. I keep sites running with monthly retainers: updates, security patches, performance checks, new features and priority support. It is for owners who want the site handled without hiring someone in-house. Reach out and I will scope a package to what your business actually needs.'
 			}
 		}
 	]

--- a/src/app/(public)/locations/page.tsx
+++ b/src/app/(public)/locations/page.tsx
@@ -13,10 +13,11 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/locations' },
 	title: 'Service Locations | Hudson Digital Solutions',
 	description:
-		'Hudson Digital Solutions builds websites for small businesses across the US. Find professional web design in your city: Texas, Florida, Georgia, and more.',
+		'I build websites that book jobs and take payments for small businesses across the US. Find local web design in Texas, Florida, Georgia and beyond.',
 	openGraph: {
 		title: 'Service Locations | Hudson Digital Solutions',
-		description: 'Professional web design for small businesses across the US.'
+		description:
+			'Websites that book jobs and take payments for small businesses across the US.'
 	}
 }
 
@@ -45,11 +46,11 @@ export default function LocationsPage() {
 						Service Locations
 					</p>
 					<h1 className="text-page-title text-foreground leading-tight text-balance">
-						Serving Businesses Across the US
+						Building Websites for Businesses Across the US
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						{totalCities} cities across {states.length} states. Find
-						professional web design near you.
+						{totalCities} cities across {states.length} states. Find a web
+						designer who works near you.
 					</p>
 				</div>
 			</section>
@@ -97,8 +98,9 @@ export default function LocationsPage() {
 								Don&apos;t see your city?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								We work with clients remotely across the entire US. Get in touch
-								to discuss your project.
+								I work with clients remotely across the entire US. Tell me what
+								you&apos;re building and I&apos;ll tell you how I&apos;d
+								approach it.
 							</p>
 							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -22,12 +22,12 @@ export const metadata: Metadata = {
 	title: SEO_CONFIG.home?.title ?? 'Hudson Digital Solutions',
 	description:
 		SEO_CONFIG.home?.description ??
-		'Professional website design for small businesses in Dallas-Fort Worth.',
+		'I build Dallas-Fort Worth small businesses fast websites with local SEO and booking that turn your reputation into booked, paying customers.',
 	openGraph: {
 		title: SEO_CONFIG.home?.title ?? 'Hudson Digital Solutions',
 		description:
 			SEO_CONFIG.home?.description ??
-			'Professional website design for small businesses in Dallas-Fort Worth.',
+			'I build Dallas-Fort Worth small businesses fast websites with local SEO and booking that turn your reputation into booked, paying customers.',
 		url: SEO_CONFIG.home?.canonical ?? 'https://hudsondigitalsolutions.com'
 	},
 	twitter: {
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
 		title: SEO_CONFIG.home?.title ?? 'Hudson Digital Solutions',
 		description:
 			SEO_CONFIG.home?.description ??
-			'Professional website design for small businesses in Dallas-Fort Worth.'
+			'I build Dallas-Fort Worth small businesses fast websites with local SEO and booking that turn your reputation into booked, paying customers.'
 	},
 	alternates: {
 		canonical:
@@ -50,11 +50,11 @@ const websiteOutcomes = [
 	},
 	{
 		trigger: 'A customer opens it on their phone',
-		outcome: 'it looks sharp on every screen'
+		outcome: 'it loads fast and looks sharp on every screen'
 	},
 	{
 		trigger: 'Someone wants to reach you',
-		outcome: 'the inquiry hits your inbox instantly'
+		outcome: 'the inquiry lands in your inbox right away'
 	},
 	{
 		trigger: 'A customer is ready to book',
@@ -76,7 +76,7 @@ const solutions = [
 		Icon: Code2,
 		title: 'A Website That Looks the Part',
 		description:
-			'A clean, professional design that matches the quality of your work, so first-time visitors trust you before they ever call. Mobile-ready and fast on every device.',
+			'A clean, professional design that matches the quality of your work, so first-time visitors trust you before they call. Fast on every device, sharp on every phone.',
 		stat: '1-4 wks',
 		statLabel: 'First Delivery',
 		ctaLabel: 'See Recent Work',
@@ -86,17 +86,17 @@ const solutions = [
 		Icon: TrendingUp,
 		title: 'Found When Customers Search',
 		description:
-			'Built to show up when people in your area search for what you do. Proper SEO, fast load times, and the local details Google looks for, so your reputation actually gets seen.',
+			'Built to show up when people in DFW search for what you do. Real local SEO, fast load times and the details Google looks for, so your reputation gets seen by the people nearby.',
 		stat: 'Built in',
 		statLabel: 'local SEO',
-		ctaLabel: 'Read Our SEO Approach',
+		ctaLabel: 'Read My SEO Approach',
 		ctaHref: `${ROUTES.SERVICES}#seo`
 	},
 	{
 		Icon: Settings,
 		title: 'Yours to Control',
 		description:
-			'A simple admin panel means you change your hours, prices, photos, and text yourself, in minutes, no developer, no waiting, no invoice.',
+			'A simple admin panel means you change your hours, prices, photos and text yourself in minutes. No developer, no waiting, no invoice every time you tweak a line.',
 		stat: '$0',
 		statLabel: 'to make edits',
 		ctaLabel: "See What's Included",
@@ -124,15 +124,15 @@ export default function HomePage() {
 						{/* Left — headline + CTAs */}
 						<div className="lg:col-span-3 flex flex-col gap-8">
 							<h1 className="text-page-title text-foreground leading-tight text-balance">
-								Your business earned the reviews. Now it needs the website.
+								You earned the reviews. Now you need the website to match.
 							</h1>
 
 							<p className="text-lead text-muted-foreground max-w-lg text-balance">
 								You&apos;ve got the 5-star ratings and the word-of-mouth. But
 								when someone Googles you, there&apos;s no website to send them
-								to, or one that doesn&apos;t do you justice. We build small
-								businesses a professional website that turns your reputation
-								into booked customers.
+								to, or one that doesn&apos;t do you justice. I build DFW small
+								businesses a fast, professional website that turns your
+								reputation into booked customers.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3">
@@ -191,7 +191,7 @@ export default function HomePage() {
 									<div className="flex items-center gap-2 mb-1">
 										<Zap className="w-3.5 h-3.5 text-accent shrink-0" />
 										<span className="text-xs font-semibold text-foreground uppercase tracking-widest">
-											Everything Your Website Does For You
+											What Your Website Does For You
 										</span>
 									</div>
 									<p className="text-xs text-muted-foreground">
@@ -231,7 +231,7 @@ export default function HomePage() {
 							What You Get
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							A Website That Pulls Its Weight
+							A Website That Earns Its Keep
 						</h2>
 					</div>
 
@@ -276,7 +276,8 @@ export default function HomePage() {
 
 					<p className="text-sm text-muted-foreground text-center mt-8 max-w-2xl mx-auto">
 						Need online booking, payments, or automatic lead follow-up wired in?
-						We handle that too, once your site is doing its job.
+						I spent ten years in revenue operations before building websites, so
+						I handle that part too once your site is doing its job.
 					</p>
 				</div>
 			</section>
@@ -292,7 +293,8 @@ export default function HomePage() {
 							Free Business Tools
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Calculate your potential in 60 seconds. No signup required.
+							Run the numbers on your own business in 60 seconds. No signup, no
+							sales call.
 						</p>
 					</div>
 
@@ -308,7 +310,7 @@ export default function HomePage() {
 								</h3>
 								<p className="text-sm text-muted-foreground leading-relaxed mb-6 flex-1">
 									See how much business you&apos;re leaving on the table with a
-									website that doesn&apos;t convert visitors into customers.
+									website that doesn&apos;t turn visitors into customers.
 								</p>
 								<div className="flex items-center gap-1.5 text-sm font-semibold text-accent">
 									Try Calculator
@@ -327,8 +329,8 @@ export default function HomePage() {
 									Website Cost Estimator
 								</h3>
 								<p className="text-sm text-muted-foreground leading-relaxed mb-6 flex-1">
-									Get instant transparent pricing for your project based on
-									features, scope, and complexity.
+									Get a straight, no-guesswork price for your project based on
+									the features, scope and pages you actually need.
 								</p>
 								<div className="flex items-center gap-1.5 text-sm font-semibold text-accent">
 									Get Estimate
@@ -350,8 +352,8 @@ export default function HomePage() {
 									Performance Savings Calculator
 								</h3>
 								<p className="text-sm text-muted-foreground leading-relaxed mb-6 flex-1">
-									Discover how much revenue slow load times are costing you
-									every single month.
+									See how much revenue a slow site is costing you every month.
+									Speed moves sales. The math is rarely small.
 								</p>
 								<div className="flex items-center gap-1.5 text-sm font-semibold text-accent">
 									Analyze Site
@@ -395,7 +397,7 @@ export default function HomePage() {
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
 							Every month without a real website is another month of customers
 							Googling you and finding nothing, or finding a competitor instead.
-							Let&apos;s fix that.
+							Tell me about your business and I&apos;ll map out the fix.
 						</p>
 					</div>
 

--- a/src/app/(public)/services/page.tsx
+++ b/src/app/(public)/services/page.tsx
@@ -7,20 +7,19 @@ import { ServicesGrid } from '@/components/ui/ServicesGrid'
 import { SEO_CONFIG } from '@/lib/seo-config'
 
 export const metadata: Metadata = {
-	title:
-		SEO_CONFIG.services?.title || 'Our Services | Hudson Digital Solutions',
+	title: SEO_CONFIG.services?.title || 'Services | Hudson Digital Solutions',
 	description:
 		SEO_CONFIG.services?.description ||
-		'Professional website design and development for small businesses.',
+		'I build fast, mobile-ready websites for Dallas-Fort Worth small businesses, plus booking and payments when you want them. Free plan, no obligation.',
 	openGraph: {
 		title:
 			SEO_CONFIG.services?.ogTitle ??
 			SEO_CONFIG.services?.title ??
-			'Our Services | Hudson Digital Solutions',
+			'Services | Hudson Digital Solutions',
 		description:
 			SEO_CONFIG.services?.ogDescription ??
 			SEO_CONFIG.services?.description ??
-			'Professional website design and development for small businesses.',
+			'I build fast, mobile-ready websites for Dallas-Fort Worth small businesses, plus booking and payments when you want them. Free plan, no obligation.',
 		url: SEO_CONFIG.services?.canonical || ''
 	},
 	alternates: {
@@ -67,15 +66,15 @@ export default function ServicesPage() {
 				/>
 				<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
 					<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-						Professional Services
+						What I Do
 					</p>
 					<h1 className="text-page-title text-foreground leading-tight text-balance">
 						Websites Built for Small Businesses
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
-						A professional website designed, built, and launched for your
-						business. Plus the option to connect booking, payments, and
-						follow-up when you&apos;re ready.
+						I design, build and launch your website. When you&apos;re ready, I
+						wire in booking, payments and follow-up so the site actually brings
+						work in instead of just sitting there.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
 						<Button asChild variant="accent" size="xl">
@@ -101,13 +100,13 @@ export default function ServicesPage() {
 				<div className="container-wide">
 					<div className="text-center mb-10">
 						<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-							What We Build
+							What I Build
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
 							A Website, Done Right
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							We handle the tech. You focus on running your business.
+							I handle the tech. You run your business.
 						</p>
 					</div>
 					<ServicesGrid />
@@ -125,8 +124,10 @@ export default function ServicesPage() {
 							Proven Results
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Small business owners trust us to get it done right and on time,
-							without the technical runaround.
+							Before I built websites, I spent about ten years in revenue
+							operations running Salesforce, Power BI and HubSpot. I bring that
+							same focus on outcomes here: done right, on time, no technical
+							runaround.
 						</p>
 					</div>
 
@@ -157,11 +158,11 @@ export default function ServicesPage() {
 							How It Works
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							Our Process
+							My Process
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Simple, clear steps from first conversation to live and working,
-							no technical jargon required.
+							Clear steps from our first conversation to live and working. No
+							jargon, no surprises.
 						</p>
 					</div>
 					<ProcessSteps />
@@ -183,8 +184,9 @@ export default function ServicesPage() {
 							</h2>
 
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Tell us about your business. We&apos;ll map out the website it
-								needs, pages, timeline, and cost, and you decide from there.
+								Tell me about your business. I&apos;ll map out the website it
+								needs with pages, timeline and cost spelled out. Then you decide
+								from there.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/app/(public)/showcase/page.tsx
+++ b/src/app/(public)/showcase/page.tsx
@@ -12,11 +12,11 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/showcase' },
 	title: 'Showcase | Hudson Digital Solutions',
 	description:
-		'Real websites delivering measurable results for small businesses. See how we help local businesses get found online, win customers, and grow.',
+		'Websites I built for DFW small businesses that turn traffic into booked jobs and paid invoices. See the work, the numbers and how it gets done.',
 	openGraph: {
 		title: 'Showcase | Hudson Digital Solutions',
 		description:
-			'Real websites delivering measurable results for small businesses. See how we help local businesses get found online, win customers, and grow.',
+			'Websites I built for DFW small businesses that turn traffic into booked jobs and paid invoices. See the work, the numbers and how it gets done.',
 		type: 'website'
 	}
 }
@@ -86,12 +86,12 @@ async function ShowcaseProjects() {
 							Featured
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							Four small businesses.{' '}
+							Four DFW businesses.{' '}
 							<span className="text-accent">One thing in common.</span>
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							A website built around what they actually needed, not what looked
-							good in a template.
+							I built each site around how the business actually makes money,
+							not around a template that looked nice on a sales deck.
 						</p>
 					</div>
 
@@ -160,8 +160,8 @@ async function ShowcaseProjects() {
 								Want your business on this page?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-8 max-w-xl mx-auto">
-								Free 30-minute call. We map out pages, timeline, and a clear
-								price for your website. No sales pitch.
+								Book a free 30-minute call. We map out your pages, a timeline,
+								and a flat price. No sales pitch, just a plan.
 							</p>
 							<Button asChild variant="accent" size="xl">
 								<Link href="/contact">
@@ -209,8 +209,8 @@ export default function ShowcasePage() {
 						Real Projects. Real Results.
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
-						Real websites for small businesses. See how we help local businesses
-						get found online, win customers, and grow.
+						Websites I built for DFW small businesses. Each one gets the
+						business found, books the work and gets it paid. Here is the proof.
 					</p>
 
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
@@ -264,13 +264,13 @@ export default function ShowcasePage() {
 								    (closing CTA). The inline CTA precedes this one in DOM
 								    order. */}
 							<h3 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-								Ready to create your{' '}
-								<span className="text-accent">success story?</span>
+								Ready to be the{' '}
+								<span className="text-accent">next one on this page?</span>
 							</h3>
 
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Join these businesses with a website that does justice to what
-								they&apos;ve built. Let&apos;s build yours.
+								You have built a real business. Your website should pull its
+								weight too. Tell me what you do and I&apos;ll build it.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/app/(public)/testimonials/page.tsx
+++ b/src/app/(public)/testimonials/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/testimonials' },
 	title: 'Client Testimonials | Hudson Digital Solutions',
 	description:
-		'Real results from the small businesses we have built websites for. See how a professional website turned local reputations into booked customers.'
+		'Real results from DFW small businesses I have built websites for. See how a site built as a revenue system turned local reputations into booked work.'
 }
 
 const testimonials = [
@@ -112,14 +112,14 @@ export default function TestimonialsPage() {
 				/>
 				<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
 					<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-						Client Success Stories
+						Client Results
 					</p>
 					<h1 className="text-page-title text-foreground leading-tight text-balance">
 						Real Results. Real Clients.
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						Don&apos;t just take our word for it. See what small businesses are
-						achieving with a website built for their reputation.
+						You do not have to take my word for it. Here is what DFW owners got
+						after I rebuilt their website to actually pull in work.
 					</p>
 				</div>
 			</section>
@@ -172,11 +172,11 @@ export default function TestimonialsPage() {
 							Testimonials
 						</p>
 						<h2 className="text-section-title text-foreground mb-comfortable text-balance">
-							What Our Clients Say
+							What My Clients Say
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Every testimonial is a small business whose website finally
-							matches the work behind it.
+							Each one is a local business owner whose website finally matches
+							the reputation they earned the hard way.
 						</p>
 					</div>
 
@@ -237,13 +237,13 @@ export default function TestimonialsPage() {
 						/>
 						<div className="relative z-10">
 							<h2 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-								Ready to be our next{' '}
+								Want to be my next{' '}
 								<span className="text-accent">success story?</span>
 							</h2>
 
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Join the small businesses that finally have a website doing
-								justice to the reputation they have earned.
+								Let us build you a website that books work instead of collecting
+								dust. Tell me about your business and I will map out a plan.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/app/(public)/tools/page.tsx
+++ b/src/app/(public)/tools/page.tsx
@@ -15,11 +15,10 @@ export const metadata: Metadata = {
 	alternates: { canonical: '/tools' },
 	title: 'Free Business Tools & Calculators | Hudson Digital Solutions',
 	description:
-		'Free interactive tools for business owners and freelancers. Calculate ROI, generate invoices and contracts, format JSON, analyze performance, and more.',
+		'Free tools I built for DFW small business owners. Run the numbers on ROI, generate invoices and contracts, format JSON, then check site performance.',
 	openGraph: {
 		title: 'Free Business Tools & Calculators',
-		description:
-			'Interactive tools to help you make data-driven decisions about your website.'
+		description: 'Run the numbers before you spend a dollar on your website.'
 	}
 }
 
@@ -38,14 +37,14 @@ export default function ToolsPage() {
 				/>
 				<div className="relative z-10 container-wide px-4 sm:px-6 pt-28 pb-16 sm:pt-32 sm:pb-20 text-center">
 					<p className="text-xs font-semibold uppercase tracking-widest text-accent mb-3">
-						Try For Free
+						Free To Use
 					</p>
 					<h1 className="text-page-title text-foreground leading-tight text-balance">
 						Free Business Tools
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6">
-						Make data-driven decisions about your website with our free
-						interactive calculators. No credit card required, no signup needed.
+						I built these to help you run the numbers on your website before you
+						spend a dollar. No credit card, no signup, no catch.
 					</p>
 				</div>
 			</section>
@@ -100,11 +99,12 @@ export default function ToolsPage() {
 						/>
 						<div className="relative z-10">
 							<h2 className="text-section-title text-foreground mb-6 max-w-3xl mx-auto text-balance">
-								Ready to Take Action?
+								Ready to Build the Real Thing?
 							</h2>
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								These calculators show the potential. Let&apos;s make it
-								reality. Schedule a free consultation to discuss your project.
+								The numbers tell you what is possible. I build the website that
+								gets you there. Grab a free call and tell me what you are
+								working on.
 							</p>
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">
 								<Button asChild variant="accent" size="xl">

--- a/src/app/(public)/tools/tools-data.ts
+++ b/src/app/(public)/tools/tools-data.ts
@@ -71,7 +71,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'ROI Calculator',
 		description:
-			'Calculate how much additional revenue you could generate by improving your website conversion rate.',
+			'Your website is a revenue system. See the dollars a higher conversion rate puts in your pocket, with the math laid out so you can trust the number.',
 		href: TOOL_ROUTES.ROI_CALCULATOR,
 		Icon: TrendingUp,
 		benefits: [
@@ -85,7 +85,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Website Cost Estimator',
 		description:
-			'Get an instant estimate for your website project based on your specific requirements and features.',
+			'Pick the features your business needs and get a real ballpark for your site, no sales call required. Same pricing logic I quote DFW clients.',
 		href: TOOL_ROUTES.COST_ESTIMATOR,
 		Icon: Calculator,
 		benefits: [
@@ -99,7 +99,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Performance Savings Calculator',
 		description:
-			'Discover how much revenue you are losing due to slow website performance with real PageSpeed analysis.',
+			'A slow site quietly bleeds sales. Run real PageSpeed numbers against your traffic and see the revenue a faster site wins back every month.',
 		href: TOOL_ROUTES.PERFORMANCE_CALCULATOR,
 		Icon: Zap,
 		benefits: [
@@ -113,7 +113,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Meta Tag Generator',
 		description:
-			'Generate SEO-optimized meta tags, Open Graph, and Twitter Card markup for your web pages.',
+			'Get the title, description, Open Graph and Twitter Card tags Google and social feeds actually read. Paste them in and your pages stop looking broken when shared.',
 		href: TOOL_ROUTES.META_TAG_GENERATOR,
 		Icon: Tags,
 		benefits: [
@@ -127,12 +127,12 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'LocalBusiness Schema Generator',
 		description:
-			'Build schema.org LocalBusiness JSON-LD structured data so Google understands your business and shows you in local results.',
+			'Build the schema.org JSON-LD that tells Google what your business is and where it is. This is the markup I use to land DFW clients in the local pack.',
 		href: TOOL_ROUTES.SCHEMA_GENERATOR,
 		Icon: MapPin,
 		benefits: [
 			'Valid schema.org JSON-LD',
-			'Address, hours, geo, and social links',
+			'Address, hours, geo, social links',
 			'Helps you rank in the local pack'
 		],
 		cta: 'Generate Schema',
@@ -141,11 +141,11 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Texas TTL Calculator',
 		description:
-			'Calculate tax, title, and license fees plus monthly payment estimates for vehicle purchases in Texas.',
+			'Buying a vehicle in Texas? Get the tax, title and license fees plus a monthly payment estimate before you sit down at the dealer.',
 		href: TOOL_ROUTES.TTL_CALCULATOR,
 		Icon: Car,
 		benefits: [
-			'Tax, title, and license fees',
+			'Tax, title, license fees',
 			'Monthly payment estimates',
 			'Texas-specific calculations'
 		],
@@ -155,7 +155,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Mortgage Calculator',
 		description:
-			'Calculate your monthly mortgage payment including principal, interest, taxes, insurance, and PMI.',
+			'See the full monthly mortgage payment, not the teaser number. Principal, interest, taxes, insurance and PMI broken out so you know what you are signing up for.',
 		href: TOOL_ROUTES.MORTGAGE_CALCULATOR,
 		Icon: Home,
 		benefits: [
@@ -169,7 +169,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Tip Calculator',
 		description:
-			'Calculate tip amounts and split the bill fairly among multiple people for any dining occasion.',
+			'Figure the tip and split the check evenly across the table. Set the percentage, set the headcount, get the per-person number.',
 		href: TOOL_ROUTES.TIP_CALCULATOR,
 		Icon: Receipt,
 		benefits: [
@@ -183,7 +183,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Paystub Calculator',
 		description:
-			'Generate detailed payroll breakdowns with federal and state tax calculations and net pay.',
+			'Run a clean payroll breakdown with federal and state withholding and the net pay that actually hits the bank. Useful when you are cutting checks yourself.',
 		href: TOOL_ROUTES.PAYSTUB_CALCULATOR,
 		Icon: DollarSign,
 		benefits: [
@@ -197,7 +197,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Profit Margin & Markup Calculator',
 		description:
-			'Enter your cost and selling price to get gross margin, markup, and profit, or find the price for a target margin.',
+			'Drop in your cost and price to see gross margin, markup and profit per sale. Or work it backward and find the price that hits the margin you want.',
 		href: TOOL_ROUTES.PROFIT_MARGIN_CALCULATOR,
 		Icon: Percent,
 		benefits: [
@@ -211,7 +211,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Invoice Late Fee Calculator',
 		description:
-			'Work out the late fee and total owed on an overdue invoice, using a flat fee or a percentage rate per day, week, or month.',
+			'Client paying late? Work out the late fee and total owed on an overdue invoice with a flat fee or a percentage rate per day, week, or month.',
 		href: TOOL_ROUTES.INVOICE_LATE_FEE_CALCULATOR,
 		Icon: CalendarClock,
 		benefits: [
@@ -225,7 +225,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Time Card Calculator',
 		description:
-			'Add clock-in and clock-out times with breaks to total hours, split overtime, and calculate gross pay.',
+			'Punch in clock-in and clock-out times with breaks to total the hours, split overtime at 1.5x and get gross pay. Built for running a small crew.',
 		href: TOOL_ROUTES.TIME_CARD_CALCULATOR,
 		Icon: Clock,
 		benefits: [
@@ -239,7 +239,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Contract Generator',
 		description:
-			'Create professional contracts ready for signature with customizable terms and PDF download.',
+			'Put together a clean contract you can send for signature today. Set your own terms and download the PDF. No legal-template subscription to cancel later.',
 		href: TOOL_ROUTES.CONTRACT_GENERATOR,
 		Icon: FileSignature,
 		benefits: [
@@ -253,7 +253,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Invoice Generator',
 		description:
-			'Create professional invoices with line items, totals, and tax, ready to download as PDF.',
+			'Build a sharp invoice with line items, tax and totals, then download the PDF and send it. Get paid faster without paying for billing software.',
 		href: TOOL_ROUTES.INVOICE_GENERATOR,
 		Icon: FileText,
 		benefits: [
@@ -267,7 +267,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Proposal Generator',
 		description:
-			'Create professional project proposals for clients with scope, timeline, and pricing. PDF included.',
+			'Send a proposal that closes. Lay out scope, timeline and pricing in a clean PDF clients can read and approve fast.',
 		href: TOOL_ROUTES.PROPOSAL_GENERATOR,
 		Icon: Briefcase,
 		benefits: [
@@ -281,7 +281,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'JSON Formatter',
 		description:
-			'Format, validate, and minify JSON data online with syntax error detection and instant feedback.',
+			'Format, validate and minify JSON right in the browser. It points to the exact line that broke so you stop guessing where the syntax error is.',
 		href: TOOL_ROUTES.JSON_FORMATTER,
 		Icon: Code2,
 		benefits: [
@@ -295,7 +295,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Comma Separator',
 		description:
-			'Convert a column of values into a comma-separated series. Paste a spreadsheet column or any space-separated list and get clean, comma-separated output.',
+			'Paste a spreadsheet column or any list and get a clean comma-separated string back. Add quotes, drop duplicates, copy it where you need it.',
 		href: TOOL_ROUTES.COMMA_SEPARATOR,
 		Icon: List,
 		benefits: [
@@ -309,7 +309,7 @@ export const TOOLS: readonly ToolEntry[] = [
 	{
 		title: 'Word & Character Counter',
 		description:
-			'Count words, characters, sentences, paragraphs, and reading time as you type. Handy for meta descriptions, tweets, and content limits.',
+			'Counts words, characters, sentences, paragraphs and reading time as you type. Handy for hitting meta description limits, post lengths and content caps.',
 		href: TOOL_ROUTES.WORD_COUNTER,
 		Icon: Type,
 		benefits: [

--- a/src/app/(public)/website-migration/page.tsx
+++ b/src/app/(public)/website-migration/page.tsx
@@ -18,11 +18,11 @@ import { ROUTES } from '@/lib/constants/routes'
 export const metadata: Metadata = {
 	title: 'Website Migration: Keep Your Rankings | Hudson Digital',
 	description:
-		'Migrate your website to a platform you own without losing Google rankings. We recover your domain, set up redirects, and build a faster, fully owned site.',
+		'I move your DFW business to a website you own without losing Google rankings. I recover your domain, set up redirects, then build a faster site you keep.',
 	openGraph: {
 		title: 'Website Migration - Keep Your Rankings, Lose the Fees',
 		description:
-			'We migrate your website to a platform you own. No contracts, no monthly hostage fees.',
+			'I move your site to a platform you own. No contracts, no monthly hostage fees.',
 		url: 'https://hudsondigitalsolutions.com/website-migration'
 	},
 	alternates: {
@@ -42,19 +42,19 @@ const risks = [
 		Icon: Globe,
 		title: 'Your Website Can Go Dark Overnight',
 		description:
-			"Many managed website platforms delete your site within 30 days of cancellation. No export option, no backup. If you haven't planned ahead, your online presence vanishes."
+			'A lot of managed platforms delete your site within 30 days of cancellation. No export, no backup. Stop paying and your whole online presence disappears with it.'
 	},
 	{
 		Icon: Shield,
 		title: 'Your Domain May Not Be Yours',
 		description:
-			'Some providers register your domain under their own account. Getting it transferred can take weeks of back-and-forth, or worse, they hold it hostage.'
+			'Some providers register your domain under their own account, not yours. Getting it back can take weeks of email tag. A few of them will flat out hold it hostage.'
 	},
 	{
 		Icon: AlertTriangle,
 		title: 'Your Google Rankings Are at Risk',
 		description:
-			"A botched migration can tank your Google Business Profile and search rankings. If URLs change without proper redirects, you lose the SEO equity you've built over years."
+			'A sloppy migration can tank your Google Business Profile and your search rankings. Change URLs without proper redirects and you throw away years of SEO you paid for.'
 	}
 ]
 
@@ -69,25 +69,25 @@ const migrationSteps: MigrationStep[] = [
 		step: '01',
 		title: 'Free Migration Audit',
 		description:
-			'We review your current setup (website, domain ownership, Google Business Profile, CRM data) and create a migration plan with zero downtime.'
+			'I go through your current setup. Website, domain ownership, Google Business Profile, your customer data. Then I map out a plan to switch you over with zero downtime.'
 	},
 	{
 		step: '02',
 		title: 'Domain Recovery',
 		description:
-			'We handle the domain transfer process with your current provider on your behalf. If your domain is locked, we know the exact steps to get it released.'
+			'I deal with your current provider to transfer the domain so you do not have to. If it is locked down, I know the exact steps to pry it loose.'
 	},
 	{
 		step: '03',
 		title: 'Website Rebuild',
 		description:
-			'Your new website goes live on a platform you own. Faster, mobile-optimized, and built to rank on Google. We preserve your existing content and improve it.'
+			'Your new site goes live on a platform you own. Faster, built for phones, built to rank on Google. I keep your existing content and make it sharper.'
 	},
 	{
 		step: '04',
 		title: 'SEO Preservation',
 		description:
-			'We set up proper redirects, submit updated sitemaps, and verify your Google Business Profile stays connected. Your rankings are protected throughout the switch.'
+			'I set up the redirects, submit fresh sitemaps, then confirm your Google Business Profile stays connected. Your rankings are covered the whole way through.'
 	}
 ]
 
@@ -139,7 +139,7 @@ export default function WebsiteMigrationPage() {
 				name: 'How long does a website migration take?',
 				acceptedAnswer: {
 					'@type': 'Answer',
-					text: 'Most migrations are complete in 1-2 weeks. Your new site goes live before we touch anything on the old platform, so there is zero downtime.'
+					text: 'Most migrations wrap in 1-2 weeks. Your new site goes live before I touch anything on the old platform, so there is zero downtime.'
 				}
 			},
 			{
@@ -147,7 +147,7 @@ export default function WebsiteMigrationPage() {
 				name: 'Will I lose my Google rankings?',
 				acceptedAnswer: {
 					'@type': 'Answer',
-					text: 'No. We set up proper 301 redirects, update your Google Business Profile, and submit fresh sitemaps. Most clients see improved rankings within 30 days because the new site loads faster.'
+					text: 'No. I set up proper 301 redirects, update your Google Business Profile, then submit fresh sitemaps. Most clients see better rankings within 30 days because the new site loads faster.'
 				}
 			},
 			{
@@ -155,7 +155,7 @@ export default function WebsiteMigrationPage() {
 				name: "What if my provider won't release my domain?",
 				acceptedAnswer: {
 					'@type': 'Answer',
-					text: 'We handle the domain transfer process directly with your provider. If they delay, we know the ICANN dispute process and have helped multiple clients recover their domains.'
+					text: 'I run the domain transfer directly with your provider. If they stall, I know the ICANN dispute process and have gotten domains back for clients in exactly this spot.'
 				}
 			}
 		]
@@ -184,9 +184,9 @@ export default function WebsiteMigrationPage() {
 						Customers
 					</h1>
 					<p className="text-lead text-muted-foreground max-w-2xl mx-auto mt-6 mb-10">
-						Stuck paying hundreds a month for a website you don&apos;t own? We
-						migrate everything to a faster site that&apos;s 100% yours, with
-						zero downtime and preserved SEO rankings.
+						Paying hundreds a month for a website you don&apos;t even own? I
+						move everything to a faster site that is 100% yours, with zero
+						downtime and your SEO rankings kept intact.
 					</p>
 					<div className="flex flex-col sm:flex-row gap-3 justify-center">
 						<Button asChild variant="accent" size="xl">
@@ -223,9 +223,9 @@ export default function WebsiteMigrationPage() {
 							What Happens When You Leave Your Provider Without a Plan
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							Managed website platforms make it easy to sign up and hard to
-							leave. Here&apos;s what most business owners don&apos;t realize
-							until it&apos;s too late.
+							Managed platforms make it easy to sign up and a pain to leave.
+							Here is what most owners do not find out until they try to walk
+							away.
 						</p>
 					</div>
 
@@ -308,7 +308,7 @@ export default function WebsiteMigrationPage() {
 							Your Migration in 4 Steps
 						</h2>
 						<p className="text-lead text-muted-foreground max-w-2xl mx-auto">
-							We handle everything. You keep running your business.
+							I handle all of it. You keep running your business.
 						</p>
 					</div>
 
@@ -347,15 +347,15 @@ export default function WebsiteMigrationPage() {
 
 					<div className="grid sm:grid-cols-2 gap-4">
 						{[
-							'A website you own, no monthly hostage fees',
+							'A website you own outright, no monthly hostage fees',
 							'Your domain registered in your name',
 							'Google Business Profile connected and verified',
-							'Page load under 2 seconds',
-							'Mobile-optimized responsive design',
-							'SEO rankings preserved or improved',
+							'Pages that load in under 2 seconds',
+							'A design that works on every phone',
+							'SEO rankings kept or improved',
 							'Contact forms that email you directly',
-							'Analytics dashboard to track visitors',
-							'Full training so you can update it yourself',
+							'An analytics dashboard so you can see your visitors',
+							'Training so you can update the site yourself',
 							'30 days of priority support after launch'
 						].map(item => (
 							<div key={item} className="flex items-start gap-3">
@@ -380,7 +380,7 @@ export default function WebsiteMigrationPage() {
 								30 days
 							</div>
 							<div className="text-sm text-muted-foreground">
-								Most platforms delete your site after cancellation
+								How long most platforms keep your site before deleting it
 							</div>
 						</div>
 						<div className="bg-background px-8 py-10 text-center relative overflow-hidden">
@@ -392,7 +392,7 @@ export default function WebsiteMigrationPage() {
 								1-2 wks
 							</div>
 							<div className="text-sm text-muted-foreground">
-								Typical migration timeline with zero downtime
+								Typical time to move you over with zero downtime
 							</div>
 						</div>
 						<div className="bg-background px-8 py-10 text-center relative overflow-hidden">
@@ -404,7 +404,7 @@ export default function WebsiteMigrationPage() {
 								$0/mo
 							</div>
 							<div className="text-sm text-muted-foreground">
-								Required monthly fees after your site is built
+								Monthly fees you owe me once the site is built
 							</div>
 						</div>
 					</div>
@@ -426,9 +426,9 @@ export default function WebsiteMigrationPage() {
 							</h2>
 
 							<p className="text-lead text-muted-foreground mb-10 max-w-2xl mx-auto">
-								Book a free migration consultation. We&apos;ll audit your
-								current setup, tell you exactly what it takes to switch, and
-								give you a fixed quote with no surprises.
+								Book a free migration consult. I will audit your current setup,
+								tell you straight what it takes to switch, then hand you a fixed
+								quote with no surprises.
 							</p>
 
 							<div className="flex flex-col sm:flex-row gap-3 justify-center">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -91,11 +91,12 @@ export default function Footer() {
 									<h3 className="text-h4 text-foreground">HDS</h3>
 								</div>
 								<p className="text-accent text-xs font-semibold mb-subheading">
-									Professional websites for small businesses.
+									Websites built like revenue systems for DFW small businesses.
 								</p>
 								<p className="text-xs text-muted-foreground">
-									We build small businesses a professional website that turns
-									the reputation they&apos;ve earned into booked customers.
+									I spent ten years in revenue operations before I built sites.
+									I treat your website the same way: a system that turns the
+									reputation you&apos;ve earned into booked customers.
 								</p>
 							</div>
 
@@ -103,15 +104,15 @@ export default function Footer() {
 							<div className="space-y-tight">
 								<div className="flex items-center gap-tight text-muted-foreground">
 									<CheckCircle className="h-4 w-4 text-accent" />
-									<span className="text-xs">Proven Track Record</span>
+									<span className="text-xs">Real numbers, not promises</span>
 								</div>
 								<div className="flex items-center gap-tight text-muted-foreground">
 									<CheckCircle className="h-4 w-4 text-accent" />
-									<span className="text-xs">Launched in Weeks</span>
+									<span className="text-xs">Live in weeks, not months</span>
 								</div>
 								<div className="flex items-center gap-tight text-muted-foreground">
 									<Clock className="h-4 w-4 text-accent" />
-									<span className="text-xs">Response within 2 hours</span>
+									<span className="text-xs">I reply within 2 hours</span>
 								</div>
 							</div>
 						</div>
@@ -191,11 +192,11 @@ export default function Footer() {
 						    form-routing CTA card above. */}
 						<div className="md:col-span-1">
 							<h4 className="text-foreground font-semibold mb-heading">
-								Prefer to reach out directly?
+								Rather just talk?
 							</h4>
 							<p className="text-xs text-muted-foreground mb-heading">
-								Email or call. Fastest path to a quote without filling out a
-								form.
+								Email or call me. Fastest way to a quote with no form to fill
+								out.
 							</p>
 
 							<div className="space-y-3">

--- a/src/lib/seo-config.ts
+++ b/src/lib/seo-config.ts
@@ -26,7 +26,7 @@ export const SEO_CONFIG: Record<string, SEOMetaData> = {
 	services: {
 		title: 'Small Business Website Design | Hudson Digital',
 		description:
-			'Professional websites designed and built for small businesses: custom, mobile-ready, fast, and easy to find on Google. Free website plan, no obligation.',
+			'Professional websites designed and built for small businesses: custom, mobile-ready, fast and easy to find on Google. Free website plan, no obligation.',
 		ogTitle: 'Website Design for Small Businesses | Hudson Digital',
 		ogDescription:
 			'Professional websites built for small businesses: custom, fast, mobile-ready, built to bring in customers. Launched in weeks.',
@@ -34,19 +34,19 @@ export const SEO_CONFIG: Record<string, SEOMetaData> = {
 	},
 
 	about: {
-		title: 'Web Designer Who Understands Small Business | Hudson Digital',
+		title: 'Web Designer Who Gets Small Business | Hudson Digital',
 		description:
-			'An experienced web developer with a real business background, building small businesses the professional website their reputation deserves.',
-		ogTitle: 'Web Designer Who Understands Small Business | Hudson Digital',
+			'I spent 5+ years in revenue operations before building websites. Now I build DFW small businesses a site that brings in real customers.',
+		ogTitle: 'Web Designer Who Gets Small Business | Hudson Digital',
 		ogDescription:
-			'Experienced developer with a business background, building websites that actually bring in customers for small businesses.',
+			'Former revenue operations operator who builds DFW small businesses a website that brings in real customers instead of sitting there as a brochure.',
 		canonical: `${SITE_URL}/about`,
 		structuredData: {
 			'@context': 'https://schema.org',
 			'@type': 'AboutPage',
 			name: 'About Hudson Digital Solutions',
 			description:
-				'Learn about our founder and our mission: building small businesses the professional website their reputation deserves'
+				'I spent 5+ years in revenue operations before building DFW small businesses a website that turns their reputation into booked customers.'
 		}
 	}
 } as const

--- a/src/lib/seo-config.ts
+++ b/src/lib/seo-config.ts
@@ -36,7 +36,7 @@ export const SEO_CONFIG: Record<string, SEOMetaData> = {
 	about: {
 		title: 'Web Designer Who Gets Small Business | Hudson Digital',
 		description:
-			'I spent 5+ years in revenue operations before building websites. Now I build DFW small businesses a site that brings in real customers.',
+			'I spent nearly a decade in revenue operations before building websites. Now I build DFW small businesses a site that brings in real customers.',
 		ogTitle: 'Web Designer Who Gets Small Business | Hudson Digital',
 		ogDescription:
 			'Former revenue operations operator who builds DFW small businesses a website that brings in real customers instead of sitting there as a brochure.',
@@ -46,7 +46,7 @@ export const SEO_CONFIG: Record<string, SEOMetaData> = {
 			'@type': 'AboutPage',
 			name: 'About Hudson Digital Solutions',
 			description:
-				'I spent 5+ years in revenue operations before building DFW small businesses a website that turns their reputation into booked customers.'
+				'I spent nearly a decade in revenue operations before building DFW small businesses a website that turns their reputation into booked customers.'
 		}
 	}
 } as const


### PR DESCRIPTION
Rewrites user-facing copy on the core marketing pages into Richard's first-person operator voice (matching the blogs): home, about, services, website-migration, contact, faq, showcase/tools/testimonials/locations index intros, tools-data descriptions, Footer, about seo-config. Only prose changed; JSX/links/CTAs/logic preserved; hard rules enforced; real testimonial quotes + legal left untouched. Per-file rewrite+verify workflow; lint/typecheck/build green (208 pages).

REVIEW NEEDED: the About page says '5+ years' revenue ops; the live blogs say 'nearly a decade' + cite 2,200%/95%/$3.7M. These need reconciling to one accurate set of figures across blogs + About.

[hudsor01]