### PR TITLE
fix: align blog post header with body + pin dialog close button

### DIFF
--- a/src/app/(public)/blog/[slug]/page.tsx
+++ b/src/app/(public)/blog/[slug]/page.tsx
@@ -251,62 +251,66 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 			{/* Article Header */}
 			<article className="pb-16">
 				<header className="relative bg-background py-section-sm overflow-hidden">
-					<div className="relative container-narrow px-4 sm:px-6">
-						{/* Tags */}
-						{tags.length > 0 && (
-							<div className="flex flex-wrap gap-tight mb-content-block">
-								{tags.map(tag => (
-									<Link
-										key={tag.id}
-										href={`/blog/tag/${tag.slug}`}
-										className="flex flex-center gap-1 text-sm text-accent bg-accent/10 hover:bg-accent/20 px-3 py-1 rounded-full transition-colors"
-									>
-										<Tag className="w-4 h-4" />
-										{tag.name}
-									</Link>
-								))}
-							</div>
-						)}
+					<div className="relative container-wide">
+						<div className="mx-auto max-w-5xl">
+							<div className="max-w-3xl">
+								{/* Tags */}
+								{tags.length > 0 && (
+									<div className="flex flex-wrap gap-tight mb-content-block">
+										{tags.map(tag => (
+											<Link
+												key={tag.id}
+												href={`/blog/tag/${tag.slug}`}
+												className="flex flex-center gap-1 text-sm text-accent bg-accent/10 hover:bg-accent/20 px-3 py-1 rounded-full transition-colors"
+											>
+												<Tag className="w-4 h-4" />
+												{tag.name}
+											</Link>
+										))}
+									</div>
+								)}
 
-						{/* Title */}
-						<h1 className="text-page-title text-foreground leading-tight text-balance mb-content-block">
-							{post.title}
-						</h1>
+								{/* Title */}
+								<h1 className="text-page-title text-foreground leading-tight text-balance mb-content-block">
+									{post.title}
+								</h1>
 
-						{/* Excerpt */}
-						{post.excerpt && (
-							<p className="text-xl text-muted-foreground mb-comfortable text-pretty">
-								{post.excerpt}
-							</p>
-						)}
+								{/* Excerpt */}
+								{post.excerpt && (
+									<p className="text-xl text-muted-foreground mb-comfortable text-pretty">
+										{post.excerpt}
+									</p>
+								)}
 
-						{/* Meta */}
-						<div className="flex flex-wrap gap-comfortable text-muted-foreground">
-							<div className="flex flex-center gap-tight">
-								<Calendar className="w-5 h-5" />
-								<time dateTime={post.published_at}>
-									{formatDate(post.published_at, 'long')}
-								</time>
-							</div>
-							<div className="flex flex-center gap-tight">
-								<Clock className="w-5 h-5" />
-								<span>{post.reading_time} min read</span>
-							</div>
-							{post.author && (
-								<div className="flex flex-center gap-tight">
-									{post.author.profile_image && (
-										<Image
-											src={post.author.profile_image}
-											alt={post.author.name}
-											width={24}
-											height={24}
-											className="w-6 h-6 rounded-full object-cover"
-											sizes="24px"
-										/>
+								{/* Meta */}
+								<div className="flex flex-wrap gap-comfortable text-muted-foreground">
+									<div className="flex flex-center gap-tight">
+										<Calendar className="w-5 h-5" />
+										<time dateTime={post.published_at}>
+											{formatDate(post.published_at, 'long')}
+										</time>
+									</div>
+									<div className="flex flex-center gap-tight">
+										<Clock className="w-5 h-5" />
+										<span>{post.reading_time} min read</span>
+									</div>
+									{post.author && (
+										<div className="flex flex-center gap-tight">
+											{post.author.profile_image && (
+												<Image
+													src={post.author.profile_image}
+													alt={post.author.name}
+													width={24}
+													height={24}
+													className="w-6 h-6 rounded-full object-cover"
+													sizes="24px"
+												/>
+											)}
+											<span>By {post.author.name}</span>
+										</div>
 									)}
-									<span>By {post.author.name}</span>
 								</div>
-							)}
+							</div>
 						</div>
 					</div>
 				</header>
@@ -345,8 +349,12 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
 
 				{/* Author Bio */}
 				{post.author && (
-					<div className="container-narrow py-8">
-						<AuthorCard author={post.author} />
+					<div className="container-wide py-8">
+						<div className="mx-auto max-w-5xl">
+							<div className="max-w-3xl">
+								<AuthorCard author={post.author} />
+							</div>
+						</div>
 					</div>
 				)}
 			</article>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -764,6 +764,19 @@ button,
 		max-width: 28rem;
 		z-index: 51;
 	}
+	.dialog-close-button {
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border-radius: 0.375rem;
+		color: var(--color-foreground);
+		cursor: pointer;
+	}
 }
 
 /* Typography component */


### PR DESCRIPTION
## What

Two UI fixes:

1. **Dialog close button position** — The \`.dialog-close-button\` class was referenced in the Dialog primitive but never defined in \`globals.css\`, so the X fell to the end of the dialog's flex column (bottom-left). Added an absolute top-right rule. Applies to every dialog, including the exit-intent modal.

2. **Blog post header alignment** — The post header sat in \`container-narrow\` (42rem, page-centered) while the body used \`container-wide > max-w-5xl\`, so the title rendered skinnier and offset right of the content below it. Moved the header and author card into the same \`container-wide > max-w-5xl > max-w-3xl\` column the body uses, so the title, excerpt, meta, and article text share one left edge.

## Verification

- \`bun run lint\` and \`bun run typecheck\` pass
- Both fixes confirmed visually in Chrome (header left-edge alignment is pixel-perfect; close button renders top-right)

> Note: blog post title/tagline/em-dash content edits from the same session were applied directly to the Neon DB and are not part of this code diff.

[hudsor01]